### PR TITLE
fix: import local TV when source advertises an Episode catalog

### DIFF
--- a/crates/remux-server/src/addons/mod.rs
+++ b/crates/remux-server/src/addons/mod.rs
@@ -1220,7 +1220,7 @@ impl AddonService {
                     .filter(|c| {
                         c.media_kind
                             .as_ref()
-                            .is_some_and(|mk| kinds.contains(mk))
+                            .is_some_and(|mk| kind_in_type_list(mk, kinds))
                     })
                     .collect(),
                 Err(e) => {

--- a/crates/remux-server/src/addons/opendal.rs
+++ b/crates/remux-server/src/addons/opendal.rs
@@ -2350,6 +2350,44 @@ mod tests {
         );
     }
 
+    // A local "episode" source is a Series library, so catalogs_for_kinds must
+    // admit its catalog when Series is requested (as RefreshLibraryTask does), but
+    // not for an unrelated kind.
+    #[tokio::test]
+    async fn episode_catalog_admitted_when_series_requested() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_, guard) = new_test_server()
+            .await
+            .unwrap();
+        let ctx = &guard.0;
+
+        let (_, db_addon) = make_local_addon(ctx, dir.path(), "episode").await;
+        ctx.addons
+            .reload(&ctx.db, &ctx.config)
+            .await
+            .unwrap();
+
+        for (requested, should_admit) in
+            [(db::MediaKind::Series, true), (db::MediaKind::Movie, false)]
+        {
+            let admitted = ctx
+                .addons
+                .catalogs_for_kinds(ctx, &[requested.clone()])
+                .await
+                .into_iter()
+                .find(|(rt, _)| {
+                    rt.row
+                        .id
+                        == db_addon.id
+                })
+                .is_some_and(|(_, cats)| !cats.is_empty());
+            assert_eq!(
+                admitted, should_admit,
+                "episode catalog admission for {requested:?} should be {should_admit}"
+            );
+        }
+    }
+
     // ---------------------------------------------------------------------------
     // Files inside special-feature subdirs (trailers/, extras/, etc.) must be
     // skipped — they are not episodes or movies.


### PR DESCRIPTION
local addon with a content type of  "TV Episodes" scans cleanly (`scan complete … upserted=N`, no errors) and `opendal_files` fills with correct `imdb_id`, `season`, and `episode` rows. 
but the series library stays `0-0 of 0`, `media` table gets no `series`/`season`/`episode` rows. 

the movies `opendal-local` addon works fine.

this is because `catalogs_for_kinds` pre-filters addons with `supports_type`, but the per-catalog post-filter used a raw `kinds.contains()`. A local `"episode"` source advertises a `MediaKind::Episode` catalog, so it was dropped when `RefreshLibraryTask` requested `LIBRARY_KINDS` (Movie, Series, ...), silently skipping the entire local TV library. 

fixed by using `kind_in_type_list` in the post-filter so it matches the pre-filter. 

tested with my media library and local tv shows now show up and are playable.

I used Claude to debug this and find a fix. It wrote the code and tests since I'm not proficient in Rust but I reviewed the logic and it seems sound and cleaned it up to try to match your coding style.