### PR TITLE
fix: force nextup active-series join order

### DIFF
--- a/crates/remux-server/src/api/shows.rs
+++ b/crates/remux-server/src/api/shows.rs
@@ -288,6 +288,8 @@ async fn shows_nextup_all(
     // Inner UNION selects last_played_at/played_at directly from idx_ums_user_play_state
     // (covering) so no second join to user_media_state is needed. UNION ALL is safe
     // because the two legs are mutually exclusive (play_count > 0 vs play_count = 0).
+    // CROSS JOIN pins SQLite to start from the small active set and then PK-lookup
+    // media rows, avoiding a slow scan over the full episode index.
     let date_cutoff = q
         .next_up_date_cutoff
         .clone()
@@ -301,7 +303,7 @@ async fn shows_nextup_all(
            SELECT media_id, last_played_at, played_at \
            FROM user_media_state WHERE user_id = ? AND play_count = 0 AND playback_position > 0 \
          ) AS active \
-         JOIN media m ON m.id = active.media_id \
+         CROSS JOIN media m ON m.id = active.media_id \
          WHERE m.kind = 'episode' \
          AND m.grandparent_id IS NOT NULL \
          GROUP BY m.grandparent_id \


### PR DESCRIPTION
 Fixes a slow `NextUp` query by forcing SQLite to use the right join order.

  The current query was starting from the `media` side and walking a large episode index, even though the active `user_media_state` set is usually small. On the live DB this was enough to turn a simple `NextUp` request into a multi-
  second query.

  This changes the join in `crates/remux-server/src/api/shows.rs` from `JOIN` to `CROSS JOIN` so SQLite evaluates the active state set first, then does targeted lookups into `media`.

  On the live DB I tested against, the query dropped from about 7.7s to about 0.06s.
  
  AI was definitely used.