### PR TITLE
fix(iptv): restore iptv_sources table lost in migration squash

### DIFF
--- a/crates/remux-server/migrations/202606190001_iptv_sources_table.sql
+++ b/crates/remux-server/migrations/202606190001_iptv_sources_table.sql
@@ -1,0 +1,20 @@
+-- Restore the iptv_sources table that was accidentally dropped during the
+-- migration squash in PR #92 (commit cf8efd1). The table pre-dated the squash
+-- but was not re-created there, while db::IptvSource (src/db/iptv.rs) kept
+-- querying it — so every IPTV source operation (list/get/save/delete) failed
+-- with "no such table: iptv_sources" on databases initialized from the squash.
+
+-- Columns mirror the IptvSource struct in src/db/iptv.rs:
+--   id, name, m3u_url, epg_url (deprecated, kept for compatibility),
+--   refresh_interval, source_type ('m3u' | 'xtream'),
+--   xtream_username, xtream_password.
+CREATE TABLE IF NOT EXISTS iptv_sources (
+    id               TEXT NOT NULL PRIMARY KEY,
+    name             TEXT NOT NULL,
+    m3u_url          TEXT NOT NULL,
+    epg_url          TEXT,
+    refresh_interval TEXT NOT NULL DEFAULT '24h',
+    source_type      TEXT NOT NULL DEFAULT 'm3u',
+    xtream_username  TEXT,
+    xtream_password  TEXT
+);


### PR DESCRIPTION
## Problem

After the migration squash in #92 (`cf8efd1`), the `iptv_sources` table is missing from the schema. However, `db::IptvSource` in `src/db/iptv.rs` still queries it:

```rust
// src/db/iptv.rs:83
sqlx::query_as::<_, Self>("SELECT * FROM iptv_sources ORDER BY name")
// also lines 91, 101 (INSERT), 125 (DELETE)
```

The squash only re-creates `epg_sources` (`migrations/202606140005_squash.sql:204`), not `iptv_sources`. As a result, **every IPTV source operation fails** with `no such table: iptv_sources` on databases initialised from the squash (i.e. any fresh install since v0.8.x).

This breaks the entire IPTV management UI: listing, creating, editing, and deleting M3U/Xtream sources all error out.

## Fix

Add the table back as a new migration (`202606190001_iptv_sources_table.sql`). The column set mirrors the `IptvSource` struct in `src/db/iptv.rs`:

| Column | Type | Notes |
|---|---|---|
| `id` | TEXT PK | UUID |
| `name` | TEXT NOT NULL | |
| `m3u_url` | TEXT NOT NULL | M3U playlist URL or Xtream server base |
| `epg_url` | TEXT | Deprecated, kept for schema compat (per existing comment in `iptv.rs:36`) |
| `refresh_interval` | TEXT NOT NULL DEFAULT `24h` | |
| `source_type` | TEXT NOT NULL DEFAULT `m3u` | `m3u` \| `xtream` (lowercase, matches `IptvSourceType` serde/strum renames) |
| `xtream_username` | TEXT | Xtream only |
| `xtream_password` | TEXT | Xtream only |

`CREATE TABLE IF NOT EXISTS` keeps existing installs (where the table survived from pre-squash migrations) untouched — no data migration needed.

## Verification

- `cargo check -p remux-server` ✅
- `cargo fmt --all -- --check` ✅
- Applied all 3 migrations (squash → perf_indexes → this) to a fresh in-memory SQLite and confirmed:
  - `iptv_sources` table is created with the expected 8 columns
  - `INSERT` (matches `IptvSource::save` column list) succeeds
  - `INSERT ... ON CONFLICT (id) DO UPDATE` (the upsert pattern in `IptvSource::save`) correctly updates existing rows
  - `SELECT *` returns columns in the order the `FromRow` derive expects

## Root cause (for context)

Pre-squash, `iptv_sources` was created by an earlier migration. The squash consolidated schema into one file but missed this table — likely an oversight since `epg_sources` (the sister table added in the same IPTV refactor #73) made it in, while `iptv_sources` did not.

cc @lostb1t — happy to adjust column types/defaults if any differ from your intent.