### PR TITLE
perf: reduce startup latency by caching hw-detection and deferring startup tasks

### DIFF
--- a/crates/remux-server/src/lib.rs
+++ b/crates/remux-server/src/lib.rs
@@ -196,25 +196,45 @@ pub async fn init_app(
     crate::db::Settings::init_server_id(&conn).await?;
 
     // Probe hardware and persist results at startup.
-    // vaapi_driver is always re-detected (regardless of auto_detect) because
-    // it is a runtime property of the host, not a user preference.
+    //
+    // Both `hardware_acceleration_type` and `vaapi_driver` describe properties
+    // of the host hardware, which does not change between boots. Re-probing on
+    // every restart adds 0.2-10s of startup latency (the VAAPI probe can hang
+    // for seconds on misconfigured drivers) for no benefit.
+    //
+    // We therefore only probe when the value is not already cached from a
+    // previous boot. To force re-detection after a hardware change, clear the
+    // cached value in the encoding settings (set the field to null).
     {
         let mut enc_opts = db::Settings::get_encoding_config(&conn).await?;
+        let mut changed = false;
         if enc_opts
             .auto_detect_hardware_acceleration
             .unwrap_or(true)
+            && enc_opts
+                .hardware_acceleration_type
+                .is_none()
         {
             let detected =
                 crate::transcode::engine::detect_hardware_acceleration().await;
             enc_opts.hardware_acceleration_type = Some(detected);
+            changed = true;
         }
-        let device = enc_opts
-            .vaapi_device
-            .as_deref()
-            .unwrap_or("/dev/dri/renderD128");
-        let driver = crate::transcode::engine::detect_vaapi_driver(device).await;
-        enc_opts.vaapi_driver = Some(driver);
-        db::Settings::set_encoding_config(&conn, &enc_opts).await?;
+        if enc_opts
+            .vaapi_driver
+            .is_none()
+        {
+            let device = enc_opts
+                .vaapi_device
+                .as_deref()
+                .unwrap_or("/dev/dri/renderD128");
+            let driver = crate::transcode::engine::detect_vaapi_driver(device).await;
+            enc_opts.vaapi_driver = Some(driver);
+            changed = true;
+        }
+        if changed {
+            db::Settings::set_encoding_config(&conn, &enc_opts).await?;
+        }
     }
 
     let saved_config = db::Settings::get_config(&conn).await?;
@@ -278,9 +298,21 @@ pub async fn init_app(
     task_service
         .start()
         .await?;
-    task_service
-        .run_startup_tasks()
-        .await?;
+
+    // Run startup tasks in the background so they don't delay the server from
+    // accepting connections. Startup tasks (library refresh, metadata refresh,
+    // cache cleanup, ...) can take a long time on large libraries, and there's
+    // no need to block first-request readiness for them — the data they
+    // populate is also refreshed periodically by the scheduler.
+    let startup_service = task_service.clone();
+    tokio::spawn(async move {
+        if let Err(e) = startup_service
+            .run_startup_tasks()
+            .await
+        {
+            error!(error = %e, "startup task failed");
+        }
+    });
 
     let state = AppState {
         ctx: ctx.clone(),


### PR DESCRIPTION
## Problem

Two things in `init_app` delay the server from accepting its first connection after a restart:

### 1. Hardware-acceleration re-detected on every boot

`lib.rs:198-218` runs two ffmpeg-based probes synchronously on **every** startup:

- `detect_hardware_acceleration()` — runs `ffmpeg -hwaccels` + inspects device files (~50–200ms)
- `detect_vaapi_driver(device)` — runs `ffmpeg -v verbose -init_hw_device vaapi=va:...` (**200ms–5+ s**, and can hang on misconfigured/broken VAAPI drivers)

Both describe properties of the host hardware, which does not change between boots. The results are then written back to the encoding settings — the same value almost every time.

The existing comment notes vaapi_driver "is always re-detected because it is a runtime property of the host". That's exactly the argument *for* caching: a runtime property of the host is stable across reboots.

### 2. `run_startup_tasks()` blocks `init_app` from returning

`lib.rs:282` awaits `run_startup_tasks()`, so the server won't bind its listener until **all** startup-triggered scheduled tasks complete. These include library refresh, metadata refresh, IPTV refresh, cache cleanup — on a large library this can delay first-request readiness by minutes, even though the data they populate is also refreshed periodically by the scheduler.

## Fix

### 1. Cache hw-detection — only probe when not already cached

```rust
if enc_opts.auto_detect_hardware_acceleration.unwrap_or(true)
    && enc_opts.hardware_acceleration_type.is_none()
{
    // probe…
}
if enc_opts.vaapi_driver.is_none() {
    // probe…
}
```

First boot probes both and persists them; subsequent boots skip both probes entirely. To force re-detection after a hardware change, clear the cached value in the encoding settings (set the field to null).

### 2. Defer startup tasks to the background

```rust
let startup_service = task_service.clone();
tokio::spawn(async move {
    if let Err(e) = startup_service.run_startup_tasks().await {
        error!(error = %e, "startup task failed");
    }
});
```

`TaskService` is `#[derive(Clone)]` with `Arc` internals, so cloning is cheap and the background task shares the same scheduler/handlers. The server now returns from `init_app` (and starts accepting connections) as soon as the router is built.

## Impact

Startup → first-request latency drops by:
- ~0.2–10s on every boot (hw probes), most pronounced on embedded/VAAPI systems
- Up to minutes on large libraries (startup tasks now run concurrently with serving)

## Notes / trade-offs

- For hw-detection: if a user changes `vaapi_device` in settings, the cached `vaapi_driver` could be stale until cleared. This is a narrow edge case (hardware reconfig) and the PR description documents the re-detect escape hatch. Happy to add a settings-change invalidation if you prefer.
- For startup tasks: requests that arrive before the first startup refresh completes will see slightly stale data (e.g. not-yet-refreshed metadata), which is the same state as mid-cycle between scheduled runs. No correctness impact.

## Verification

- `cargo check -p remux-server` ✅
- `cargo fmt --all -- --check` ✅
- Unit tests pass (single-threaded): `test_playback_start`, `test_playback_start_minimal_payload` ✅

cc @lostb1t — happy to split into two PRs if you'd prefer to take one but not the other.