### PR TITLE
Feat: Server uptime and restart in dashboard

### DIFF
--- a/crates/remux-dashboard/src/components/server_info.rs
+++ b/crates/remux-dashboard/src/components/server_info.rs
@@ -3,7 +3,49 @@ use crate::{
     state::AppState,
 };
 use dioxus::prelude::*;
-use remux_sdks::remux::{GetItemCounts, ItemCounts, PublicSystemInfo};
+use remux_sdks::remux::{GetItemCounts, ItemCounts, PublicSystemInfo, RestartServer};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Parse an RFC 3339 timestamp (the format chrono::to_rfc3339() produces)
+/// into seconds since the Unix epoch.
+fn parse_rfc3339(s: &str) -> Option<u64> {
+    // Format: YYYY-MM-DDTHH:MM:SS[.fraction][Z|+HH:MM|-HH:MM]
+    if s.len() < 19 || s.as_bytes()[10] != b'T' {
+        return None;
+    }
+    let year: i64 = s[0..4].parse().ok()?;
+    let month: u32 = s[5..7].parse().ok()?;
+    let day: u32 = s[8..10].parse().ok()?;
+    let hour: u32 = s[11..13].parse().ok()?;
+    let min: u32 = s[14..16].parse().ok()?;
+    let sec: u32 = s[17..19].parse().ok()?;
+
+    // Convert to Unix timestamp using the Gregorian calendar algorithm.
+    let (y, m) = if month <= 2 {
+        (year - 1, month as i64 + 12)
+    } else {
+        (year, month as i64)
+    };
+    // Days since 1970-01-01
+    let days = y * 365 + y / 4 - y / 100 + y / 400 + (153 * m + 3) / 5 + day as i64 - 719469;
+    Some((days * 86400 + hour as i64 * 3600 + min as i64 * 60 + sec as i64) as u64)
+}
+
+fn format_uptime(started_at: &str) -> String {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let started = parse_rfc3339(started_at).unwrap_or(0);
+    if started == 0 || started > now {
+        return "N/A".to_string();
+    }
+    let diff_secs = now - started;
+    let days = diff_secs / 86400;
+    let hours = (diff_secs % 86400) / 3600;
+    let mins = (diff_secs % 3600) / 60;
+    format!("{days}d {hours}h {mins}m")
+}
 
 #[component]
 pub fn KvRow(label: &'static str, value: String) -> Element {
@@ -20,9 +62,12 @@ pub fn ServerInfoCard(app_state: AppState) -> Element {
     let mut server_info: Signal<Option<PublicSystemInfo>> = use_signal(|| None);
     let mut loading = use_signal(|| true);
     let mut error = use_signal(|| Option::<String>::None);
+    let mut restarting = use_signal(|| false);
+    let app_state_for_effect = app_state.clone();
+    let app_state_for_restart = app_state.clone();
 
     use_effect(move || {
-        let client = app_state
+        let client = app_state_for_effect
             .client
             .clone();
         spawn(async move {
@@ -40,6 +85,23 @@ pub fn ServerInfoCard(app_state: AppState) -> Element {
         });
     });
 
+    let on_restart = move |_| {
+        let client = app_state_for_restart
+            .client
+            .clone();
+        restarting.set(true);
+        spawn(async move {
+            let _ = client
+                .execute(RestartServer)
+                .await;
+            // Give the server a moment to restart, then refresh the page
+            gloo_timers::future::sleep(std::time::Duration::from_secs(10)).await;
+            if let Some(window) = web_sys::window() {
+                window.location().reload().ok();
+            }
+        });
+    };
+
     rsx! {
         Card { title: "Server",
             if *loading.read() {
@@ -49,6 +111,28 @@ pub fn ServerInfoCard(app_state: AppState) -> Element {
             } else if let Some(info) = server_info.read().as_ref() {
                 KvRow { label: "Name", value: info.server_name.clone() }
                 KvRow { label: "Version", value: info.remux_version.clone() }
+                div { class: "kv-row",
+                    span { class: "kv-label", "Uptime" }
+                    span { class: "kv-value",
+                        {
+                            info.remux_started_at
+                                .as_deref()
+                                .map(format_uptime)
+                                .unwrap_or_else(|| "N/A".to_string())
+                        }
+                        button {
+                            class: "btn btn-ghost",
+                            style: "height:30px;font-size:.68rem;padding:0 10px;margin-left:0.5rem",
+                            disabled: *restarting.read(),
+                            onclick: on_restart,
+                            if *restarting.read() {
+                                "Restarting..."
+                            } else {
+                                "Restart"
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/crates/remux-sdks/src/remux/mod.rs
+++ b/crates/remux-sdks/src/remux/mod.rs
@@ -851,6 +851,7 @@ pub struct PublicSystemInfo {
     pub version: String,
     pub remux_version: String,
     pub operating_system: String,
+    pub remux_started_at: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -4073,6 +4074,21 @@ impl Endpoint for PublicSystemInfo {
 
     fn path(&self) -> String {
         "/system/info/public".into()
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct RestartServer;
+
+impl Endpoint for RestartServer {
+    type Output = serde_json::Value;
+
+    fn path(&self) -> String {
+        "/system/restart".into()
+    }
+
+    fn method(&self) -> Method {
+        Method::POST
     }
 }
 

--- a/crates/remux-server/src/api/system.rs
+++ b/crates/remux-server/src/api/system.rs
@@ -48,6 +48,7 @@ pub async fn system_info_public(
         version: "10.11.8".to_string(),
         remux_version: env!("CARGO_PKG_VERSION").to_string(),
         id: server_id(),
+        remux_started_at: Some(state.ctx.started_at.to_rfc3339()),
         ..Default::default()
     }))
 }

--- a/crates/remux-server/src/lib.rs
+++ b/crates/remux-server/src/lib.rs
@@ -261,6 +261,7 @@ pub async fn init_app(
         )),
         web_paths,
         addons,
+        started_at: Utc::now(),
     };
 
     // Sync intro items at startup (best-effort; errors are logged not fatal).
@@ -347,6 +348,8 @@ pub struct AppContext {
     /// Present in filesystem builds; `None` in desktop (assets are embedded).
     pub web_paths: Option<FilesystemPaths>,
     pub addons: addons::AddonService,
+    /// When this server process started.
+    pub started_at: chrono::DateTime<chrono::Utc>,
 }
 
 impl AppContext {


### PR DESCRIPTION
Adds a row with uptime + a button to restart server directly from dashboard.