### PR TITLE
fix: recompute Season/Episode stable UUID after meta enrichment

### DIFF
--- a/crates/remux-server/src/addons/mod.rs
+++ b/crates/remux-server/src/addons/mod.rs
@@ -1416,22 +1416,22 @@ impl AddonService {
             }
         }
 
-        // Recompute stable UUID for Movie/Series once the canonical external ID
+        // Recompute stable UUID for Movie/Series/Season/Episode once the canonical external ID
         // (IMDB or custom stremio) is resolved by meta enrichment. Catalog stubs
         // arrive with a TMDB-keyed UUID; validate() expects the canonical one.
-        if matches!(media.kind, db::MediaKind::Movie | db::MediaKind::Series) {
-            let raw = db::MediaIdRaw {
-                kind: media
-                    .kind
-                    .clone(),
-                external_ids: media
-                    .external_ids
-                    .clone(),
-                season: None,
-                episode: None,
-            };
-            if let Some(canonical) = raw.canonical() {
-                media.id = crate::common::stable_media_uuid(&media.kind, &canonical);
+        if matches!(
+            media.kind,
+            db::MediaKind::Movie
+                | db::MediaKind::Series
+                | db::MediaKind::Season
+                | db::MediaKind::Episode
+        ) {
+            let raw = media.media_id_raw();
+            if raw
+                .canonical()
+                .is_some()
+            {
+                media.id = uuid::Uuid::from(&raw);
             }
         }
 

--- a/crates/remux-server/src/db/media.rs
+++ b/crates/remux-server/src/db/media.rs
@@ -5742,6 +5742,83 @@ mod tests {
     use crate::db::MediaIdRaw;
 
     #[test]
+    fn stale_episode_id_recomputes_to_canonical_and_validates() {
+        let series_imdb = NonEmptyString::try_new("tt1844624".to_string()).unwrap();
+        let mut ep = Media {
+            kind: MediaKind::Episode,
+            title: "S0E1 - Behind the Fright".to_string(),
+            idx: Some(1),
+            parent_idx: Some(0),
+            external_ids: ExternalIds {
+                series_imdb: Some(series_imdb.clone()),
+                ..Default::default()
+            },
+            id: crate::common::stable_media_uuid(&MediaKind::Episode, "tt1844624:1:1"),
+            ..Default::default()
+        };
+
+        assert!(
+            ep.validate()
+                .is_err()
+        );
+
+        let raw = ep.media_id_raw();
+        assert!(
+            raw.canonical()
+                .is_some()
+        );
+        ep.id = Uuid::from(&raw);
+
+        assert_eq!(
+            ep.id,
+            crate::common::stable_media_uuid(&MediaKind::Episode, "tt1844624:0:1")
+        );
+        assert!(
+            ep.validate()
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn stale_season_id_recomputes_to_canonical_and_validates() {
+        let series_imdb = NonEmptyString::try_new("tt1844624".to_string()).unwrap();
+        let mut season = Media {
+            kind: MediaKind::Season,
+            title: "Specials".to_string(),
+            idx: Some(0),
+            external_ids: ExternalIds {
+                series_imdb: Some(series_imdb.clone()),
+                ..Default::default()
+            },
+            id: crate::common::stable_media_uuid(&MediaKind::Season, "tt1844624:1"),
+            ..Default::default()
+        };
+
+        assert!(
+            season
+                .validate()
+                .is_err()
+        );
+
+        let raw = season.media_id_raw();
+        assert!(
+            raw.canonical()
+                .is_some()
+        );
+        season.id = Uuid::from(&raw);
+
+        assert_eq!(
+            season.id,
+            crate::common::stable_media_uuid(&MediaKind::Season, "tt1844624:0")
+        );
+        assert!(
+            season
+                .validate()
+                .is_ok()
+        );
+    }
+
+    #[test]
     fn from_path_tmdb_in_directory() {
         let ids = ExternalIds::from_path(
             "Movies/The Matrix (1999) [tmdbid-603]/The Matrix.mkv",


### PR DESCRIPTION
**Issue**
-  `skipping media item with invalid UUID ... UUID mismatch` errors logged after library refresh 
- seasons/episodes mentioned in the errors never land in the DB, whole seasons of specials vanish.
- skipped item's `id` encodes a season one higher than the stored `parent_idx` (same IMDB anchor, episode number unchanged)

**Cause**
- `AddonRuntime::refresh_meta` re-derives the canonical UUID for `Movie`/`Series` only, not for `Season`/`Episode`.
- The recompute block's comment says: "Catalog stubs arrive with a TMDB-keyed UUID; validate() expects the canonical one", it just was never extended to seasons/episodes.

**Fix**
- `addons/mod.rs`: extend the UUID recompute to `Movie | Series | Season | Episode`, deriving the key via `media.media_id_raw()`, guarded on `canonical().is_some()`.
- `db/media.rs`: regression tests for episode and series ids


> I used Claude to debug and fix this then manually reviewed it and wrote the PR description myself