### PR TITLE
fix: support Stremio addons with non-standard content types (fankai/anime)

### DIFF
--- a/crates/remux-sdks/src/stremio/mod.rs
+++ b/crates/remux-sdks/src/stremio/mod.rs
@@ -408,6 +408,7 @@ pub struct Meta {
     )]
     pub writer: Option<Vec<String>>,
     pub description: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_option_string_or_array")]
     pub genre: Option<Vec<String>>,
     #[serde(
         default,
@@ -440,6 +441,7 @@ pub struct Meta {
     )]
     pub popularity: Option<f64>,
     pub id: String,
+    #[serde(default, deserialize_with = "deserialize_option_string_or_array")]
     pub genres: Option<Vec<String>>,
     // pub season_posters: Option<Vec<String>>,
     // this can be a range 2012-2015
@@ -631,11 +633,15 @@ where
             if t.is_empty() {
                 Ok(None)
             } else {
-                let std_duration = parse_duration_lossy(t).map_err(D::Error::custom)?;
-
-                Ok(Some(
-                    Duration::from_std(std_duration).map_err(D::Error::custom)?,
-                ))
+                match parse_duration_lossy(t) {
+                    Ok(std_duration) => Ok(Some(
+                        Duration::from_std(std_duration).map_err(D::Error::custom)?,
+                    )),
+                    // Some addons (e.g. fankai) put a status string like "En cours"
+                    // in the runtime field instead of a duration. Don't fail the
+                    // whole catalog over one unparseable runtime.
+                    Err(_) => Ok(None),
+                }
             }
         }
     }
@@ -986,7 +992,7 @@ pub fn client(base: &str) -> Result<RestClient, url::ParseError> {
 
 #[cfg(test)]
 mod tests {
-    use super::{MediaType, parse_duration_lossy};
+    use super::{MediaType, Meta, parse_duration_lossy};
     use std::time::Duration;
 
     #[test]
@@ -1032,5 +1038,29 @@ mod tests {
         let kind = MediaType::Unknown("my_custom_type".into());
         let path = format!("/meta/{}/some_id.json", kind);
         assert_eq!(path, "/meta/my_custom_type/some_id.json");
+    }
+
+    #[test]
+    fn meta_genre_and_genres_accept_bare_string() {
+        let json = r#"{
+            "id": "fankai:123",
+            "type": "series",
+            "genre": "En cours",
+            "genres": "En cours"
+        }"#;
+        let meta: Meta = serde_json::from_str(json).unwrap();
+        assert_eq!(meta.genre, Some(vec!["En cours".to_string()]));
+        assert_eq!(meta.genres, Some(vec!["En cours".to_string()]));
+    }
+
+    #[test]
+    fn meta_runtime_ignores_unparseable_status_string() {
+        let json = r#"{
+            "id": "fankai:123",
+            "type": "series",
+            "runtime": "En cours"
+        }"#;
+        let meta: Meta = serde_json::from_str(json).unwrap();
+        assert_eq!(meta.runtime, None);
     }
 }

--- a/crates/remux-server/src/addons/mod.rs
+++ b/crates/remux-server/src/addons/mod.rs
@@ -963,6 +963,46 @@ fn user_scoped(runtime: &AddonRuntime, override_ids: Option<&[Uuid]>) -> bool {
     }
 }
 
+/// Maps a manifest-declared Stremio type to the `MediaKind` it represents,
+/// returning `None` for custom types with no recognized equivalent (e.g.
+/// fankai's "anime") instead of silently collapsing them to `Movie`.
+///
+/// `sdks::remux::MediaKind`'s own `From<stremio::MediaType>` impl defaults
+/// unrecognized strings to `Movie` — fine for content-item conversion, but
+/// wrong here: it would make `supports_type` believe a series/anime-only addon
+/// serves only movies, excluding it from `addons_for::<dyn StreamAddon>` for
+/// every Series/Season/Episode lookup. Leaving the type out of
+/// `supported_types` instead makes `supports_type` skip the manifest-types
+/// gate entirely for that addon (see the `mt.is_empty()` check), which is the
+/// correct behavior when the addon's declared type can't be mapped.
+fn recognized_manifest_media_kind(
+    t: sdks::stremio::MediaType,
+) -> Option<sdks::remux::MediaKind> {
+    use sdks::remux::MediaKind as MK;
+    use sdks::stremio::MediaType as MT;
+    Some(match t {
+        MT::Movie => MK::Movie,
+        MT::Series => MK::Series,
+        MT::Tv | MT::Channel => MK::TvChannel,
+        MT::Album => MK::Album,
+        MT::Artist => MK::Artist,
+        MT::Track => MK::Track,
+        MT::Events => MK::TvProgram,
+        MT::Unknown(s) => match s.as_str() {
+            "episode" => MK::Episode,
+            "season" => MK::Season,
+            "person" => MK::Person,
+            "genre" => MK::Genre,
+            "studio" => MK::Studio,
+            "collection" => MK::Collection,
+            "folder" => MK::Folder,
+            "stream" => MK::Stream,
+            "playlist" => MK::Playlist,
+            _ => return None,
+        },
+    })
+}
+
 fn kind_in_type_list(kind: &db::MediaKind, list: &[db::MediaKind]) -> bool {
     list.contains(kind)
         || (matches!(kind, db::MediaKind::Episode | db::MediaKind::Season)
@@ -1221,7 +1261,7 @@ impl AddonService {
                                     caps.metadata
                                         .supported_types = raw_types
                                         .into_iter()
-                                        .map(Into::into)
+                                        .filter_map(recognized_manifest_media_kind)
                                         .collect();
                                 }
                             }
@@ -2928,5 +2968,31 @@ mod tests {
         };
         apply_title_format(&mut media);
         assert_eq!(media.title, "S3E4 - Tumbleton");
+    }
+
+    /// Regression test: an addon whose manifest declares only a custom type
+    /// (e.g. fankai's "anime") must not have that type collapse to `Movie` in
+    /// `supported_types` — doing so made `supports_type` believe the addon
+    /// only serves movies, excluding it from `addons_for::<dyn StreamAddon>`
+    /// for every Series/Season/Episode, so no stream addon was ever even
+    /// attempted for episodes (silent "no streams" with no error logged).
+    #[test]
+    fn recognized_manifest_media_kind_drops_unrecognized_custom_type() {
+        assert_eq!(
+            recognized_manifest_media_kind(sdks::stremio::MediaType::Unknown(
+                "anime".to_string()
+            )),
+            None
+        );
+        assert_eq!(
+            recognized_manifest_media_kind(sdks::stremio::MediaType::Series),
+            Some(sdks::remux::MediaKind::Series)
+        );
+        assert_eq!(
+            recognized_manifest_media_kind(sdks::stremio::MediaType::Unknown(
+                "episode".to_string()
+            )),
+            Some(sdks::remux::MediaKind::Episode)
+        );
     }
 }

--- a/crates/remux-server/src/addons/stremio.rs
+++ b/crates/remux-server/src/addons/stremio.rs
@@ -436,6 +436,10 @@ impl TreeAddon for StremioAddon {
                         .external_ids
                         .series_custom_stremio_id
                         .clone(),
+                    custom_stremio_type: root
+                        .external_ids
+                        .custom_stremio_type
+                        .clone(),
                     ..Default::default()
                 };
                 let series_id = root
@@ -648,6 +652,57 @@ fn is_404(e: &anyhow::Error) -> bool {
 // Meta helpers
 // ---------------------------------------------------------------------------
 
+/// Finds a working alternate Stremio type for `meta_id` by consulting the
+/// addon's own manifest, for the case where `tried_type` (derived generically
+/// from `MediaKind`) 404s. Only considers `meta` resources whose `idPrefixes`
+/// match `meta_id` (or which have no prefix restriction), and probes each
+/// candidate type with a real request — the manifest can list types that
+/// don't apply to this specific ID, so a match here isn't guaranteed either.
+/// Returns the successful fetch directly to avoid a redundant second request.
+async fn manifest_meta_type_fallback(
+    svc: &stremio_service::StremioService,
+    tried_type: &sdks::stremio::MediaType,
+    meta_id: &str,
+) -> Option<sdks::stremio::Meta> {
+    let manifest = svc
+        .get_manifest()
+        .await
+        .ok()?;
+    let tried = tried_type.to_string();
+    let candidates: Vec<String> = manifest
+        .resources
+        .into_iter()
+        .filter_map(|r| match r {
+            sdks::stremio::Resource::Detailed(r) if r.name == ResourceType::Meta => {
+                let prefix_ok = r
+                    .id_prefixes
+                    .as_ref()
+                    .map(|prefixes| {
+                        prefixes
+                            .iter()
+                            .any(|p| meta_id.starts_with(p.as_str()))
+                    })
+                    .unwrap_or(true);
+                prefix_ok.then_some(r.types)
+            }
+            _ => None,
+        })
+        .flatten()
+        .filter(|t| t != &tried)
+        .collect();
+
+    for candidate in candidates {
+        let alt_type = sdks::stremio::MediaType::Unknown(candidate);
+        if let Ok(meta) = svc
+            .get_meta(alt_type, meta_id.to_string())
+            .await
+        {
+            return Some(meta);
+        }
+    }
+    None
+}
+
 /// Fetch the raw Stremio `Meta` for `media`, storing it in `cache` keyed by
 /// the series-level lookup id. Returns the cached `Arc` immediately if present.
 async fn fetch_and_cache_meta(
@@ -680,7 +735,9 @@ async fn fetch_and_cache_meta(
             .external_ids
             .series_imdb
             .is_none();
-    let media_type = sdks::stremio::MediaType::from(&media.kind);
+    let media_type = media
+        .external_ids
+        .stremio_media_type(&media.kind);
     let meta = if let Some(stored) = ctx
         .store
         .get::<sdks::stremio::Meta>(
@@ -695,6 +752,25 @@ async fn fetch_and_cache_meta(
             .await
         {
             Ok(m) => m,
+            // Custom-ID items (no IMDB/TMDB) have no `MediaKind`-derived type that's
+            // guaranteed correct: a DB row imported before `custom_stremio_type` was
+            // tracked (or a season/episode that never inherited it) falls back to a
+            // generic type that may not match the addon's own non-standard one (e.g.
+            // "anime"). Ask the addon's manifest what type(s) it actually serves for
+            // this ID and retry, rather than failing permanently.
+            Err(e)
+                if is_404(&e)
+                    && is_custom
+                    && media
+                        .external_ids
+                        .custom_stremio_type
+                        .is_none() =>
+            {
+                match manifest_meta_type_fallback(svc, &media_type, &meta_id).await {
+                    Some(m) => m,
+                    None => return Err(e),
+                }
+            }
             Err(e) if is_404(&e) && !is_custom => {
                 let tmdb_id = media
                     .external_ids
@@ -792,6 +868,10 @@ async fn stremio_meta_fetch(
                     .external_ids
                     .series_custom_stremio_id
                     .clone(),
+                custom_stremio_type: media
+                    .external_ids
+                    .custom_stremio_type
+                    .clone(),
                 ..Default::default()
             };
             let seasons =
@@ -823,6 +903,10 @@ async fn stremio_meta_fetch(
                 custom_stremio_id: media
                     .external_ids
                     .series_custom_stremio_id
+                    .clone(),
+                custom_stremio_type: media
+                    .external_ids
+                    .custom_stremio_type
                     .clone(),
                 ..Default::default()
             };
@@ -1231,15 +1315,6 @@ async fn stremio_streams(
 ) -> Result<Vec<crate::stream::StreamInfo>> {
     let (media_type, id, tmdb_fallback_id) = match media.kind {
         db::MediaKind::Episode => {
-            let series_id: String = media
-                .external_ids
-                .series_imdb
-                .as_deref()
-                .map(|s| s.to_string())
-                .or_else(|| media.external_ids.series_custom_stremio_id.clone())
-                .ok_or_else(|| {
-                    anyhow!("episode has no series_imdb or series_custom_stremio_id for stream lookup")
-                })?;
             let season = media
                 .parent_idx
                 .unwrap_or(1);
@@ -1250,9 +1325,33 @@ async fn stremio_streams(
                 .external_ids
                 .series_tmdb
                 .map(|tid| format!("tmdb:{}:{}:{}", tid, season, episode));
+            // Prefer the addon's own video id (captured from the series meta's
+            // `videos[].id`) over reconstructing "{series}:{season}:{episode}" —
+            // that composite form is only a convention for series-type addons,
+            // not guaranteed for custom types. Fall back to reconstruction for
+            // episodes stored before this field was captured.
+            let id = media
+                .external_ids
+                .custom_stremio_id
+                .clone()
+                .ok_or(())
+                .or_else(|_| {
+                    media
+                        .external_ids
+                        .series_imdb
+                        .as_deref()
+                        .map(|s| s.to_string())
+                        .or_else(|| media.external_ids.series_custom_stremio_id.clone())
+                        .map(|series_id| format!("{}:{}:{}", series_id, season, episode))
+                        .ok_or_else(|| {
+                            anyhow!("episode has no series_imdb or series_custom_stremio_id for stream lookup")
+                        })
+                })?;
             (
-                sdks::stremio::MediaType::Series,
-                format!("{}:{}:{}", series_id, season, episode),
+                media
+                    .external_ids
+                    .stremio_media_type(&media.kind),
+                id,
                 tmdb_fb,
             )
         }
@@ -1299,7 +1398,13 @@ async fn stremio_streams(
                 .external_ids
                 .tmdb
                 .map(|tid| format!("tmdb:{}", tid));
-            (sdks::stremio::MediaType::from(&media.kind), id, tmdb_fb)
+            (
+                media
+                    .external_ids
+                    .stremio_media_type(&media.kind),
+                id,
+                tmdb_fb,
+            )
         }
     };
 
@@ -1459,4 +1564,200 @@ async fn stremio_streams(
             })
         })
         .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mock_manifest(server: &httpmock::MockServer) {
+        server.mock(|when, then| {
+            when.path("/manifest.json");
+            then.status(200)
+                .json_body(serde_json::json!({
+                    "id": "fankai-test",
+                    "name": "Fankai",
+                    "version": "1.0.0",
+                    "resources": [
+                        "catalog",
+                        {"name": "meta", "types": ["anime"], "idPrefixes": ["fk"]}
+                    ],
+                    "types": ["anime"],
+                    "catalogs": []
+                }));
+        });
+    }
+
+    /// Regression test for the "no seasons/episodes" bug: an addon-custom type
+    /// (e.g. fankai's "anime") 404s when queried with the generic type derived
+    /// from `MediaKind` ("series"). The fallback should consult the addon's own
+    /// manifest and retry with its declared type instead of failing outright.
+    #[tokio::test]
+    async fn manifest_meta_type_fallback_retries_with_addon_declared_type() {
+        let server = httpmock::MockServer::start();
+        mock_manifest(&server);
+        let series_attempt = server.mock(|when, then| {
+            when.path("/meta/series/fk:27.json");
+            then.status(404);
+        });
+        let anime_attempt = server.mock(|when, then| {
+            when.path("/meta/anime/fk:27.json");
+            then.status(200)
+                .json_body(serde_json::json!({
+                    "meta": {"id": "fk:27", "type": "anime", "name": "Bleach Yabai"}
+                }));
+        });
+
+        let svc =
+            stremio_service::StremioService::from_url(&server.base_url()).unwrap();
+
+        // Confirm the generic type really does 404 first, matching the bug report.
+        let direct = svc
+            .get_meta(sdks::stremio::MediaType::Series, "fk:27".to_string())
+            .await;
+        assert!(direct.is_err());
+        series_attempt.assert();
+
+        let meta = manifest_meta_type_fallback(
+            &svc,
+            &sdks::stremio::MediaType::Series,
+            "fk:27",
+        )
+        .await;
+
+        assert!(
+            meta.is_some(),
+            "fallback must find the addon's declared \"anime\" type"
+        );
+        assert_eq!(
+            meta.unwrap()
+                .get_name(),
+            Some("Bleach Yabai".to_string())
+        );
+        anime_attempt.assert();
+    }
+
+    #[tokio::test]
+    async fn manifest_meta_type_fallback_none_when_no_type_works() {
+        let server = httpmock::MockServer::start();
+        mock_manifest(&server);
+        server.mock(|when, then| {
+            when.path("/meta/anime/fk:999.json");
+            then.status(404);
+        });
+
+        let svc =
+            stremio_service::StremioService::from_url(&server.base_url()).unwrap();
+        let meta = manifest_meta_type_fallback(
+            &svc,
+            &sdks::stremio::MediaType::Series,
+            "fk:999",
+        )
+        .await;
+
+        assert!(meta.is_none());
+    }
+
+    #[tokio::test]
+    async fn manifest_meta_type_fallback_skips_non_matching_prefix() {
+        let server = httpmock::MockServer::start();
+        mock_manifest(&server);
+        // "tt" is not covered by fankai's declared idPrefixes (["fk"]) — the
+        // fallback must not even attempt the "anime" type for it.
+        let anime_attempt = server.mock(|when, then| {
+            when.path("/meta/anime/tt1234567.json");
+            then.status(200)
+                .json_body(serde_json::json!({
+                    "meta": {"id": "tt1234567", "type": "anime", "name": "Should Not Match"}
+                }));
+        });
+
+        let svc =
+            stremio_service::StremioService::from_url(&server.base_url()).unwrap();
+        let meta = manifest_meta_type_fallback(
+            &svc,
+            &sdks::stremio::MediaType::Series,
+            "tt1234567",
+        )
+        .await;
+
+        assert!(meta.is_none());
+        anime_attempt.assert_hits(0);
+    }
+
+    fn episode_media(external_ids: db::ExternalIds) -> db::Media {
+        db::Media {
+            kind: db::MediaKind::Episode,
+            parent_idx: Some(1),
+            idx: Some(1),
+            external_ids,
+            ..Default::default()
+        }
+    }
+
+    /// Regression test: the stream lookup must use the addon's own video id
+    /// (`custom_stremio_id`, captured from `videos[].id`) rather than
+    /// reconstructing "{series}:{season}:{episode}" — some addons don't follow
+    /// that convention, and a mismatched reconstructed id silently returns zero
+    /// streams instead of erroring.
+    #[tokio::test]
+    async fn stremio_streams_prefers_captured_video_id_over_reconstruction() {
+        let server = httpmock::MockServer::start();
+        let reconstructed = server.mock(|when, then| {
+            when.path("/stream/anime/fk:27:1:1.json");
+            then.status(404);
+        });
+        let captured = server.mock(|when, then| {
+            when.path("/stream/anime/fk-ep-1.json");
+            then.status(200)
+                .json_body(serde_json::json!({"streams": [{"url": "https://example.com/1.mp4"}]}));
+        });
+
+        let svc =
+            stremio_service::StremioService::from_url(&server.base_url()).unwrap();
+        let manifest_url = StremioManifestUrl::try_new(server.base_url()).unwrap();
+        let media = episode_media(db::ExternalIds {
+            series_custom_stremio_id: Some("fk:27".to_string()),
+            custom_stremio_id: Some("fk-ep-1".to_string()),
+            custom_stremio_type: Some("anime".to_string()),
+            ..Default::default()
+        });
+
+        let streams = stremio_streams(&svc, &manifest_url, &media)
+            .await
+            .unwrap();
+
+        assert_eq!(streams.len(), 1);
+        captured.assert();
+        reconstructed.assert_hits(0);
+    }
+
+    /// Episodes stored before `custom_stremio_id` was captured (or from addons
+    /// that genuinely use the composite convention) must keep working via the
+    /// reconstructed "{series}:{season}:{episode}" id.
+    #[tokio::test]
+    async fn stremio_streams_falls_back_to_reconstructed_id_when_uncaptured() {
+        let server = httpmock::MockServer::start();
+        let reconstructed = server.mock(|when, then| {
+            when.path("/stream/anime/fk:27:1:1.json");
+            then.status(200)
+                .json_body(serde_json::json!({"streams": [{"url": "https://example.com/1.mp4"}]}));
+        });
+
+        let svc =
+            stremio_service::StremioService::from_url(&server.base_url()).unwrap();
+        let manifest_url = StremioManifestUrl::try_new(server.base_url()).unwrap();
+        let media = episode_media(db::ExternalIds {
+            series_custom_stremio_id: Some("fk:27".to_string()),
+            custom_stremio_type: Some("anime".to_string()),
+            ..Default::default()
+        });
+
+        let streams = stremio_streams(&svc, &manifest_url, &media)
+            .await
+            .unwrap();
+
+        assert_eq!(streams.len(), 1);
+        reconstructed.assert();
+    }
 }

--- a/crates/remux-server/src/db/media.rs
+++ b/crates/remux-server/src/db/media.rs
@@ -188,6 +188,21 @@ impl TryFrom<sdks::stremio::MediaType> for MediaKind {
     }
 }
 
+/// Extracts the addon's raw Stremio type string when it's a non-standard type
+/// (e.g. "anime") that `MediaKind` cannot represent and would otherwise collapse
+/// to a generic `Movie`/`Series`. Structural keywords (`episode`/`season`/`person`)
+/// are not content types and are excluded.
+fn custom_stremio_type(media_type: &sdks::stremio::MediaType) -> Option<String> {
+    match media_type {
+        sdks::stremio::MediaType::Unknown(s)
+            if !matches!(s.as_str(), "episode" | "season" | "person") =>
+        {
+            Some(s.clone())
+        }
+        _ => None,
+    }
+}
+
 impl From<&MediaKind> for sdks::stremio::MediaType {
     fn from(kind: &MediaKind) -> Self {
         match kind {
@@ -833,6 +848,12 @@ pub struct ExternalIds {
     /// For seasons/episodes of a custom-ID series: the parent series's `custom_stremio_id`.
     /// Analogous to `series_imdb` for the custom-ID path.
     pub series_custom_stremio_id: Option<String>,
+    /// The addon's own non-standard Stremio type string (e.g. "anime"), when the
+    /// catalog/meta item used one. `MediaKind` collapses these to `Movie`/`Series`
+    /// for internal use, but the addon's `/meta/{type}/{id}.json` and
+    /// `/stream/{type}/{id}.json` routes require the original type string — losing
+    /// it here means later meta/stream lookups 404 against the source addon.
+    pub custom_stremio_type: Option<String>,
 }
 
 impl ExternalIds {
@@ -1003,6 +1024,23 @@ impl ExternalIds {
             &source.series_custom_stremio_id,
             replace,
         );
+        merge_option(
+            &mut self.custom_stremio_type,
+            &source.custom_stremio_type,
+            replace,
+        );
+    }
+
+    /// The Stremio `MediaType` to use when querying the source addon for this
+    /// item: the addon's own non-standard type string when one was captured
+    /// (see `custom_stremio_type`), otherwise the generic type derived from
+    /// `kind`. Addons that serve a custom type (e.g. "anime") 404 on `/meta`
+    /// and `/stream` routes built from the generic type.
+    pub fn stremio_media_type(&self, kind: &MediaKind) -> sdks::stremio::MediaType {
+        self.custom_stremio_type
+            .clone()
+            .map(sdks::stremio::MediaType::Unknown)
+            .unwrap_or_else(|| sdks::stremio::MediaType::from(kind))
     }
 }
 
@@ -5345,6 +5383,7 @@ impl TryFrom<sdks::stremio::Meta> for Media {
                 if let Some(ref imdb) = meta.imdb_id {
                     ids.imdb = NonEmptyString::try_new(imdb.clone()).ok();
                 }
+                ids.custom_stremio_type = custom_stremio_type(&meta.media_type);
                 ids
             },
             status,
@@ -5472,6 +5511,10 @@ pub fn stremio_meta_to_medias(meta: sdks::stremio::Meta) -> Result<Vec<Media>> {
                         grandparent_id: Some(media.id),
                         external_ids: ExternalIds {
                             series_custom_stremio_id: Some(custom_id.clone()),
+                            custom_stremio_type: media
+                                .external_ids
+                                .custom_stremio_type
+                                .clone(),
                             ..Default::default()
                         },
                         released_at: episodes
@@ -5507,6 +5550,14 @@ pub fn stremio_meta_to_medias(meta: sdks::stremio::Meta) -> Result<Vec<Media>> {
                         episode.idx = ep.episode;
                         episode.external_ids = ExternalIds {
                             series_custom_stremio_id: Some(custom_id.clone()),
+                            custom_stremio_type: media
+                                .external_ids
+                                .custom_stremio_type
+                                .clone(),
+                            custom_stremio_id: Some(
+                                ep.id
+                                    .clone(),
+                            ),
                             ..Default::default()
                         };
                         episode.parent_id = Some(season_id);
@@ -5581,6 +5632,10 @@ pub fn stremio_meta_to_medias(meta: sdks::stremio::Meta) -> Result<Vec<Media>> {
                         series_tmdb: media
                             .external_ids
                             .tmdb,
+                        custom_stremio_type: media
+                            .external_ids
+                            .custom_stremio_type
+                            .clone(),
                         ..Default::default()
                     },
                     parent_id: Some(media.id),
@@ -5621,6 +5676,14 @@ pub fn stremio_meta_to_medias(meta: sdks::stremio::Meta) -> Result<Vec<Media>> {
                         series_tmdb: media
                             .external_ids
                             .tmdb,
+                        custom_stremio_type: media
+                            .external_ids
+                            .custom_stremio_type
+                            .clone(),
+                        custom_stremio_id: Some(
+                            ep.id
+                                .clone(),
+                        ),
                         ..Default::default()
                     };
                     episode.grandparent_id = Some(media.id);
@@ -5697,6 +5760,9 @@ pub fn stremio_meta_seasons(
             let ext = ExternalIds {
                 series_imdb: Some(iid.clone()),
                 series_tmdb: series_external_ids.tmdb,
+                custom_stremio_type: series_external_ids
+                    .custom_stremio_type
+                    .clone(),
                 ..Default::default()
             };
             (id, ext)
@@ -5712,6 +5778,9 @@ pub fn stremio_meta_seasons(
             });
             let ext = ExternalIds {
                 series_custom_stremio_id: Some(cid.clone()),
+                custom_stremio_type: series_external_ids
+                    .custom_stremio_type
+                    .clone(),
                 ..Default::default()
             };
             (id, ext)
@@ -5791,6 +5860,17 @@ pub fn stremio_meta_season_episodes(
             episode.external_ids = ExternalIds {
                 series_imdb: Some(iid.clone()),
                 series_tmdb: series_external_ids.tmdb,
+                custom_stremio_type: series_external_ids
+                    .custom_stremio_type
+                    .clone(),
+                // The addon's own video id for this specific episode. Series-type
+                // addons conventionally set this to "{imdb}:{season}:{episode}",
+                // but that's a convention, not a guarantee — keep the literal
+                // value so stream lookups use exactly what the addon gave us.
+                custom_stremio_id: Some(
+                    ep.id
+                        .clone(),
+                ),
                 ..Default::default()
             };
         } else if let Some(ref cid) = custom_id {
@@ -5805,6 +5885,13 @@ pub fn stremio_meta_season_episodes(
             });
             episode.external_ids = ExternalIds {
                 series_custom_stremio_id: Some(cid.clone()),
+                custom_stremio_type: series_external_ids
+                    .custom_stremio_type
+                    .clone(),
+                custom_stremio_id: Some(
+                    ep.id
+                        .clone(),
+                ),
                 ..Default::default()
             };
         }
@@ -5847,7 +5934,12 @@ pub fn stremio_meta_season_episodes(
 ///      series have NULL parent_id so the subquery would always return NULL anyway;
 ///      seasons must not inherit the series premiere (TVDB lists future seasons early).
 ///
-/// Items with no resolvable date are always excluded (the OR condition is false for them).
+/// Items with no resolvable date at all are excluded (the OR condition is false
+/// for them) — EXCEPT top-level movies/series, where an unknown date is not
+/// evidence of a future release (some Stremio addon catalogs never report one)
+/// and hiding them outright would make their entire catalog unbrowsable. Seasons
+/// and episodes keep the strict behavior: a season/episode with no date at all
+/// (not even inherited from its parent) is presumed not yet aired.
 ///
 /// The filter is expressed as OR branches rather than a CASE expression so that SQLite
 /// can use `idx_media_digital_released_at` for branch 1 and `idx_media_released_at`
@@ -5883,6 +5975,9 @@ pub fn push_release_date_filter(
         // Movies / series / seasons: no parent fallback. Each branch is indexable.
         // Branch 1 → idx_media_digital_released_at
         // Branch 2 → idx_media_released_at
+        // Branch 3 → top-level movies/series with no resolvable date at all pass
+        // through (see doc comment above); seasons are excluded from this branch
+        // so an undated season of an otherwise-dated series stays hidden.
         qb.push(format!(
             " AND (({a}digital_released_at IS NOT NULL AND {a}digital_released_at <= "
         ))
@@ -5894,7 +5989,9 @@ pub fn push_release_date_filter(
         ))
         .push_bind(threshold)
         .push(format!(
-            " AND NOT ({a}kind = 'movie' AND {a}released_at > date('now', '-1 year'))))"
+            " AND NOT ({a}kind = 'movie' AND {a}released_at > date('now', '-1 year'))) \
+              OR ({a}digital_released_at IS NULL AND {a}released_at IS NULL \
+                  AND {a}kind IN ('movie', 'series')))"
         ));
     }
 }
@@ -6323,6 +6420,125 @@ mod tests {
     use crate::db::MediaIdRaw;
 
     #[test]
+    fn custom_stremio_type_extracts_non_standard_type() {
+        assert_eq!(
+            custom_stremio_type(&sdks::stremio::MediaType::Unknown(
+                "anime".to_string()
+            )),
+            Some("anime".to_string())
+        );
+        assert_eq!(custom_stremio_type(&sdks::stremio::MediaType::Series), None);
+        assert_eq!(
+            custom_stremio_type(&sdks::stremio::MediaType::Unknown(
+                "episode".to_string()
+            )),
+            None
+        );
+    }
+
+    #[test]
+    fn stremio_media_type_prefers_custom_type_over_kind() {
+        let anime_ids = ExternalIds {
+            custom_stremio_type: Some("anime".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            anime_ids.stremio_media_type(&MediaKind::Series),
+            sdks::stremio::MediaType::Unknown("anime".to_string())
+        );
+
+        let standard_ids = ExternalIds::default();
+        assert_eq!(
+            standard_ids.stremio_media_type(&MediaKind::Series),
+            sdks::stremio::MediaType::Series
+        );
+    }
+
+    /// Regression test: an addon-custom Stremio type (e.g. fankai's "anime")
+    /// must survive the catalog → Media conversion and propagate onto the
+    /// series' seasons/episodes, so a later `/meta/{type}/{id}.json` lookup
+    /// against the source addon uses the correct type instead of the generic
+    /// one derived from `MediaKind` (which would 404 for non-standard types).
+    #[test]
+    fn stremio_meta_to_medias_propagates_custom_type_to_episodes() {
+        let json = r#"{
+            "id": "fk:27",
+            "type": "anime",
+            "name": "Bleach Yabai",
+            "videos": [
+                {"id": "fk:27:1:1", "season": 1, "episode": 1, "title": "Ep 1"},
+                {"id": "fk:27:1:2", "season": 1, "episode": 2, "title": "Ep 2"}
+            ]
+        }"#;
+        let meta: sdks::stremio::Meta = serde_json::from_str(json).unwrap();
+        let medias = stremio_meta_to_medias(meta).unwrap();
+
+        let series = medias
+            .iter()
+            .find(|m| m.kind == MediaKind::Series)
+            .expect("series media");
+        assert_eq!(
+            series
+                .external_ids
+                .custom_stremio_type,
+            Some("anime".to_string())
+        );
+
+        let season = medias
+            .iter()
+            .find(|m| m.kind == MediaKind::Season)
+            .expect("season media");
+        assert_eq!(
+            season
+                .external_ids
+                .custom_stremio_type,
+            Some("anime".to_string())
+        );
+
+        let episode = medias
+            .iter()
+            .find(|m| m.kind == MediaKind::Episode)
+            .expect("episode media");
+        assert_eq!(
+            episode
+                .external_ids
+                .custom_stremio_type,
+            Some("anime".to_string())
+        );
+    }
+
+    /// Regression test: the addon's own `videos[].id` (e.g. "fk:27:1:1") must be
+    /// captured onto the episode's `custom_stremio_id`, not just derived from
+    /// series id + season + episode — some addons don't follow the
+    /// "{series}:{season}:{episode}" convention for their video ids, and a
+    /// reconstructed id that doesn't match what the addon actually assigned
+    /// returns zero streams instead of erroring.
+    #[test]
+    fn stremio_meta_to_medias_captures_episode_video_id() {
+        let json = r#"{
+            "id": "fk:27",
+            "type": "anime",
+            "name": "Bleach Yabai",
+            "videos": [
+                {"id": "fk:27:1:1", "season": 1, "episode": 1, "title": "Ep 1"}
+            ]
+        }"#;
+        let meta: sdks::stremio::Meta = serde_json::from_str(json).unwrap();
+        let medias = stremio_meta_to_medias(meta).unwrap();
+
+        let episode = medias
+            .iter()
+            .find(|m| m.kind == MediaKind::Episode)
+            .expect("episode media");
+        assert_eq!(
+            episode
+                .external_ids
+                .custom_stremio_id,
+            Some("fk:27:1:1".to_string())
+        );
+    }
+
+    #[test]
     fn stale_episode_id_recomputes_to_canonical_and_validates() {
         let series_imdb = NonEmptyString::try_new("tt1844624".to_string()).unwrap();
         let mut ep = Media {
@@ -6526,7 +6742,9 @@ mod tests {
 
     /// Verifies push_release_date_filter hides movies with a recent theatrical date
     /// but no digital release date, while still showing movies with an old theatrical
-    /// date (>1 year) or an explicit digital release date.
+    /// date (>1 year), an explicit digital release date, or no known date at all
+    /// (some addon catalogs never report one; unknown is not evidence of a future
+    /// release).
     #[tokio::test]
     async fn release_date_filter_hides_recent_theatrical_only_movies() {
         let (_server, guard) = crate::integration_test::new_test_server()
@@ -6554,6 +6772,7 @@ mod tests {
         let (id_recent, ext_recent) = make_movie_ids("tt9990001");
         let (id_old, ext_old) = make_movie_ids("tt9990002");
         let (id_digital, ext_digital) = make_movie_ids("tt9990003");
+        let (id_no_date, ext_no_date) = make_movie_ids("tt9990004");
 
         // Theatrical only, released 2 months ago — no digital date → must be hidden.
         let mut recent_theatrical = Media {
@@ -6600,6 +6819,21 @@ mod tests {
             .await
             .unwrap();
 
+        // No known release date at all (e.g. addon never reports one) → must be shown.
+        let mut no_date = Media {
+            id: id_no_date,
+            title: "No Known Release Date".to_string(),
+            kind: MediaKind::Movie,
+            external_ids: ext_no_date,
+            released_at: None,
+            digital_released_at: None,
+            ..Default::default()
+        };
+        no_date
+            .save(db)
+            .await
+            .unwrap();
+
         let result = Media::get_by_filter(
             db,
             &MediaFilter {
@@ -6633,6 +6867,73 @@ mod tests {
         assert!(
             titles.contains(&"Has Digital Release"),
             "movie with digital release date must be shown; got: {:?}",
+            titles
+        );
+        assert!(
+            titles.contains(&"No Known Release Date"),
+            "movie with no known release date must be shown; got: {:?}",
+            titles
+        );
+    }
+
+    /// Same "unknown date passes" rule as movies, but for a top-level series with
+    /// no known release date at all — the case that actually motivated the rule
+    /// (some Stremio addon catalogs never report one for any of their series).
+    #[tokio::test]
+    async fn release_date_filter_shows_series_with_no_known_date() {
+        let (_server, guard) = crate::integration_test::new_test_server()
+            .await
+            .unwrap();
+        let db = &guard
+            .0
+            .db;
+        let now = chrono::Utc::now().naive_utc();
+
+        let ext = ExternalIds {
+            imdb: Some(NonEmptyString::try_new("tt9990005".to_string()).unwrap()),
+            ..Default::default()
+        };
+        let mut series = Media {
+            id: uuid::Uuid::from(&MediaIdRaw {
+                kind: MediaKind::Series,
+                external_ids: ext.clone(),
+                season: None,
+                episode: None,
+            }),
+            title: "No Known Date Series".to_string(),
+            kind: MediaKind::Series,
+            external_ids: ext,
+            released_at: None,
+            digital_released_at: None,
+            ..Default::default()
+        };
+        series
+            .save(db)
+            .await
+            .unwrap();
+
+        let result = Media::get_by_filter(
+            db,
+            &MediaFilter {
+                kind: Some(vec![MediaKind::Series]),
+                digital_released_before: Some(now),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let titles: Vec<&str> = result
+            .records
+            .iter()
+            .map(|m| {
+                m.title
+                    .as_str()
+            })
+            .collect();
+        assert!(
+            titles.contains(&"No Known Date Series"),
+            "series with no known release date must be shown; got: {:?}",
             titles
         );
     }

--- a/crates/remux-server/src/services/stremio.rs
+++ b/crates/remux-server/src/services/stremio.rs
@@ -8,7 +8,7 @@ use std::{
     pin::Pin,
     time::{Duration, Instant},
 };
-use tracing::{debug, error};
+use tracing::debug;
 
 #[derive(Clone)]
 pub struct StremioService {
@@ -188,14 +188,14 @@ impl StremioService {
                                 .metas
                                 .is_empty()
                         })
-                        .unwrap_or(true),
+                        .unwrap_or(false),
                 )
             })
             .filter_map(|result| async move {
                 match result {
                     Ok(response) => Some(stream::iter(response.metas)),
                     Err(e) => {
-                        error!("Failed to fetch catalog page: {}", e);
+                        debug!("stopping catalog pagination: {}", e);
                         None
                     }
                 }


### PR DESCRIPTION
## Summary

Fixes the fankai (FKStream) addon catalog end-to-end. The catalog import
crashed, then paginated forever, then imported items were invisible in
collections, then had no seasons/episodes, then had no playable streams —
each layer was masked by the next, so this PR fixes all of them together.

### 1. Catalog import crash
- `Meta.genre` / `Meta.genres` now accept a bare string (some addons send a
  single string instead of an array), reusing the existing tolerant
  deserializer already used for `country`/`director`/`cast`/`writer`.
- `Meta.runtime` now treats an unparseable value (e.g. fankai's `"En cours"`
  status string, not a duration) as absent instead of failing the whole
  catalog page's deserialization.

### 2. Infinite pagination
`get_catalog_stream` continued paginating on *any* fetch error instead of
stopping — once the addon's real last page was reached and it started
returning 404 instead of an empty array, this hammered the addon with
hundreds of requests (`skip=79` through `skip=3397+`). Now a fetch error
stops pagination (expected/normal terminal condition, downgraded to `debug!`).

### 3. Imported items invisible in collections
The release-date filter (`FilterByDigitalReleaseDate`) hid every item with
no resolvable release date at all — some addon catalogs (fankai included)
never report one. Movies/series with no known date now pass the filter
(unknown ≠ future release); seasons/episodes keep the strict "hide if
undated" behavior since a missing air date there really does mean unaired.

### 4. No seasons/episodes
`fetch_and_cache_meta` derived the Stremio type to query from `MediaKind`
(→ `"series"`), 404ing against addons using a custom type (fankai's
`"anime"`). Fixed by:
- Tracking the addon's own non-standard type string via
  `ExternalIds::custom_stremio_type`, propagated onto seasons/episodes, and
  preferring it over the generic derived type.
- When a custom-ID item still 404s (e.g. rows created before this field
  existed), consulting the addon's own manifest for its declared type(s) and
  retrying instead of failing permanently (`manifest_meta_type_fallback`).

### 5. No playable streams
Two separate bugs, both silent (no error, just an empty stream list):
- The stream lookup reconstructed the video id as
  `"{series}:{season}:{episode}"` — only a convention for series-type
  addons, not a guarantee. Now the addon's own video id
  (`videos[].id`, captured as `ExternalIds::custom_stremio_id`) is used
  directly, falling back to reconstruction for episodes stored before this
  field was captured.
- `supports_type()` collapsed any unrecognized manifest type (e.g. `"anime"`)
  to `MediaKind::Movie`, which made the addon registry believe an
  anime/series-only addon served *only* movies — silently excluding it from
  `addons_for::<dyn StreamAddon>` for every Series/Season/Episode lookup, so
  no stream addon was ever even attempted for episodes. Unrecognized types
  are now left out of `supported_types` entirely, which correctly bypasses
  the manifest-type gate instead of asserting a wrong one.

## Test plan
- [x] `cargo test -p remux-server --lib -- --test-threads=1` — 251 passed, 0 failed
- [x] `cargo fmt --all -- --check` clean
- [x] Verified end-to-end against the real fankai addon: catalog import,
      collection visibility, season/episode tree, and stream playback for
      "Bleach Yabai" S1E1 all confirmed working via live DB inspection and
      manual playback test