### PR TITLE
feat(engine): add configurable loudness normalization

### DIFF
--- a/crates/remux-dashboard/src/pages/settings.rs
+++ b/crates/remux-dashboard/src/pages/settings.rs
@@ -349,6 +349,7 @@ pub fn PlaybackSettingsCard(app_state: AppState) -> Element {
     let mut allow_av1_encoding = use_signal(|| false);
     let mut h264_crf = use_signal(|| 23_u32);
     let mut h265_crf = use_signal(|| 28_u32);
+    let mut normalize_audio_loudness = use_signal(|| true);
     let mut enable_video_transcoding = use_signal(|| true);
     let mut subtitle_mode = use_signal(|| "Burn".to_string());
     let mut loading = use_signal(|| true);
@@ -426,6 +427,10 @@ pub fn PlaybackSettingsCard(app_state: AppState) -> Element {
                         opts.h265_crf
                             .unwrap_or(28),
                     );
+                    normalize_audio_loudness.set(
+                        opts.normalize_audio_loudness
+                            .unwrap_or(true),
+                    );
                     enable_video_transcoding.set(
                         opts.enable_video_transcoding
                             .unwrap_or(true),
@@ -483,7 +488,7 @@ pub fn PlaybackSettingsCard(app_state: AppState) -> Element {
             h264_crf: Some(*h264_crf.peek()),
             h265_crf: Some(*h265_crf.peek()),
             enable_video_transcoding: Some(*enable_video_transcoding.peek()),
-            normalize_audio_loudness: None,
+            normalize_audio_loudness: Some(*normalize_audio_loudness.peek()),
             subtitle_mode: subtitle_mode
                 .peek()
                 .parse::<EmbeddedSubtitleHandling>()
@@ -654,6 +659,19 @@ pub fn PlaybackSettingsCard(app_state: AppState) -> Element {
                                         },
                                     }
                                 }
+                            }
+                        }
+
+                        div { class: "field",
+                            label { class: "field-label", "Audio Loudness Normalisation" }
+                            div { class: "field-hint", "Apply EBU R128 loudness normalisation (loudnorm=I=-14:TP=-1:LRA=11) when transcoding audio. Has no effect when audio is stream-copied." }
+                            label { style: "display:flex;align-items:center;gap:8px",
+                                input {
+                                    r#type: "checkbox",
+                                    checked: *normalize_audio_loudness.read(),
+                                    onchange: move |e| normalize_audio_loudness.set(e.checked()),
+                                }
+                                "Normalise audio loudness to -14 LUFS"
                             }
                         }
 

--- a/crates/remux-dashboard/src/pages/settings.rs
+++ b/crates/remux-dashboard/src/pages/settings.rs
@@ -663,15 +663,15 @@ pub fn PlaybackSettingsCard(app_state: AppState) -> Element {
                         }
 
                         div { class: "field",
-                            label { class: "field-label", "Audio Loudness Normalisation" }
-                            div { class: "field-hint", "Apply EBU R128 loudness normalisation (loudnorm=I=-14:TP=-1:LRA=11) when transcoding audio. Has no effect when audio is stream-copied." }
+                            label { class: "field-label", "Audio Loudness Normalization" }
+                            div { class: "field-hint", "Apply EBU R128 loudness normalization (loudnorm=I=-14:TP=-1:LRA=11) when transcoding audio. Has no effect when audio is stream-copied." }
                             label { style: "display:flex;align-items:center;gap:8px",
                                 input {
                                     r#type: "checkbox",
                                     checked: *normalize_audio_loudness.read(),
                                     onchange: move |e| normalize_audio_loudness.set(e.checked()),
                                 }
-                                "Normalise audio loudness to -14 LUFS"
+                                "Normalize audio loudness to -14 LUFS"
                             }
                         }
 

--- a/crates/remux-dashboard/src/pages/settings.rs
+++ b/crates/remux-dashboard/src/pages/settings.rs
@@ -483,6 +483,7 @@ pub fn PlaybackSettingsCard(app_state: AppState) -> Element {
             h264_crf: Some(*h264_crf.peek()),
             h265_crf: Some(*h265_crf.peek()),
             enable_video_transcoding: Some(*enable_video_transcoding.peek()),
+            normalize_audio_loudness: None,
             subtitle_mode: subtitle_mode
                 .peek()
                 .parse::<EmbeddedSubtitleHandling>()

--- a/crates/remux-sdks/src/remux/mod.rs
+++ b/crates/remux-sdks/src/remux/mod.rs
@@ -588,6 +588,11 @@ pub struct EncodingOptions {
     /// unaffected by this setting.
     #[default(Some(true))]
     pub enable_video_transcoding: Option<bool>,
+    /// Apply loudness normalization (`loudnorm=I=-14:TP=-1:LRA=11`) to the
+    /// audio stream when transcoding. Has no effect when audio_codec is "copy".
+    /// Defaults to true.
+    #[default(Some(true))]
+    pub normalize_audio_loudness: Option<bool>,
     /// Controls how embedded subtitle streams unsupported by the client are handled.
     /// Burn: encode into video (default). Extract: serve via Stream.js/VTT endpoint.
     /// Strip: remove from media source so the client never sees them.

--- a/crates/remux-server/src/api/hls.rs
+++ b/crates/remux-server/src/api/hls.rs
@@ -480,6 +480,9 @@ async fn create_hls_session(
                 .h265_crf
                 .unwrap_or(28),
             is_live,
+            normalize_audio_loudness: encoding_opts
+                .normalize_audio_loudness
+                .unwrap_or(true),
         };
 
         // Spawn the transcode task with proper error handling
@@ -1116,6 +1119,9 @@ async fn hls_segment_inner(
                             .h265_crf
                             .unwrap_or(28),
                         is_live: false,
+                        normalize_audio_loudness: encoding_opts
+                            .normalize_audio_loudness
+                            .unwrap_or(true),
                     };
 
                     // Reinitialise the session's state for the new transcode run.

--- a/crates/remux-server/src/api/playback.rs
+++ b/crates/remux-server/src/api/playback.rs
@@ -835,6 +835,9 @@ async fn videos_stream_inner(
         h265_crf: encoding_opts
             .h265_crf
             .unwrap_or(28),
+        normalize_audio_loudness: encoding_opts
+            .normalize_audio_loudness
+            .unwrap_or(true),
     };
 
     let stream = crate::playback::engine::start_progressive_transcode(params)?;

--- a/crates/remux-server/src/playback/engine.rs
+++ b/crates/remux-server/src/playback/engine.rs
@@ -308,6 +308,9 @@ pub struct TranscodeParams {
     pub h265_crf: u32,
     /// True for live TV / RTSP streams — disables seeking and enables auto-restart on exit.
     pub is_live: bool,
+    /// Apply `loudnorm=I=-14:TP=-1:LRA=11` when transcoding audio. Has no effect
+    /// when audio_codec is "copy". See EncodingOptions::normalize_audio_loudness.
+    pub normalize_audio_loudness: bool,
 }
 
 impl Default for TranscodeParams {
@@ -346,6 +349,7 @@ impl Default for TranscodeParams {
             h264_crf: 23,
             h265_crf: 28,
             is_live: false,
+            normalize_audio_loudness: true,
         }
     }
 }
@@ -917,6 +921,9 @@ pub(crate) fn build_hls_args(params: &TranscodeParams) -> Vec<String> {
         if let Some(ch) = params.audio_channels {
             args.extend(["-ac".into(), ch.to_string()]);
         }
+        if params.normalize_audio_loudness {
+            args.extend(["-af".into(), "loudnorm=I=-14:TP=-1:LRA=11".into()]);
+        }
     }
 
     // HLS output
@@ -1309,6 +1316,9 @@ pub struct ProgressiveTranscodeParams {
     pub allow_av1_encoding: bool,
     pub h264_crf: u32,
     pub h265_crf: u32,
+    /// Apply `loudnorm=I=-14:TP=-1:LRA=11` when transcoding audio. Has no effect
+    /// when audio_codec is "copy". See EncodingOptions::normalize_audio_loudness.
+    pub normalize_audio_loudness: bool,
 }
 
 /// Build the ffmpeg CLI args for a progressive transcode piped to stdout.
@@ -1664,6 +1674,9 @@ pub(crate) fn build_progressive_args(
         }
         if let Some(ch) = params.audio_channels {
             args.extend(["-ac".into(), ch.to_string()]);
+        }
+        if params.normalize_audio_loudness {
+            args.extend(["-af".into(), "loudnorm=I=-14:TP=-1:LRA=11".into()]);
         }
     }
 

--- a/crates/remux-server/src/playback/engine.rs
+++ b/crates/remux-server/src/playback/engine.rs
@@ -2210,6 +2210,7 @@ mod tests {
             allow_av1_encoding: false,
             h264_crf: 23,
             h265_crf: 28,
+            normalize_audio_loudness: false,
         }
     }
 
@@ -2815,5 +2816,70 @@ mod tests {
         assert!(args_contains(&args, "-reconnect"));
         assert!(args_contains(&args, "-reconnect_at_eof"));
         assert!(args_contains(&args, "-reconnect_streamed"));
+    }
+
+    // ── Loudness normalisation tests ─────────────────────────────────────────
+
+    #[test]
+    fn hls_loudnorm_added_when_transcoding_audio() {
+        let dir = PathBuf::from("/tmp/test_session");
+        let args = build_hls_args(&TranscodeParams {
+            audio_codec: "aac".into(),
+            normalize_audio_loudness: true,
+            ..default_hls(dir)
+        });
+        assert!(args_contains(&args, "loudnorm=I=-14:TP=-1:LRA=11"));
+    }
+
+    #[test]
+    fn hls_loudnorm_absent_when_disabled() {
+        let dir = PathBuf::from("/tmp/test_session");
+        let args = build_hls_args(&TranscodeParams {
+            audio_codec: "aac".into(),
+            normalize_audio_loudness: false,
+            ..default_hls(dir)
+        });
+        assert!(!args_contains(&args, "loudnorm=I=-14:TP=-1:LRA=11"));
+    }
+
+    #[test]
+    fn hls_loudnorm_absent_when_audio_copy() {
+        let dir = PathBuf::from("/tmp/test_session");
+        let args = build_hls_args(&TranscodeParams {
+            audio_codec: "copy".into(),
+            normalize_audio_loudness: true,
+            ..default_hls(dir)
+        });
+        assert!(!args_contains(&args, "loudnorm=I=-14:TP=-1:LRA=11"));
+    }
+
+    #[test]
+    fn progressive_loudnorm_added_when_transcoding_audio() {
+        let args = build_progressive_args(&ProgressiveTranscodeParams {
+            audio_codec: "aac".into(),
+            normalize_audio_loudness: true,
+            ..default_progressive()
+        });
+        assert!(args_contains(&args, "loudnorm=I=-14:TP=-1:LRA=11"));
+    }
+
+    #[test]
+    fn progressive_loudnorm_absent_when_disabled() {
+        let args = build_progressive_args(&ProgressiveTranscodeParams {
+            audio_codec: "aac".into(),
+            normalize_audio_loudness: false,
+            ..default_progressive()
+        });
+        assert!(!args_contains(&args, "loudnorm=I=-14:TP=-1:LRA=11"));
+    }
+
+    #[test]
+    fn progressive_loudnorm_absent_when_audio_copy() {
+        let args = build_progressive_args(&ProgressiveTranscodeParams {
+            audio_codec: "copy".into(),
+            normalize_audio_loudness: true,
+            ..default_progressive()
+        });
+        assert!(!args_contains(&args, "loudnorm=I=-14:TP=-1:LRA=11"));
     }
 }


### PR DESCRIPTION
## Summary

Remux's primary workload is Stremio addon content — streams sourced from remote HTTP URLs that get repackaged as HLS with audio re-encoded for client compatibility (EAC3/AC3 → AAC). These sources often have wildly different loudness levels, causing jarring volume jumps between titles. This adds an optional EBU R128 loudness normalisation pass (`-af loudnorm=I=-14:TP=-1:LRA=11`) to the ffmpeg audio pipeline, bringing transcoded audio to a consistent -14 LUFS.

### Changes

**SDK (`crates/remux-sdks/src/remux/mod.rs`)**
- Add `normalize_audio_loudness: Option<bool>` to `EncodingOptions` (defaults to `Some(true)`)

**Server (`crates/remux-server/src/playback/engine.rs`)**
- Add `normalize_audio_loudness: bool` field to `TranscodeParams` and `ProgressiveTranscodeParams`
- Append `-af loudnorm=I=-14:TP=-1:LRA=11` in `build_hls_args` and `build_progressive_args` when the flag is true

**Server (`crates/remux-server/src/api/hls.rs`, `playback.rs`)**
- Wire `normalize_audio_loudness` from `EncodingOptions` through to both param structs

**Dashboard (`crates/remux-dashboard/src/pages/settings.rs`)**
- Add `normalize_audio_loudness: None` to `EncodingOptions` struct literal

## Behaviour

- `true` (default): transcoded audio goes through the EBU R128 loudness filter (I=-14 LUFS, TP=-1 dBTP, LRA=11 LU)
- `false`: unchanged from before
- **No effect on direct play** — ffmpeg is not involved, so no filter can run
- **No effect when `audio_codec` is `"copy"`** — audio is never decoded, so it cannot be filtered; applying loudnorm would require forcing a re-encode, which would silently degrade audio for clients that requested passthrough (e.g. AV receivers handling EAC3/TrueHD natively)

This feature intentionally scopes to sessions where a transcode is already happening.

## Test plan

- [x] Play content from two sources with different loudness levels, confirm volume is consistent — live LUFS test on homelab: Shrek (EAC3→AAC) without loudnorm: -22.5 LUFS; with loudnorm: -13.8 LUFS (8.7 dB gain, within 0.2 LU of -14 target). See [comment](https://github.com/lostb1t/remux/pull/125#issuecomment-5048487729).
- [x] Confirm `audio_codec: copy` sessions are unaffected — live ffmpeg process inspection on homelab confirmed `-c:a copy` session has no `-af loudnorm` in its args. Guard is structural: loudnorm lives in the `else` branch of `if ffmpeg_audio_codec == "copy"` at `engine.rs:900`.

## AI disclosure

Initial implementation was drafted with Claude Code, then reviewed and tested by me.
