### PR TITLE
fix(items): resolve parent_id aliases before child query

### DIFF
--- a/crates/remux-server/src/api/items.rs
+++ b/crates/remux-server/src/api/items.rs
@@ -3548,4 +3548,95 @@ mod tests {
             "empty smart collection must not appear in /UserViews; got: {names:?}"
         );
     }
+
+    // Regression: GET /Items?parentId=<alias-uuid> used db::Media::get_by_id for the parent
+    // lookup, which does a straight WHERE id = $1 and cannot follow alias mappings in the
+    // in-memory store. Stremio addons expose series under a virtual alias UUID; children are
+    // stored under the canonical UUID, so browsing returned empty. This test would have
+    // returned TotalRecordCount=0 before the fix.
+    #[tokio::test]
+    async fn parent_id_alias_resolves_children() {
+        let (server, guard, token) = authenticated_server().await;
+        let auth = auth_header_with_token(&token);
+        let db = &guard
+            .0
+            .db;
+        let user_id = get_user_id(&server, &auth).await;
+        let now = Utc::now().naive_utc();
+
+        let series = insert_media(db, "Alias Show", db::MediaKind::Series, "tt9000001").await;
+        let series_imdb = series
+            .external_ids
+            .imdb
+            .clone()
+            .unwrap();
+
+        let season_ext = ExternalIds {
+            series_imdb: Some(series_imdb),
+            ..Default::default()
+        };
+        let season_id = Uuid::from(&MediaIdRaw {
+            kind: db::MediaKind::Season,
+            external_ids: season_ext.clone(),
+            season: Some(1),
+            episode: None,
+        });
+        let mut season = db::Media {
+            id: season_id,
+            title: "Season 1".to_string(),
+            kind: db::MediaKind::Season,
+            parent_id: Some(series.id),
+            grandparent_id: Some(series.id),
+            idx: Some(1),
+            external_ids: season_ext,
+            created_at: now,
+            updated_at: now,
+            ..Default::default()
+        };
+        season
+            .save(db)
+            .await
+            .unwrap();
+
+        // Mimic a Stremio addon virtual alias: store alias_uuid -> canonical series.id.
+        let alias_uuid = Uuid::new_v4();
+        guard
+            .0
+            .store
+            .save(
+                alias_uuid.to_string(),
+                series.id,
+                std::time::Duration::from_secs(3600),
+            );
+
+        let resp = server
+            .get(&format!("/users/{}/items", user_id))
+            .add_header(
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth).unwrap(),
+            )
+            .add_query_params(&[("parentId", alias_uuid.to_string().as_str())])
+            .await;
+
+        resp.assert_status_ok();
+        let body: serde_json::Value = resp.json();
+        assert!(
+            body["TotalRecordCount"]
+                .as_i64()
+                .unwrap_or(0)
+                > 0,
+            "browsing a series via its alias UUID must return children; got TotalRecordCount={}",
+            body["TotalRecordCount"]
+        );
+        assert!(
+            body["Items"]
+                .as_array()
+                .map(|a| {
+                    a.iter()
+                        .any(|i| i["Name"] == "Season 1")
+                })
+                .unwrap_or(false),
+            "Season 1 must appear when browsing the series via its alias UUID"
+        );
+    }
 }

--- a/crates/remux-server/src/api/items.rs
+++ b/crates/remux-server/src/api/items.rs
@@ -188,13 +188,13 @@ pub async fn get_items(
         .parent_id
         .clone()
     {
-        db::Media::get_by_id(
-            &state
-                .ctx
-                .db,
-            &parent_id,
-        )
-        .await?
+        let resolved = MediaResolveService::resolve_item(parent_id, &state.ctx).await?;
+        if let Some(ref m) = resolved {
+            if m.id != parent_id {
+                q.parent_id = Some(m.id);
+            }
+        }
+        resolved
     } else {
         None
     };


### PR DESCRIPTION
Fixes empty episode listings when browsing a series that comes from a Stremio addon.

## What was wrong

`GET /Items?parentId=<uuid>` used `db::Media::get_by_id` for the parent lookup — a straight `WHERE id = $1`. That can't follow alias mappings from the in-memory store.

When AIOStreams (or any Stremio addon) returns a series using only a TMDB ID, remux puts it in the store under a UUID derived from that TMDB ID (call it the _alias UUID_). When IMDB data is resolved later, the series is persisted to the DB under a _different_ canonical UUID derived from the IMDB ID, and an alias mapping is registered in the store. Clients that received the alias UUID earlier then browse episodes using that alias — but `db::Media::get_by_id` can't follow the alias, so the child query runs against the alias UUID and returns nothing.

## Fix

Swap `db::Media::get_by_id` for `MediaResolveService::resolve_item`, which checks the DB first, then the store alias map, and persists from the addon store if needed. If the resolved ID differs from what was passed in, `q.parent_id` is updated to the canonical value before the child query runs.

## Bug evidence

Reproduced on a live server using a real AIOStreams-sourced series ("The Animals of Farthing Wood", served as `tmdb:188` by AIOStreams).

Searching for the series returns it under the store alias UUID (TMDB-derived, before IMDB resolution):

```
GET /users/{userId}/items?searchTerm=Animals+Farthing+Wood
→ Id: 19d189d0-16cc-5973-903c-b1deb90933c6
  ProviderIds: { "Tmdb": "188" }   ← no IMDB yet; alias UUID
```

Browsing children using that alias UUID (as a Stremio client would):

```
GET /users/{userId}/items?parentId=19d189d0-16cc-5973-903c-b1deb90933c6
→ TotalRecordCount: 0   ← bug: no seasons returned
```

Control — same request but with the canonical DB UUID (IMDB-resolved):

```
GET /users/{userId}/items?parentId=95bdaf2c-8621-5de2-a4f5-f591e6ec5a25
→ TotalRecordCount: 4   ← 4 seasons present in DB
```

The children exist in the DB. They're just unreachable through the alias UUID on the unpatched server.

## Fix verification

Regression test added: `api::items::tests::parent_id_alias_resolves_children`

Seeds a series and season, stores the series under a virtual alias UUID in the in-memory store (mimicking a Stremio addon), then queries via that alias UUID and asserts `TotalRecordCount > 0`. This test would have returned `TotalRecordCount=0` before the fix.

```
test api::items::tests::parent_id_alias_resolves_children ... ok
```

## Test plan

- [x] Regression test passes (above)
- [x] Browse a series sourced from a Stremio addon; episodes should load
- [x] Browse a local series (no alias); should be unaffected

## AI disclosure

Initial implementation was drafted with Claude Code, then reviewed and tested by me.
