### PR TITLE
feat(deezer): surface playlists as real Jellyfin playlists

### DIFF
--- a/crates/remux-sdks/src/deezer/mod.rs
+++ b/crates/remux-sdks/src/deezer/mod.rs
@@ -164,6 +164,11 @@ pub struct SearchArtist {
 pub struct Playlist {
     pub id: u64,
     pub title: String,
+    /// Playlist artwork (Deezer `picture_xl`).
+    #[serde(default)]
+    pub picture_xl: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
     #[serde(default)]
     pub tracks: DeezerList<PlaylistTrack>,
 }

--- a/crates/remux-server/src/addons/deezer.rs
+++ b/crates/remux-server/src/addons/deezer.rs
@@ -20,6 +20,7 @@ use crate::{
 };
 
 const CACHE_TTL: Duration = Duration::from_secs(60);
+const PLAYLIST_CACHE_TTL: Duration = Duration::from_secs(3600);
 
 fn parse_release_date(s: &str) -> Option<NaiveDateTime> {
     chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d")
@@ -59,6 +60,7 @@ impl AddonPreset for DeezerPreset {
                 MediaKind::Track,
                 MediaKind::Album,
                 MediaKind::Artist,
+                MediaKind::Playlist,
             ],
             options: vec![AddonOption {
                 id: "playlists".to_string(),
@@ -955,85 +957,23 @@ impl DeezerAddon {
 
     // --- Catalog (playlist) ---
 
-    async fn fetch_playlist_stream(
-        &self,
-        _ctx: &AppContext,
-        playlist_id: &str,
-    ) -> Result<Pin<Box<dyn Stream<Item = db::Media> + Send>>> {
-        let playlist = match self
+    async fn fetch_playlist(&self, playlist_id: &str) -> Result<dz::Playlist> {
+        match self
             .client
-            .execute(dz::PlaylistEndpoint {
-                id: playlist_id.to_string(),
-            })
+            .execute(
+                dz::PlaylistEndpoint {
+                    id: playlist_id.to_string(),
+                }
+                .with_cache(PLAYLIST_CACHE_TTL),
+            )
             .await
         {
-            Ok(dz::DeezerResult::Ok(p)) => p,
+            Ok(dz::DeezerResult::Ok(p)) => Ok(p),
             Ok(dz::DeezerResult::Err { error }) => {
-                return Err(anyhow!("Deezer playlist error: {}", error));
+                Err(anyhow!("Deezer playlist error: {}", error))
             }
-            Err(e) => {
-                return Err(anyhow!(
-                    "Deezer playlist {} HTTP error: {}",
-                    playlist_id,
-                    e
-                ));
-            }
-        };
-
-        let items: Vec<db::Media> = playlist
-            .tracks
-            .data
-            .into_iter()
-            .map(|track| {
-                let released_at = track
-                    .album
-                    .release_date
-                    .as_deref()
-                    .and_then(parse_release_date);
-                let mut media = db::Media {
-                    id: common::stable_media_uuid(
-                        &db::MediaKind::Track,
-                        &track
-                            .id
-                            .to_string(),
-                    ),
-                    title: track.title,
-                    kind: db::MediaKind::Track,
-                    runtime: Some(track.duration as i64),
-                    released_at,
-                    description: Some(format!(
-                        "by {}",
-                        track
-                            .artist
-                            .name
-                    )),
-                    external_ids: db::ExternalIds {
-                        deezer_track: Some(track.id as i64),
-                        deezer_album: Some(
-                            track
-                                .album
-                                .id as i64,
-                        ),
-                        deezer_artist: Some(
-                            track
-                                .artist
-                                .id as i64,
-                        ),
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                };
-                if let Some(url) = track
-                    .album
-                    .cover_xl
-                {
-                    media.set_image(db::ImageKind::Primary, url);
-                }
-                media
-            })
-            .collect();
-
-        Ok(Box::pin(futures::stream::iter(items)))
+            Err(e) => Err(anyhow!("Deezer playlist {} HTTP error: {}", playlist_id, e)),
+        }
     }
 }
 
@@ -1051,19 +991,48 @@ impl AddonKind for DeezerAddon {
 #[async_trait]
 impl CatalogAddon for DeezerAddon {
     async fn catalog_list(&self, _ctx: &AppContext) -> Result<Vec<CatalogInfo>> {
-        Ok(self
-            .playlists()
-            .iter()
-            .map(|id| CatalogInfo {
-                media_kind: Some(db::MediaKind::Track),
-                ..CatalogInfo::new(id.clone(), format!("Deezer playlist {id}"))
-            })
-            .collect())
+        let client = self
+            .client
+            .clone();
+        let infos: Vec<CatalogInfo> = stream::iter(
+            self.playlists()
+                .iter()
+                .cloned(),
+        )
+        .map(|id| {
+            let client = client.clone();
+            async move {
+                let name = match client
+                    .execute(
+                        dz::PlaylistEndpoint { id: id.clone() }
+                            .with_cache(PLAYLIST_CACHE_TTL),
+                    )
+                    .await
+                {
+                    Ok(dz::DeezerResult::Ok(p))
+                        if !p
+                            .title
+                            .is_empty() =>
+                    {
+                        p.title
+                    }
+                    _ => format!("Deezer playlist {id}"),
+                };
+                CatalogInfo {
+                    media_kind: Some(db::MediaKind::Playlist),
+                    ..CatalogInfo::new(id, name)
+                }
+            }
+        })
+        .buffered(8)
+        .collect()
+        .await;
+        Ok(infos)
     }
 
     async fn catalog_stream(
         &self,
-        ctx: &AppContext,
+        _ctx: &AppContext,
         local_id: &str,
     ) -> Result<Option<Pin<Box<dyn Stream<Item = db::Media> + Send>>>> {
         if !self
@@ -1073,10 +1042,14 @@ impl CatalogAddon for DeezerAddon {
         {
             return Ok(None);
         }
-        Ok(Some(
-            self.fetch_playlist_stream(ctx, local_id)
-                .await?,
-        ))
+        // Tracks ride in `relations` (role = Playlist); the import pipeline's
+        // save_pending_relations links them as playlist members.
+        let playlist = self
+            .fetch_playlist(local_id)
+            .await?;
+        Ok(Some(Box::pin(stream::iter(vec![build_playlist_media(
+            &playlist,
+        )]))))
     }
 }
 
@@ -1215,6 +1188,121 @@ fn extract_playlist_id(input: &str) -> Option<String> {
         })
 }
 
+fn build_playlist_media(playlist: &dz::Playlist) -> db::Media {
+    let playlist_uuid = common::stable_media_uuid(
+        &db::MediaKind::Playlist,
+        &playlist
+            .id
+            .to_string(),
+    );
+    let relations: Vec<(db::MediaRelation, db::Media)> = playlist
+        .tracks
+        .data
+        .iter()
+        .enumerate()
+        .map(|(i, track)| {
+            let track_media = playlist_track_to_media(track);
+            let relation = db::MediaRelation {
+                relation_id: Uuid::new_v5(
+                    &playlist_uuid,
+                    track_media
+                        .id
+                        .as_bytes(),
+                ),
+                left_media_id: playlist_uuid,
+                right_media_id: track_media.id,
+                weight: Some(i as i64),
+                role: Some(db::RelationRole::Playlist),
+                ..Default::default()
+            };
+            (relation, track_media)
+        })
+        .collect();
+    let mut media = db::Media {
+        id: playlist_uuid,
+        title: if playlist
+            .title
+            .is_empty()
+        {
+            format!("Deezer playlist {}", playlist.id)
+        } else {
+            playlist
+                .title
+                .clone()
+        },
+        kind: db::MediaKind::Playlist,
+        collection_media_kind: Some(db::CollectionMediaKind::Music),
+        description: playlist
+            .description
+            .clone(),
+        external_ids: db::ExternalIds {
+            deezer_playlist: Some(playlist.id as i64),
+            ..Default::default()
+        },
+        relations: Some(relations),
+        refreshed_at: Some(chrono::Utc::now().naive_utc()),
+        ..Default::default()
+    };
+    if let Some(url) = playlist
+        .picture_xl
+        .clone()
+    {
+        media.set_image(db::ImageKind::Primary, url);
+    }
+    media
+}
+
+fn playlist_track_to_media(track: &dz::PlaylistTrack) -> db::Media {
+    let released_at = track
+        .album
+        .release_date
+        .as_deref()
+        .and_then(parse_release_date);
+    let mut media = db::Media {
+        id: common::stable_media_uuid(
+            &db::MediaKind::Track,
+            &track
+                .id
+                .to_string(),
+        ),
+        title: track
+            .title
+            .clone(),
+        kind: db::MediaKind::Track,
+        runtime: Some(track.duration as i64),
+        released_at,
+        description: Some(format!(
+            "by {}",
+            track
+                .artist
+                .name
+        )),
+        external_ids: db::ExternalIds {
+            deezer_track: Some(track.id as i64),
+            deezer_album: Some(
+                track
+                    .album
+                    .id as i64,
+            ),
+            deezer_artist: Some(
+                track
+                    .artist
+                    .id as i64,
+            ),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    if let Some(url) = track
+        .album
+        .cover_xl
+        .clone()
+    {
+        media.set_image(db::ImageKind::Primary, url);
+    }
+    media
+}
+
 fn track_to_result(t: dz::SearchTrack) -> db::Media {
     let album_id = common::stable_media_uuid(
         &db::MediaKind::Album,
@@ -1321,4 +1409,160 @@ fn album_to_result(a: dz::SearchAlbum) -> db::Media {
         album.set_image(db::ImageKind::Primary, url);
     }
     album
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_playlist() -> dz::Playlist {
+        dz::Playlist {
+            id: 123456,
+            title: "Summer Mix".into(),
+            picture_xl: Some("https://e.deezer.com/cover.jpg".into()),
+            description: Some("Best of summer".into()),
+            tracks: dz::DeezerList {
+                data: vec![
+                    dz::PlaylistTrack {
+                        id: 10,
+                        title: "Track A".into(),
+                        duration: 200,
+                        artist: dz::ArtistRef {
+                            id: 1,
+                            name: "Artist X".into(),
+                        },
+                        album: dz::PlaylistTrackAlbum {
+                            id: 100,
+                            cover_xl: Some("https://e.deezer.com/a.jpg".into()),
+                            release_date: Some("2021-05-01".into()),
+                        },
+                    },
+                    dz::PlaylistTrack {
+                        id: 20,
+                        title: "Track B".into(),
+                        duration: 250,
+                        artist: dz::ArtistRef {
+                            id: 2,
+                            name: "Artist Y".into(),
+                        },
+                        album: dz::PlaylistTrackAlbum::default(),
+                    },
+                ],
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn build_playlist_media_yields_playlist_with_ordered_track_relations() {
+        let playlist = sample_playlist();
+        let media = build_playlist_media(&playlist);
+
+        assert_eq!(media.kind, db::MediaKind::Playlist);
+        assert_eq!(media.title, "Summer Mix");
+        assert_eq!(
+            media.collection_media_kind,
+            Some(db::CollectionMediaKind::Music)
+        );
+        assert_eq!(
+            media
+                .external_ids
+                .deezer_playlist,
+            Some(123456)
+        );
+        assert_eq!(
+            media.get_image(db::ImageKind::Primary),
+            Some("https://e.deezer.com/cover.jpg")
+        );
+
+        let relations = media
+            .relations
+            .as_ref()
+            .expect("playlist carries its tracks as relations");
+        assert_eq!(relations.len(), 2);
+
+        // Ordered playlist memberships linking each track back to the playlist.
+        for (rel, _) in relations {
+            assert_eq!(rel.left_media_id, media.id);
+            assert_eq!(rel.role, Some(db::RelationRole::Playlist));
+        }
+        assert_eq!(
+            relations[0]
+                .0
+                .weight,
+            Some(0)
+        );
+        assert_eq!(
+            relations[1]
+                .0
+                .weight,
+            Some(1)
+        );
+        assert_eq!(
+            relations[0]
+                .0
+                .right_media_id,
+            relations[0]
+                .1
+                .id
+        );
+        assert_eq!(
+            relations[1]
+                .0
+                .right_media_id,
+            relations[1]
+                .1
+                .id
+        );
+
+        // Tracks are stable-keyed by their Deezer track id and keep album refs.
+        assert_eq!(
+            relations[0]
+                .1
+                .kind,
+            db::MediaKind::Track
+        );
+        assert_eq!(
+            relations[0]
+                .1
+                .external_ids
+                .deezer_track,
+            Some(10)
+        );
+        assert_eq!(
+            relations[0]
+                .1
+                .external_ids
+                .deezer_album,
+            Some(100)
+        );
+        assert_eq!(
+            relations[1]
+                .1
+                .external_ids
+                .deezer_track,
+            Some(20)
+        );
+    }
+
+    #[test]
+    fn build_playlist_media_falls_back_to_id_when_title_missing() {
+        let mut playlist = sample_playlist();
+        playlist.title = String::new();
+        let media = build_playlist_media(&playlist);
+        assert_eq!(media.title, "Deezer playlist 123456");
+    }
+
+    #[test]
+    fn extract_playlist_id_accepts_bare_and_url_forms() {
+        assert_eq!(extract_playlist_id("12345"), Some("12345".to_string()));
+        assert_eq!(
+            extract_playlist_id("https://www.deezer.com/playlist/12345"),
+            Some("12345".to_string())
+        );
+        assert_eq!(extract_playlist_id("  98765  "), Some("98765".to_string()));
+        assert_eq!(extract_playlist_id("not-a-playlist"), None);
+        assert_eq!(extract_playlist_id(""), None);
+    }
 }

--- a/crates/remux-server/src/addons/deezer.rs
+++ b/crates/remux-server/src/addons/deezer.rs
@@ -958,22 +958,7 @@ impl DeezerAddon {
     // --- Catalog (playlist) ---
 
     async fn fetch_playlist(&self, playlist_id: &str) -> Result<dz::Playlist> {
-        match self
-            .client
-            .execute(
-                dz::PlaylistEndpoint {
-                    id: playlist_id.to_string(),
-                }
-                .with_cache(PLAYLIST_CACHE_TTL),
-            )
-            .await
-        {
-            Ok(dz::DeezerResult::Ok(p)) => Ok(p),
-            Ok(dz::DeezerResult::Err { error }) => {
-                Err(anyhow!("Deezer playlist error: {}", error))
-            }
-            Err(e) => Err(anyhow!("Deezer playlist {} HTTP error: {}", playlist_id, e)),
-        }
+        fetch_deezer_playlist(&self.client, playlist_id).await
     }
 }
 
@@ -1002,21 +987,15 @@ impl CatalogAddon for DeezerAddon {
         .map(|id| {
             let client = client.clone();
             async move {
-                let name = match client
-                    .execute(
-                        dz::PlaylistEndpoint { id: id.clone() }
-                            .with_cache(PLAYLIST_CACHE_TTL),
-                    )
-                    .await
-                {
-                    Ok(dz::DeezerResult::Ok(p))
+                let name = match fetch_deezer_playlist(&client, &id).await {
+                    Ok(p)
                         if !p
                             .title
                             .is_empty() =>
                     {
                         p.title
                     }
-                    _ => format!("Deezer playlist {id}"),
+                    _ => default_playlist_name(&id),
                 };
                 CatalogInfo {
                     media_kind: Some(db::MediaKind::Playlist),
@@ -1162,6 +1141,31 @@ impl SearchAddon for DeezerAddon {
 // Free helpers
 // ---------------------------------------------------------------------------
 
+async fn fetch_deezer_playlist(
+    client: &sdks::RestClient<sdks::NoAuth>,
+    playlist_id: &str,
+) -> Result<dz::Playlist> {
+    match client
+        .execute(
+            dz::PlaylistEndpoint {
+                id: playlist_id.to_string(),
+            }
+            .with_cache(PLAYLIST_CACHE_TTL),
+        )
+        .await
+    {
+        Ok(dz::DeezerResult::Ok(p)) => Ok(p),
+        Ok(dz::DeezerResult::Err { error }) => {
+            Err(anyhow!("Deezer playlist error: {}", error))
+        }
+        Err(e) => Err(anyhow!("Deezer playlist {} HTTP error: {}", playlist_id, e)),
+    }
+}
+
+fn default_playlist_name(id: &str) -> String {
+    format!("Deezer playlist {id}")
+}
+
 fn extract_playlist_id(input: &str) -> Option<String> {
     let trimmed = input.trim();
     if trimmed.is_empty() {
@@ -1224,7 +1228,11 @@ fn build_playlist_media(playlist: &dz::Playlist) -> db::Media {
             .title
             .is_empty()
         {
-            format!("Deezer playlist {}", playlist.id)
+            default_playlist_name(
+                &playlist
+                    .id
+                    .to_string(),
+            )
         } else {
             playlist
                 .title

--- a/crates/remux-server/src/db/media.rs
+++ b/crates/remux-server/src/db/media.rs
@@ -748,6 +748,7 @@ pub struct ExternalIds {
     pub deezer_artist: Option<i64>,
     pub deezer_album: Option<i64>,
     pub deezer_track: Option<i64>,
+    pub deezer_playlist: Option<i64>,
     pub youtube_id: Option<String>,
     pub iptv_source_id: Option<String>,
     pub iptv_group: Option<String>,
@@ -900,6 +901,7 @@ impl ExternalIds {
         merge_option(&mut self.deezer_artist, &source.deezer_artist, replace);
         merge_option(&mut self.deezer_album, &source.deezer_album, replace);
         merge_option(&mut self.deezer_track, &source.deezer_track, replace);
+        merge_option(&mut self.deezer_playlist, &source.deezer_playlist, replace);
         merge_option(&mut self.youtube_id, &source.youtube_id, replace);
         merge_option(&mut self.iptv_source_id, &source.iptv_source_id, replace);
         merge_option(&mut self.iptv_group, &source.iptv_group, replace);

--- a/crates/remux-server/src/tasks/catalog_import_shared.rs
+++ b/crates/remux-server/src/tasks/catalog_import_shared.rs
@@ -69,8 +69,24 @@ where
                     | db::MediaKind::TvChannel
                     | db::MediaKind::Album
                     | db::MediaKind::Track
+                    | db::MediaKind::Playlist
             )
         });
+
+        // A playlist carries its tracks in `relations`, which take(max) above
+        // can't reach — truncate to honor max_items.
+        for item in items.iter_mut() {
+            if item.kind == db::MediaKind::Playlist {
+                if let Some(rels) = item
+                    .relations
+                    .as_mut()
+                {
+                    if rels.len() > max {
+                        rels.truncate(max);
+                    }
+                }
+            }
+        }
 
         // Partition: only new items need meta-batch processing.
         let existing_ids: HashSet<Uuid> = if items.is_empty() {
@@ -133,6 +149,26 @@ where
         if !existing_tv_channels.is_empty() {
             if let Err(e) = db::Media::upsert(&ctx.db, &existing_tv_channels).await {
                 warn!(catalog = media_id, error = %e, "failed to refresh existing tv channels");
+            }
+        }
+
+        // Rebuild existing playlist track memberships each refresh.
+        let existing_playlists: Vec<db::Media> = existing_items
+            .iter()
+            .filter(|m| m.kind == db::MediaKind::Playlist)
+            .cloned()
+            .collect();
+        if !existing_playlists.is_empty() {
+            if let Err(e) = ctx
+                .addons
+                .process_meta_batch(existing_playlists, ctx, false)
+                .await
+            {
+                warn!(
+                    catalog = media_id,
+                    error = %e,
+                    "failed to refresh existing playlists"
+                );
             }
         }
 
@@ -324,6 +360,66 @@ pub async fn remove_stale_catalog_memberships(
         .await
         {
             warn!(collection = %collection_id, error = %e, "failed to remove stale catalog membership");
+        }
+    }
+}
+
+/// Delete `Playlist` media whose addon catalog left `valid_collection_ids`.
+/// Run BEFORE `remove_stale_catalog_memberships` — it needs the catalog
+/// membership row to locate the orphans.
+pub async fn prune_orphaned_playlists(
+    db: &sqlx::SqlitePool,
+    valid_collection_ids: &HashSet<Uuid>,
+    domain_collection_ids: &HashSet<Uuid>,
+) {
+    let stale: Vec<Uuid> = domain_collection_ids
+        .iter()
+        .filter(|id| !valid_collection_ids.contains(*id))
+        .copied()
+        .collect();
+    if stale.is_empty() {
+        return;
+    }
+
+    const STALE_CHUNK: usize = 500;
+    let mut orphan_ids: Vec<Uuid> = Vec::new();
+    for chunk in stale.chunks(STALE_CHUNK) {
+        let mut qb = sqlx::QueryBuilder::new(
+            "SELECT DISTINCT m.id FROM media m \
+             JOIN media_relations r ON r.right_media_id = m.id \
+             WHERE r.role = 'catalog' AND m.kind = 'playlist' AND r.left_media_id IN (",
+        );
+        let mut sep = qb.separated(", ");
+        for id in chunk {
+            sep.push_bind(id);
+        }
+        qb.push(")");
+        match qb
+            .build_query_scalar::<Uuid>()
+            .fetch_all(db)
+            .await
+        {
+            Ok(v) => orphan_ids.extend(v),
+            Err(e) => {
+                warn!(error = %e, "failed to find orphaned playlists for cleanup");
+                return;
+            }
+        }
+    }
+    if orphan_ids.is_empty() {
+        return;
+    }
+
+    info!(count = orphan_ids.len(), "pruning orphaned addon playlists");
+    for id in &orphan_ids {
+        // Track memberships hang off `left_media_id` (no FK), so drop them
+        // explicitly; the catalog membership (left = collection_id) is cleared
+        // by remove_stale_catalog_memberships below.
+        if let Err(e) = db::MediaRelation::delete_by_left_id(db, id).await {
+            warn!(playlist = %id, error = %e, "failed to delete playlist relations");
+        }
+        if let Err(e) = db::Media::delete(db, id).await {
+            warn!(playlist = %id, error = %e, "failed to delete playlist media");
         }
     }
 }

--- a/crates/remux-server/src/tasks/refresh_library.rs
+++ b/crates/remux-server/src/tasks/refresh_library.rs
@@ -6,7 +6,10 @@ use uuid::Uuid;
 
 use super::{
     ProgressReporter, Task, TaskService,
-    catalog_import_shared::{import_catalog_items, remove_stale_catalog_memberships},
+    catalog_import_shared::{
+        import_catalog_items, prune_orphaned_playlists,
+        remove_stale_catalog_memberships,
+    },
 };
 use crate::{AppContext, db};
 
@@ -54,6 +57,7 @@ impl Task for RefreshLibraryTask {
             db::MediaKind::Artist,
             db::MediaKind::Album,
             db::MediaKind::Track,
+            db::MediaKind::Playlist,
         ];
         let addons = ctx
             .addons
@@ -148,6 +152,13 @@ impl Task for RefreshLibraryTask {
             }
         }
 
+        // Must run before remove_stale_catalog_memberships below.
+        prune_orphaned_playlists(
+            &ctx.db,
+            &valid_collection_ids,
+            &domain_collection_ids,
+        )
+        .await;
         remove_stale_catalog_memberships(
             &ctx.db,
             &valid_collection_ids,


### PR DESCRIPTION
Deezer playlists now show up as real Jellyfin playlists (under /Playlists) with their title, cover, and tracks — instead of a flat list of loose tracks.

- the catalog now yields one Playlist item; its tracks are linked as playlist members
- respects `max_items`, and removes the playlist when its addon catalog is disabled

Tested manually: add a playlist ID → appears in Playlists; `max_items` caps the track count; disabling the catalog removes it.

Drafted with AI, reviewed and tested by me.