### PR TITLE
fix: prevent panics and surface silent DB errors

### DIFF
--- a/crates/remux-server/src/addons/mod.rs
+++ b/crates/remux-server/src/addons/mod.rs
@@ -189,9 +189,9 @@ pub(crate) async fn save_pending_relations(ctx: &AppContext, items: &[db::Media]
         // Don't link relations that point to name-keyed person stubs.
         .filter(|r| !name_keyed_person_ids.contains(&r.right_media_id))
         .collect();
-    db::MediaRelation::delete_by_left_ids(&ctx.db, &all_ids)
-        .await
-        .ok();
+    if let Err(e) = db::MediaRelation::delete_by_left_ids(&ctx.db, &all_ids).await {
+        warn!(error = %e, "failed to delete stale relations before upsert");
+    }
     if !all_rels.is_empty() {
         if let Err(e) = db::MediaRelation::upsert(&ctx.db, &all_rels).await {
             warn!(error = %e, "failed to upsert relations batch");

--- a/crates/remux-server/src/api/playback.rs
+++ b/crates/remux-server/src/api/playback.rs
@@ -1227,7 +1227,7 @@ async fn videos_stream_inner(
         } else {
             descriptor
                 .clone()
-                .into_source()
+                .into_source()?
                 .serve(&state, &headers)
                 .await?
         };
@@ -3481,9 +3481,14 @@ pub async fn master_hls_video(
     let audio_codec = q
         .audio_codec
         .unwrap_or_else(|| "aac".to_string());
+    // Clamp to a sane range: 0 would cause divide-by-zero panics in the
+    // transcode buffer monitor (`/ segment_length`) and segment-gap
+    // calculations; absurdly large values waste buffer. Jellyfin clients
+    // send 6–10; allow 1–30.
     let segment_length = q
         .segment_length
-        .unwrap_or(6) as u32;
+        .unwrap_or(6)
+        .clamp(1, 30) as u32;
 
     // Look up existing session or create a new one.
     // When the client seeks it sends the same PlaySessionId but with a new
@@ -4891,7 +4896,7 @@ pub async fn subtitles_stream(
                     .map_err(|e| anyhow!("{e:?}"))?
             }
             _ => descriptor
-                .into_source()
+                .into_source()?
                 .serve(&state, &axum::http::HeaderMap::new())
                 .await
                 .map_err(|e| anyhow!("{e:?}"))?,

--- a/crates/remux-server/src/api/stream.rs
+++ b/crates/remux-server/src/api/stream.rs
@@ -69,7 +69,7 @@ pub async fn stream_proxy(
     }
 
     descriptor
-        .into_source()
+        .into_source()?
         .serve(&state, &headers)
         .await
 }

--- a/crates/remux-server/src/services/resolve.rs
+++ b/crates/remux-server/src/services/resolve.rs
@@ -243,9 +243,9 @@ impl MediaResolveService {
             .process_meta_item(root, ctx, false, config)
             .await;
         if !processed.is_empty() {
-            db::Media::upsert(&ctx.db, &processed)
-                .await
-                .ok();
+            if let Err(e) = db::Media::upsert(&ctx.db, &processed).await {
+                warn!(error = %e, "failed to persist resolved media item");
+            }
             crate::addons::save_pending_relations(ctx, &processed).await;
         }
         Ok(db::Media::get_by_id(&ctx.db, &resolved_id).await?)
@@ -269,9 +269,9 @@ impl MediaResolveService {
                     .await?
                     .is_none()
                 {
-                    Self::persist_from_store(id, ctx)
-                        .await
-                        .ok();
+                    if let Err(e) = Self::persist_from_store(id, ctx).await {
+                        warn!(error = %e, %id, "failed to persist media from store");
+                    }
                 }
                 return Ok(true);
             } else if let Some(_guard) = PERSIST_LOCKS

--- a/crates/remux-server/src/stream.rs
+++ b/crates/remux-server/src/stream.rs
@@ -113,34 +113,38 @@ impl StreamDescriptor {
 
     /// Instantiate the runtime service for self-contained variants.
     /// Do **not** call this for `Opendal` — those must go through the addon.
-    pub fn into_source(self) -> Box<dyn StreamSource> {
+    ///
+    /// Returns an error for variants that cannot be served directly (`Rtsp`,
+    /// `Opendal`) instead of panicking, so the request fails gracefully with
+    /// a 500 instead of crashing the worker thread.
+    pub fn into_source(self) -> anyhow::Result<Box<dyn StreamSource>> {
         match self {
             Self::Http {
                 url,
                 request_headers,
                 response_headers,
-            } => Box::new(HttpSource {
+            } => Ok(Box::new(HttpSource {
                 url,
                 request_headers,
                 response_headers,
-            }),
-            Self::Local(path) => Box::new(LocalSource { path }),
+            })),
+            Self::Local(path) => Ok(Box::new(LocalSource { path })),
             Self::Torrent {
                 info_hash,
                 file_hint,
                 file_idx,
                 trackers,
-            } => Box::new(TorrentSource {
+            } => Ok(Box::new(TorrentSource {
                 info_hash,
                 file_hint,
                 file_idx,
                 trackers,
-            }),
-            Self::Rtsp { .. } => {
-                panic!("Rtsp descriptors must be served through the transcode path")
-            }
+            })),
+            Self::Rtsp { .. } => anyhow::bail!(
+                "Rtsp descriptors must be served through the transcode path"
+            ),
             Self::Opendal { .. } => {
-                panic!("Opendal descriptors must be served through their addon")
+                anyhow::bail!("Opendal descriptors must be served through their addon")
             }
         }
     }


### PR DESCRIPTION
## Summary

Three independent robustness fixes — each prevents a failure mode where the server either panics (crashing the worker thread) or silently drops errors (causing data inconsistencies).

## 1. Validate `segment_length` from client requests

**File:** `api/playback.rs`

The `SegmentLength` query parameter is user-controlled (`Option<i32>`). It was stored directly into the transcode session without validation:

```rust
let segment_length = q.segment_length.unwrap_or(6) as u32;  // no validation
```

A `SegmentLength=0` causes **divide-by-zero panics** downstream:
- `transcode/engine.rs:193`: `cutoff_idx = (playback_secs - SEGMENT_KEEP_SECS) / segment_length`
- `api/playback.rs:4212`: `segment_gap_threshold = 24 / segment_length`

Negative values (`-1`) silently cast to huge `u32` via `as`.

**Fix:** clamp to `1..=30` at session creation. Jellyfin clients send 6–10; 30 is a generous ceiling.

## 2. Return errors instead of `panic!()` for unsupported stream variants

**File:** `stream.rs` (`StreamDescriptor::into_source`)

`into_source()` panicked for `Rtsp` and `Opendal` descriptors:

```rust
Self::Rtsp { .. } => panic!("Rtsp descriptors must be served through the transcode path"),
Self::Opendal { .. } => panic!("Opendal descriptors must be served through their addon"),
```

If a descriptor of these types reached the direct-stream path (e.g. from addon config or DB state), the worker thread crashed — a crash-per-request DoS.

**Fix:** changed return type to `anyhow::Result<Box<dyn StreamSource>>`, using `anyhow::bail!` for the unsupported variants. The request now fails gracefully with a 500. Updated all 3 call sites (`api/playback.rs` ×2, `api/stream.rs` ×1) to propagate with `?`.

## 3. Log DB-write errors instead of silently dropping them

**Files:** `addons/mod.rs`, `services/resolve.rs`

Three places used `.ok()` to silently discard DB-write errors:

- `addons/mod.rs` — `MediaRelation::delete_by_left_ids(...).await.ok()` before upserting relations
- `services/resolve.rs` — `Media::upsert(...).await.ok()` after resolving media metadata
- `services/resolve.rs` — `persist_from_store(...).await.ok()` in the concurrent-wait path

If these writes failed (DB error, disk full, etc.), the caller continued as if they succeeded, causing **silent inconsistencies** between the in-memory addon cache and the database — stale relations, missing metadata, duplicated entries on next refresh.

**Fix:** replaced `.ok()` with `warn!(error = %e, ...)` so failures are at least visible in logs and debuggable. Not propagated as hard errors (to preserve existing graceful-degradation behavior), but no longer silent.

## Verification

- `cargo check -p remux-server` ✅
- `cargo fmt --all -- --check` ✅
- Individual unit tests pass ✅ (e.g. `test_get_sessions_empty`, `test_playback_start`)
- Note: running the full test suite in parallel shows pre-existing test-isolation failures (62 tests fail on clean `upstream/main` too — shared SQLite/filesystem contention). These are not introduced by this PR.

cc @lostb1t