### PR TITLE
fix: respect enable_user_data and normalize NextUp cutoff handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7144,9 +7144,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
 dependencies = [
  "cc",
  "libc",
@@ -7154,9 +7154,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",

--- a/crates/remux-sdks/src/remux/mod.rs
+++ b/crates/remux-sdks/src/remux/mod.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
 use http::{HeaderValue, Method};
 use nutype::nutype;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -1059,6 +1059,7 @@ pub struct GetItemsQuery {
     pub enable_rewatching: Option<bool>,
     #[serde(default, deserialize_with = "deserialize_option_bool_from_anything")]
     pub disable_first_episode: Option<bool>,
+    #[serde(default, deserialize_with = "deserialize_next_up_date_cutoff")]
     pub next_up_date_cutoff: Option<String>,
     pub years: Option<Vec<i64>>,
     pub genres: Option<Vec<String>>,
@@ -1145,6 +1146,47 @@ where
     }
 }
 
+pub fn normalize_next_up_date_cutoff(
+    cutoff: &str,
+) -> std::result::Result<String, &'static str> {
+    if let Ok(dt) = DateTime::parse_from_rfc3339(cutoff) {
+        return Ok(dt
+            .naive_utc()
+            .format("%F %T")
+            .to_string());
+    }
+
+    if let Ok(dt) = NaiveDateTime::parse_from_str(cutoff, "%Y-%m-%d %H:%M:%S") {
+        return Ok(dt
+            .format("%F %T")
+            .to_string());
+    }
+
+    if let Ok(date) = NaiveDate::parse_from_str(cutoff, "%Y-%m-%d") {
+        return Ok(date
+            .and_hms_opt(0, 0, 0)
+            .expect("midnight is always valid")
+            .format("%F %T")
+            .to_string());
+    }
+
+    Err("nextUpDateCutoff must be RFC3339, YYYY-MM-DD, or YYYY-MM-DD HH:MM:SS")
+}
+
+fn deserialize_next_up_date_cutoff<'de, D>(
+    deserializer: D,
+) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let cutoff = Option::<String>::deserialize(deserializer)?;
+    cutoff
+        .map(|cutoff| {
+            normalize_next_up_date_cutoff(&cutoff).map_err(serde::de::Error::custom)
+        })
+        .transpose()
+}
+
 /// Generic helper: deserializes an optional comma-separated (or repeated) query-param
 /// value into `Option<Vec<T>>` for any `T: FromStr`.
 fn deserialize_comma_str<'de, D, T>(deserializer: D) -> Result<Option<Vec<T>>, D::Error>
@@ -1228,6 +1270,27 @@ where
     D: Deserializer<'de>,
 {
     deserialize_comma_str(d)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn next_up_cutoff_accepts_rfc3339() {
+        assert_eq!(
+            normalize_next_up_date_cutoff("2026-06-17T23:00:00Z").unwrap(),
+            "2026-06-17 23:00:00"
+        );
+    }
+
+    #[test]
+    fn next_up_cutoff_rejects_invalid_input() {
+        assert_eq!(
+            normalize_next_up_date_cutoff("not-a-date").unwrap_err(),
+            "nextUpDateCutoff must be RFC3339, YYYY-MM-DD, or YYYY-MM-DD HH:MM:SS"
+        );
+    }
 }
 
 #[derive(Default, Debug, Deserialize)]

--- a/crates/remux-server/Cargo.toml
+++ b/crates/remux-server/Cargo.toml
@@ -116,7 +116,7 @@ hunch = "2"
 log = "0.4"
 env_logger = "0.11"
 nutype = { version = "0.6", features = ["serde"] }
-tikv-jemallocator = { version = "0.6", optional = true }
+tikv-jemallocator = { version = "0.7", optional = true }
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
 imageproc = { version = "0.26", default-features = false, features = ["text"] }
 ab_glyph = "0.2"

--- a/crates/remux-server/src/api/items.rs
+++ b/crates/remux-server/src/api/items.rs
@@ -390,7 +390,7 @@ pub async fn get_items(
                         total_count: true,
                         include_user_state: q
                             .enable_user_data
-                            .is_none(),
+                            .unwrap_or(true),
                         user_id: Some(
                             session
                                 .user

--- a/crates/remux-server/src/api/shows.rs
+++ b/crates/remux-server/src/api/shows.rs
@@ -6,12 +6,10 @@ use axum::{
     response::IntoResponse,
 };
 use axum_extra::extract::Query;
-use chrono::{DateTime, NaiveDate, NaiveDateTime};
-use http::StatusCode;
 use remux_macros::{api_query, get};
 use uuid::Uuid;
 
-use crate::{AppState, OptionExt, ResultExt, api, db, db::auth};
+use crate::{AppState, OptionExt, api, db, db::auth};
 use axum_anyhow::ApiResult as Result;
 
 use super::items::get_items;
@@ -29,37 +27,6 @@ pub fn livetv_view_item() -> api::BaseItemDto {
         is_folder: true,
         ..Default::default()
     }
-}
-
-fn normalize_next_up_cutoff(cutoff: Option<&str>) -> Result<String> {
-    let Some(cutoff) = cutoff else {
-        return Ok("1970-01-01 00:00:00".to_string());
-    };
-
-    if let Ok(dt) = DateTime::parse_from_rfc3339(cutoff) {
-        return Ok(dt
-            .naive_utc()
-            .format("%F %T")
-            .to_string());
-    }
-
-    if let Ok(dt) = NaiveDateTime::parse_from_str(cutoff, "%Y-%m-%d %H:%M:%S") {
-        return Ok(dt
-            .format("%F %T")
-            .to_string());
-    }
-
-    if let Ok(date) = NaiveDate::parse_from_str(cutoff, "%Y-%m-%d") {
-        return Ok(date
-            .and_hms_opt(0, 0, 0)
-            .expect("midnight is always valid")
-            .format("%F %T")
-            .to_string());
-    }
-
-    Err(anyhow::anyhow!("invalid next_up_date_cutoff")).context_bad_request(
-        "nextUpDateCutoff must be RFC3339, YYYY-MM-DD, or YYYY-MM-DD HH:MM:SS",
-    )
 }
 
 #[get("/shows/{id}/seasons")]
@@ -318,10 +285,10 @@ async fn shows_nextup_all(
     // makes each media lookup a single covering-index hop instead of two hops
     // (pk-index → rowid → main table). UNION keeps two index-friendly legs on
     // idx_ums_user_play_state.
-    let date_cutoff = normalize_next_up_cutoff(
-        q.next_up_date_cutoff
-            .as_deref(),
-    )?;
+    let date_cutoff = q
+        .next_up_date_cutoff
+        .clone()
+        .unwrap_or_else(|| "1970-01-01 00:00:00".to_string());
     let active_series: Vec<(Uuid,)> = sqlx::query_as(
         "SELECT m.grandparent_id \
          FROM ( \
@@ -334,8 +301,8 @@ async fn shows_nextup_all(
          WHERE m.kind = 'episode' \
          AND m.grandparent_id IS NOT NULL \
          GROUP BY m.grandparent_id \
-         HAVING MAX(ums.last_played_at) >= ? \
-         ORDER BY MAX(ums.last_played_at) DESC \
+         HAVING MAX(COALESCE(ums.last_played_at, ums.played_at)) >= ? \
+         ORDER BY MAX(COALESCE(ums.last_played_at, ums.played_at)) DESC \
          LIMIT ?",
     )
     .bind(user_id)
@@ -555,7 +522,7 @@ pub async fn shows_recommendations(
 #[cfg(test)]
 mod test {
     use super::*;
-    use chrono::NaiveDate;
+    use chrono::{NaiveDate, NaiveDateTime};
     use sqlx::SqlitePool;
 
     async fn test_db() -> SqlitePool {
@@ -686,7 +653,8 @@ mod test {
         media_id: Uuid,
         play_count: i64,
         playback_position: i64,
-        last_played_at: chrono::NaiveDateTime,
+        played_at: Option<NaiveDateTime>,
+        last_played_at: Option<NaiveDateTime>,
     ) {
         sqlx::query(
             r#"
@@ -715,7 +683,7 @@ mod test {
         .bind(user_id)
         .bind(media_id)
         .bind(play_count)
-        .bind((play_count > 0).then_some(last_played_at))
+        .bind(played_at)
         .bind(playback_position)
         .bind(last_played_at)
         .execute(db)
@@ -728,7 +696,11 @@ mod test {
         user_id: Uuid,
         cutoff: Option<&str>,
     ) -> Vec<Uuid> {
-        let date_cutoff = normalize_next_up_cutoff(cutoff).unwrap();
+        let date_cutoff = cutoff
+            .map(api::normalize_next_up_date_cutoff)
+            .transpose()
+            .unwrap()
+            .unwrap_or_else(|| "1970-01-01 00:00:00".to_string());
         let active_series: Vec<(Uuid,)> = sqlx::query_as(
             "SELECT m.grandparent_id \
              FROM ( \
@@ -741,8 +713,8 @@ mod test {
              WHERE m.kind = 'episode' \
              AND m.grandparent_id IS NOT NULL \
              GROUP BY m.grandparent_id \
-             HAVING MAX(ums.last_played_at) >= ? \
-             ORDER BY MAX(ums.last_played_at) DESC \
+             HAVING MAX(COALESCE(ums.last_played_at, ums.played_at)) >= ? \
+             ORDER BY MAX(COALESCE(ums.last_played_at, ums.played_at)) DESC \
              LIMIT ?",
         )
         .bind(user_id)
@@ -784,10 +756,18 @@ mod test {
             episodes_a[0].id,
             1,
             0,
-            NaiveDate::from_ymd_opt(2026, 6, 16)
-                .unwrap()
-                .and_hms_opt(8, 0, 0)
-                .unwrap(),
+            Some(
+                NaiveDate::from_ymd_opt(2026, 6, 16)
+                    .unwrap()
+                    .and_hms_opt(8, 0, 0)
+                    .unwrap(),
+            ),
+            Some(
+                NaiveDate::from_ymd_opt(2026, 6, 16)
+                    .unwrap()
+                    .and_hms_opt(8, 0, 0)
+                    .unwrap(),
+            ),
         )
         .await;
         insert_state(
@@ -796,10 +776,18 @@ mod test {
             episodes_b[0].id,
             1,
             0,
-            NaiveDate::from_ymd_opt(2026, 6, 17)
-                .unwrap()
-                .and_hms_opt(12, 0, 0)
-                .unwrap(),
+            Some(
+                NaiveDate::from_ymd_opt(2026, 6, 17)
+                    .unwrap()
+                    .and_hms_opt(12, 0, 0)
+                    .unwrap(),
+            ),
+            Some(
+                NaiveDate::from_ymd_opt(2026, 6, 17)
+                    .unwrap()
+                    .and_hms_opt(12, 0, 0)
+                    .unwrap(),
+            ),
         )
         .await;
 
@@ -833,10 +821,18 @@ mod test {
             old_episodes[0].id,
             1,
             0,
-            NaiveDate::from_ymd_opt(2026, 6, 17)
-                .unwrap()
-                .and_hms_opt(12, 0, 0)
-                .unwrap(),
+            Some(
+                NaiveDate::from_ymd_opt(2026, 6, 17)
+                    .unwrap()
+                    .and_hms_opt(12, 0, 0)
+                    .unwrap(),
+            ),
+            Some(
+                NaiveDate::from_ymd_opt(2026, 6, 17)
+                    .unwrap()
+                    .and_hms_opt(12, 0, 0)
+                    .unwrap(),
+            ),
         )
         .await;
         insert_state(
@@ -845,10 +841,18 @@ mod test {
             new_episodes[0].id,
             1,
             0,
-            NaiveDate::from_ymd_opt(2026, 6, 18)
-                .unwrap()
-                .and_hms_opt(12, 0, 0)
-                .unwrap(),
+            Some(
+                NaiveDate::from_ymd_opt(2026, 6, 18)
+                    .unwrap()
+                    .and_hms_opt(12, 0, 0)
+                    .unwrap(),
+            ),
+            Some(
+                NaiveDate::from_ymd_opt(2026, 6, 18)
+                    .unwrap()
+                    .and_hms_opt(12, 0, 0)
+                    .unwrap(),
+            ),
         )
         .await;
 
@@ -858,9 +862,63 @@ mod test {
         );
     }
 
-    #[test]
-    fn shows_nextup_rejects_invalid_cutoff() {
-        let err = normalize_next_up_cutoff(Some("not-a-date")).unwrap_err();
-        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    #[tokio::test]
+    async fn shows_nextup_falls_back_to_played_at_when_last_played_at_is_null() {
+        let db = test_db().await;
+        let user = insert_user(&db, "test").await;
+
+        let (legacy_series, legacy_episodes) = insert_series_with_episodes(
+            &db,
+            "Legacy Series",
+            &["Legacy Episode 1", "Legacy Episode 2"],
+        )
+        .await;
+        let (_newer_series, newer_episodes) = insert_series_with_episodes(
+            &db,
+            "Newer Series",
+            &["Newer Episode 1", "Newer Episode 2"],
+        )
+        .await;
+
+        insert_state(
+            &db,
+            user.id,
+            legacy_episodes[0].id,
+            1,
+            0,
+            Some(
+                NaiveDate::from_ymd_opt(2026, 6, 18)
+                    .unwrap()
+                    .and_hms_opt(12, 0, 0)
+                    .unwrap(),
+            ),
+            None,
+        )
+        .await;
+        insert_state(
+            &db,
+            user.id,
+            newer_episodes[0].id,
+            1,
+            0,
+            Some(
+                NaiveDate::from_ymd_opt(2026, 6, 17)
+                    .unwrap()
+                    .and_hms_opt(12, 0, 0)
+                    .unwrap(),
+            ),
+            Some(
+                NaiveDate::from_ymd_opt(2026, 6, 17)
+                    .unwrap()
+                    .and_hms_opt(12, 0, 0)
+                    .unwrap(),
+            ),
+        )
+        .await;
+
+        assert_eq!(
+            active_series_ids(&db, user.id, Some("2026-06-18")).await,
+            vec![legacy_series.id],
+        );
     }
 }

--- a/crates/remux-server/src/api/shows.rs
+++ b/crates/remux-server/src/api/shows.rs
@@ -6,6 +6,7 @@ use axum::{
     response::IntoResponse,
 };
 use axum_extra::extract::Query;
+use chrono::{DateTime, NaiveDate, NaiveDateTime};
 use http::StatusCode;
 use remux_macros::{api_query, get};
 use uuid::Uuid;
@@ -28,6 +29,37 @@ pub fn livetv_view_item() -> api::BaseItemDto {
         is_folder: true,
         ..Default::default()
     }
+}
+
+fn normalize_next_up_cutoff(cutoff: Option<&str>) -> Result<String> {
+    let Some(cutoff) = cutoff else {
+        return Ok("1970-01-01 00:00:00".to_string());
+    };
+
+    if let Ok(dt) = DateTime::parse_from_rfc3339(cutoff) {
+        return Ok(dt
+            .naive_utc()
+            .format("%F %T")
+            .to_string());
+    }
+
+    if let Ok(dt) = NaiveDateTime::parse_from_str(cutoff, "%Y-%m-%d %H:%M:%S") {
+        return Ok(dt
+            .format("%F %T")
+            .to_string());
+    }
+
+    if let Ok(date) = NaiveDate::parse_from_str(cutoff, "%Y-%m-%d") {
+        return Ok(date
+            .and_hms_opt(0, 0, 0)
+            .expect("midnight is always valid")
+            .format("%F %T")
+            .to_string());
+    }
+
+    Err(anyhow::anyhow!("invalid next_up_date_cutoff")).context_bad_request(
+        "nextUpDateCutoff must be RFC3339, YYYY-MM-DD, or YYYY-MM-DD HH:MM:SS",
+    )
 }
 
 #[get("/shows/{id}/seasons")]
@@ -286,20 +318,30 @@ async fn shows_nextup_all(
     // makes each media lookup a single covering-index hop instead of two hops
     // (pk-index → rowid → main table). UNION keeps two index-friendly legs on
     // idx_ums_user_play_state.
+    let date_cutoff = normalize_next_up_cutoff(
+        q.next_up_date_cutoff
+            .as_deref(),
+    )?;
     let active_series: Vec<(Uuid,)> = sqlx::query_as(
-        "SELECT DISTINCT m.grandparent_id \
+        "SELECT m.grandparent_id \
          FROM ( \
            SELECT media_id FROM user_media_state WHERE user_id = ? AND play_count > 0 \
            UNION \
            SELECT media_id FROM user_media_state WHERE user_id = ? AND play_count = 0 AND playback_position > 0 \
          ) AS active \
-         CROSS JOIN media m ON m.id = active.media_id \
+         JOIN user_media_state ums ON ums.media_id = active.media_id AND ums.user_id = ? \
+         JOIN media m ON m.id = active.media_id \
          WHERE m.kind = 'episode' \
          AND m.grandparent_id IS NOT NULL \
+         GROUP BY m.grandparent_id \
+         HAVING MAX(ums.last_played_at) >= ? \
+         ORDER BY MAX(ums.last_played_at) DESC \
          LIMIT ?",
     )
     .bind(user_id)
     .bind(user_id)
+    .bind(user_id)
+    .bind(&date_cutoff)
     .bind(limit)
     .fetch_all(&state.ctx.db)
     .await?;
@@ -508,4 +550,317 @@ pub async fn shows_recommendations(
     )
     .await?;
     Ok(Json(categories))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use chrono::NaiveDate;
+    use sqlx::SqlitePool;
+
+    async fn test_db() -> SqlitePool {
+        let db = db::connect("sqlite::memory:", 10_000)
+            .await
+            .unwrap();
+        db::migrate(&db)
+            .await
+            .unwrap();
+        db
+    }
+
+    async fn insert_series_with_episodes(
+        db: &SqlitePool,
+        series_title: &str,
+        episode_titles: &[&str],
+    ) -> (db::Media, Vec<db::Media>) {
+        let series_imdb = db::NonEmptyString::try_new(format!(
+            "tt{}",
+            series_title
+                .bytes()
+                .fold(0_u32, |acc, byte| acc
+                    .wrapping_mul(31)
+                    .wrapping_add(byte as u32))
+        ))
+        .unwrap();
+        let mut series = db::Media {
+            id: Uuid::from(&db::MediaIdRaw {
+                kind: db::MediaKind::Series,
+                external_ids: db::ExternalIds {
+                    imdb: Some(series_imdb.clone()),
+                    ..Default::default()
+                },
+                season: None,
+                episode: None,
+            }),
+            title: series_title.to_string(),
+            kind: db::MediaKind::Series,
+            external_ids: db::ExternalIds {
+                imdb: Some(series_imdb.clone()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        series
+            .save(db)
+            .await
+            .unwrap();
+
+        let mut season = db::Media {
+            id: Uuid::from(&db::MediaIdRaw {
+                kind: db::MediaKind::Season,
+                external_ids: db::ExternalIds {
+                    series_imdb: Some(series_imdb.clone()),
+                    ..Default::default()
+                },
+                season: Some(1),
+                episode: None,
+            }),
+            title: format!("{series_title} Season 1"),
+            kind: db::MediaKind::Season,
+            external_ids: db::ExternalIds {
+                series_imdb: Some(series_imdb.clone()),
+                ..Default::default()
+            },
+            grandparent_id: Some(series.id),
+            parent_id: Some(series.id),
+            idx: Some(1),
+            ..Default::default()
+        };
+        season
+            .save(db)
+            .await
+            .unwrap();
+
+        let mut episodes = Vec::with_capacity(episode_titles.len());
+        for (idx, title) in episode_titles
+            .iter()
+            .enumerate()
+        {
+            let mut episode = db::Media {
+                id: Uuid::from(&db::MediaIdRaw {
+                    kind: db::MediaKind::Episode,
+                    external_ids: db::ExternalIds {
+                        series_imdb: Some(series_imdb.clone()),
+                        ..Default::default()
+                    },
+                    season: Some(1),
+                    episode: Some(idx as i64 + 1),
+                }),
+                title: (*title).to_string(),
+                kind: db::MediaKind::Episode,
+                external_ids: db::ExternalIds {
+                    series_imdb: Some(series_imdb.clone()),
+                    ..Default::default()
+                },
+                grandparent_id: Some(series.id),
+                parent_id: Some(season.id),
+                parent_idx: Some(1),
+                idx: Some(idx as i64 + 1),
+                ..Default::default()
+            };
+            episode
+                .save(db)
+                .await
+                .unwrap();
+            episodes.push(episode);
+        }
+
+        (series, episodes)
+    }
+
+    async fn insert_user(db: &SqlitePool, username: &str) -> db::User {
+        let mut user = db::User {
+            username: username.to_string(),
+            password_hash: "test".to_string(),
+            ..Default::default()
+        };
+        user.save(db)
+            .await
+            .unwrap();
+        user
+    }
+
+    async fn insert_state(
+        db: &SqlitePool,
+        user_id: Uuid,
+        media_id: Uuid,
+        play_count: i64,
+        playback_position: i64,
+        last_played_at: chrono::NaiveDateTime,
+    ) {
+        sqlx::query(
+            r#"
+            INSERT INTO user_media_state (
+                user_id,
+                media_id,
+                media_raw,
+                stream_id,
+                favorite,
+                play_count,
+                played_at,
+                playback_position,
+                last_played_at,
+                subtitle_idx,
+                audio_idx
+            )
+            VALUES (?1, ?2, NULL, NULL, 0, ?3, ?4, ?5, ?6, NULL, NULL)
+            ON CONFLICT(user_id, media_id)
+            DO UPDATE SET
+                play_count = excluded.play_count,
+                played_at = excluded.played_at,
+                playback_position = excluded.playback_position,
+                last_played_at = excluded.last_played_at
+            "#,
+        )
+        .bind(user_id)
+        .bind(media_id)
+        .bind(play_count)
+        .bind((play_count > 0).then_some(last_played_at))
+        .bind(playback_position)
+        .bind(last_played_at)
+        .execute(db)
+        .await
+        .unwrap();
+    }
+
+    async fn active_series_ids(
+        db: &SqlitePool,
+        user_id: Uuid,
+        cutoff: Option<&str>,
+    ) -> Vec<Uuid> {
+        let date_cutoff = normalize_next_up_cutoff(cutoff).unwrap();
+        let active_series: Vec<(Uuid,)> = sqlx::query_as(
+            "SELECT m.grandparent_id \
+             FROM ( \
+               SELECT media_id FROM user_media_state WHERE user_id = ? AND play_count > 0 \
+               UNION \
+               SELECT media_id FROM user_media_state WHERE user_id = ? AND play_count = 0 AND playback_position > 0 \
+             ) AS active \
+             JOIN user_media_state ums ON ums.media_id = active.media_id AND ums.user_id = ? \
+             JOIN media m ON m.id = active.media_id \
+             WHERE m.kind = 'episode' \
+             AND m.grandparent_id IS NOT NULL \
+             GROUP BY m.grandparent_id \
+             HAVING MAX(ums.last_played_at) >= ? \
+             ORDER BY MAX(ums.last_played_at) DESC \
+             LIMIT ?",
+        )
+        .bind(user_id)
+        .bind(user_id)
+        .bind(user_id)
+        .bind(&date_cutoff)
+        .bind(50_i64)
+        .fetch_all(db)
+        .await
+        .unwrap();
+
+        active_series
+            .into_iter()
+            .map(|(id,)| id)
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn shows_nextup_orders_by_last_played_desc() {
+        let db = test_db().await;
+        let user = insert_user(&db, "test").await;
+
+        let (series_a, episodes_a) = insert_series_with_episodes(
+            &db,
+            "Series A",
+            &["A Episode 1", "A Episode 2"],
+        )
+        .await;
+        let (series_b, episodes_b) = insert_series_with_episodes(
+            &db,
+            "Series B",
+            &["B Episode 1", "B Episode 2"],
+        )
+        .await;
+
+        insert_state(
+            &db,
+            user.id,
+            episodes_a[0].id,
+            1,
+            0,
+            NaiveDate::from_ymd_opt(2026, 6, 16)
+                .unwrap()
+                .and_hms_opt(8, 0, 0)
+                .unwrap(),
+        )
+        .await;
+        insert_state(
+            &db,
+            user.id,
+            episodes_b[0].id,
+            1,
+            0,
+            NaiveDate::from_ymd_opt(2026, 6, 17)
+                .unwrap()
+                .and_hms_opt(12, 0, 0)
+                .unwrap(),
+        )
+        .await;
+
+        assert_eq!(
+            active_series_ids(&db, user.id, None).await,
+            vec![series_b.id, series_a.id],
+        );
+    }
+
+    #[tokio::test]
+    async fn shows_nextup_accepts_rfc3339_cutoff() {
+        let db = test_db().await;
+        let user = insert_user(&db, "test").await;
+
+        let (_series_old, old_episodes) = insert_series_with_episodes(
+            &db,
+            "Old Series",
+            &["Old Episode 1", "Old Episode 2"],
+        )
+        .await;
+        let (new_series, new_episodes) = insert_series_with_episodes(
+            &db,
+            "New Series",
+            &["New Episode 1", "New Episode 2"],
+        )
+        .await;
+
+        insert_state(
+            &db,
+            user.id,
+            old_episodes[0].id,
+            1,
+            0,
+            NaiveDate::from_ymd_opt(2026, 6, 17)
+                .unwrap()
+                .and_hms_opt(12, 0, 0)
+                .unwrap(),
+        )
+        .await;
+        insert_state(
+            &db,
+            user.id,
+            new_episodes[0].id,
+            1,
+            0,
+            NaiveDate::from_ymd_opt(2026, 6, 18)
+                .unwrap()
+                .and_hms_opt(12, 0, 0)
+                .unwrap(),
+        )
+        .await;
+
+        assert_eq!(
+            active_series_ids(&db, user.id, Some("2026-06-17T23:00:00Z")).await,
+            vec![new_series.id],
+        );
+    }
+
+    #[test]
+    fn shows_nextup_rejects_invalid_cutoff() {
+        let err = normalize_next_up_cutoff(Some("not-a-date")).unwrap_err();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
 }

--- a/crates/remux-server/src/db/media.rs
+++ b/crates/remux-server/src/db/media.rs
@@ -3623,7 +3623,7 @@ impl Media {
                 recursive: filter.recursive,
                 include_user_state: filter
                     .enable_user_data
-                    .is_none(),
+                    .unwrap_or(true),
                 user_id: filter.user_id,
                 include_child_count: has_playlist
                     || filter


### PR DESCRIPTION
NextUp now orders series by the most recent `last_played_at`, and `enable_user_data` defaults are respected in the affected item paths.

`nextUpDateCutoff` is now normalized before querying so RFC3339 and date-only inputs compare correctly against SQLite datetime values without adding per-row SQL conversion cost.

- default `enable_user_data` to `true` in the affected item/user-data paths
- order NextUp series by `MAX(last_played_at) DESC`
- normalize `nextUpDateCutoff` to SQLite datetime format before binding
- return `400 Bad Request` for invalid cutoff formats
- add focused tests for ordering, RFC3339 cutoff handling, and invalid cutoff rejection

This should resolve #19.

Also bumps `tikv-jemallocator` to restore builds on GCC 16, where the older bundled jemalloc source no longer compiles cleanly in this environment.