### PR TITLE
fix: Jellyfin API compat — Filters2 endpoint and list filter params

### DIFF
--- a/crates/remux-sdks/src/remux/mod.rs
+++ b/crates/remux-sdks/src/remux/mod.rs
@@ -1523,7 +1523,9 @@ where
 /// Jellyfin uses `|` for multi-value genre/rating/tag filters (e.g.
 /// `Genres=Action|Comedy`, `OfficialRatings=PG|R`). We also accept commas so the
 /// field round-trips through our own `serialize_comma_opt` serializer.
-fn deserialize_pipe_comma_str<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
+fn deserialize_pipe_comma_str<'de, D>(
+    deserializer: D,
+) -> Result<Option<Vec<String>>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -1562,7 +1564,9 @@ where
 }
 
 /// `OfficialRatings=PG|R` → `vec!["PG", "R"]`.
-pub fn deserialize_official_ratings<'de, D>(d: D) -> Result<Option<Vec<String>>, D::Error>
+pub fn deserialize_official_ratings<'de, D>(
+    d: D,
+) -> Result<Option<Vec<String>>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -1687,13 +1691,19 @@ mod tests {
     #[test]
     fn genres_filter_parses_pipe_separated() {
         let q = parse_query("Genres=Action|Comedy");
-        assert_eq!(q.genres, Some(vec!["Action".to_string(), "Comedy".to_string()]));
+        assert_eq!(
+            q.genres,
+            Some(vec!["Action".to_string(), "Comedy".to_string()])
+        );
     }
 
     #[test]
     fn genres_filter_also_accepts_comma_separated() {
         let q = parse_query("Genres=Action,Comedy");
-        assert_eq!(q.genres, Some(vec!["Action".to_string(), "Comedy".to_string()]));
+        assert_eq!(
+            q.genres,
+            Some(vec!["Action".to_string(), "Comedy".to_string()])
+        );
     }
 
     #[test]
@@ -1717,10 +1727,22 @@ mod tests {
     #[test]
     fn filter_fields_default_to_none_when_absent() {
         let q = parse_query("IncludeItemTypes=Movie");
-        assert!(q.years.is_none());
-        assert!(q.genres.is_none());
-        assert!(q.official_ratings.is_none());
-        assert!(q.tags.is_none());
+        assert!(
+            q.years
+                .is_none()
+        );
+        assert!(
+            q.genres
+                .is_none()
+        );
+        assert!(
+            q.official_ratings
+                .is_none()
+        );
+        assert!(
+            q.tags
+                .is_none()
+        );
     }
 }
 

--- a/crates/remux-sdks/src/remux/mod.rs
+++ b/crates/remux-sdks/src/remux/mod.rs
@@ -1220,28 +1220,38 @@ pub struct GetItemsQuery {
     #[serde(default, deserialize_with = "deserialize_next_up_date_cutoff")]
     pub next_up_date_cutoff: Option<String>,
     #[serde(
+        deserialize_with = "deserialize_years",
         serialize_with = "serialize_comma_opt",
-        skip_serializing_if = "Option::is_none"
+        skip_serializing_if = "Option::is_none",
+        default
     )]
     pub years: Option<Vec<i64>>,
     #[serde(
+        deserialize_with = "deserialize_genres",
         serialize_with = "serialize_comma_opt",
-        skip_serializing_if = "Option::is_none"
+        skip_serializing_if = "Option::is_none",
+        default
     )]
     pub genres: Option<Vec<String>>,
     #[serde(
+        deserialize_with = "deserialize_genre_ids",
         serialize_with = "serialize_comma_opt",
-        skip_serializing_if = "Option::is_none"
+        skip_serializing_if = "Option::is_none",
+        default
     )]
     pub genre_ids: Option<Vec<String>>,
     #[serde(
+        deserialize_with = "deserialize_official_ratings",
         serialize_with = "serialize_comma_opt",
-        skip_serializing_if = "Option::is_none"
+        skip_serializing_if = "Option::is_none",
+        default
     )]
     pub official_ratings: Option<Vec<String>>,
     #[serde(
+        deserialize_with = "deserialize_tags",
         serialize_with = "serialize_comma_opt",
-        skip_serializing_if = "Option::is_none"
+        skip_serializing_if = "Option::is_none",
+        default
     )]
     pub tags: Option<Vec<String>>,
     #[serde(
@@ -1501,6 +1511,80 @@ where
     deserialize_comma_str(d)
 }
 
+/// Deserialize `Years=2020,2021` into `Vec<i64>` (comma-separated, Jellyfin style).
+pub fn deserialize_years<'de, D>(d: D) -> Result<Option<Vec<i64>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserialize_comma_str(d)
+}
+
+/// Deserialize string filters that Jellyfin clients send pipe-separated.
+/// Jellyfin uses `|` for multi-value genre/rating/tag filters (e.g.
+/// `Genres=Action|Comedy`, `OfficialRatings=PG|R`). We also accept commas so the
+/// field round-trips through our own `serialize_comma_opt` serializer.
+fn deserialize_pipe_comma_str<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Input {
+        Single(String),
+        Multiple(Vec<String>),
+    }
+
+    let input = Option::<Input>::deserialize(deserializer)?;
+    let split_one = |s: &str| {
+        s.split([',', '|'])
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .collect::<Vec<String>>()
+    };
+    let values = match input {
+        Some(Input::Single(s)) => split_one(&s),
+        Some(Input::Multiple(ss)) => ss
+            .iter()
+            .flat_map(|s| split_one(s))
+            .collect(),
+        None => return Ok(None),
+    };
+    Ok(Some(values))
+}
+
+/// `Genres=Action|Comedy` → `vec!["Action", "Comedy"]`.
+pub fn deserialize_genres<'de, D>(d: D) -> Result<Option<Vec<String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserialize_pipe_comma_str(d)
+}
+
+/// `OfficialRatings=PG|R` → `vec!["PG", "R"]`.
+pub fn deserialize_official_ratings<'de, D>(d: D) -> Result<Option<Vec<String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserialize_pipe_comma_str(d)
+}
+
+/// `Tags=Christmas|Halloween` → `vec!["Christmas", "Halloween"]`.
+pub fn deserialize_tags<'de, D>(d: D) -> Result<Option<Vec<String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserialize_pipe_comma_str(d)
+}
+
+/// `GenreIds=id1,id2` → comma-separated string ids (UUIDs may be unresolved yet).
+pub fn deserialize_genre_ids<'de, D>(d: D) -> Result<Option<Vec<String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserialize_pipe_comma_str(d)
+}
+
 pub fn deserialize_uuids<'de, D>(d: D) -> Result<Option<Vec<Uuid>>, D::Error>
 where
     D: Deserializer<'de>,
@@ -1572,6 +1656,71 @@ mod tests {
                 .unwrap_or_default(),
             EmbeddedSubtitleHandling::Burn
         );
+    }
+
+    // --- Filter query deserialization ---
+
+    fn parse_query(q: &str) -> GetItemsQuery {
+        serde_urlencoded::from_str::<GetItemsQuery>(q).unwrap()
+    }
+
+    #[test]
+    fn years_filter_parses_comma_separated() {
+        let q = parse_query("Years=2020,2021&IncludeItemTypes=Movie");
+        assert_eq!(q.years, Some(vec![2020, 2021]));
+    }
+
+    #[test]
+    fn years_filter_single_value() {
+        let q = parse_query("Years=1999");
+        assert_eq!(q.years, Some(vec![1999]));
+    }
+
+    #[test]
+    fn years_filter_skips_garbage_values() {
+        // deserialize_comma_str logs and drops values it cannot parse rather
+        // than failing the whole request.
+        let q = parse_query("Years=2020,notayear,2021");
+        assert_eq!(q.years, Some(vec![2020, 2021]));
+    }
+
+    #[test]
+    fn genres_filter_parses_pipe_separated() {
+        let q = parse_query("Genres=Action|Comedy");
+        assert_eq!(q.genres, Some(vec!["Action".to_string(), "Comedy".to_string()]));
+    }
+
+    #[test]
+    fn genres_filter_also_accepts_comma_separated() {
+        let q = parse_query("Genres=Action,Comedy");
+        assert_eq!(q.genres, Some(vec!["Action".to_string(), "Comedy".to_string()]));
+    }
+
+    #[test]
+    fn official_ratings_filter_parses_pipe() {
+        let q = parse_query("OfficialRatings=PG|R");
+        assert_eq!(
+            q.official_ratings,
+            Some(vec!["PG".to_string(), "R".to_string()])
+        );
+    }
+
+    #[test]
+    fn tags_filter_parses_pipe() {
+        let q = parse_query("Tags=Christmas|Halloween");
+        assert_eq!(
+            q.tags,
+            Some(vec!["Christmas".to_string(), "Halloween".to_string()])
+        );
+    }
+
+    #[test]
+    fn filter_fields_default_to_none_when_absent() {
+        let q = parse_query("IncludeItemTypes=Movie");
+        assert!(q.years.is_none());
+        assert!(q.genres.is_none());
+        assert!(q.official_ratings.is_none());
+        assert!(q.tags.is_none());
     }
 }
 

--- a/crates/remux-sdks/src/remux/mod.rs
+++ b/crates/remux-sdks/src/remux/mod.rs
@@ -1156,21 +1156,21 @@ pub struct GetItemsQuery {
     // #[serde_as(as = "Option<StringWithSeparator::<CommaSeparator, ItemFields>>")]
     //#[serde_as(as = "Option<StringWithSeparator<CommaSeparator, ItemFields>>")]
     #[serde(
-        deserialize_with = "deserialize_fields",
+        deserialize_with = "deserialize_separated_str",
         serialize_with = "serialize_comma_opt",
         skip_serializing_if = "Option::is_none",
         default
     )]
     pub fields: Option<Vec<ItemFields>>,
     #[serde(
-        deserialize_with = "deserialize_media_types",
+        deserialize_with = "deserialize_separated_str",
         serialize_with = "serialize_comma_opt",
         skip_serializing_if = "Option::is_none",
         default
     )]
     pub exclude_item_types: Option<Vec<MediaType>>,
     #[serde(
-        deserialize_with = "deserialize_media_types",
+        deserialize_with = "deserialize_separated_str",
         serialize_with = "serialize_comma_opt",
         skip_serializing_if = "Option::is_none",
         default
@@ -1192,14 +1192,14 @@ pub struct GetItemsQuery {
     //#[serde_as(as = "Option<StringWithSeparator::<CommaSeparator, SortOrder>>")]
     //pub sort_order: Option<SortOrder>,
     #[serde(
-        deserialize_with = "deserialize_sort_by",
+        deserialize_with = "deserialize_separated_str",
         serialize_with = "serialize_comma_opt",
         skip_serializing_if = "Option::is_none",
         default
     )]
     pub sort_by: Option<Vec<ItemSortBy>>,
     #[serde(
-        deserialize_with = "deserialize_sort_order",
+        deserialize_with = "deserialize_separated_str",
         serialize_with = "serialize_comma_opt",
         skip_serializing_if = "Option::is_none",
         default
@@ -1220,42 +1220,42 @@ pub struct GetItemsQuery {
     #[serde(default, deserialize_with = "deserialize_next_up_date_cutoff")]
     pub next_up_date_cutoff: Option<String>,
     #[serde(
-        deserialize_with = "deserialize_years",
+        deserialize_with = "deserialize_separated_str",
         serialize_with = "serialize_comma_opt",
         skip_serializing_if = "Option::is_none",
         default
     )]
     pub years: Option<Vec<i64>>,
     #[serde(
-        deserialize_with = "deserialize_genres",
+        deserialize_with = "deserialize_separated_str",
         serialize_with = "serialize_comma_opt",
         skip_serializing_if = "Option::is_none",
         default
     )]
     pub genres: Option<Vec<String>>,
     #[serde(
-        deserialize_with = "deserialize_genre_ids",
+        deserialize_with = "deserialize_separated_str",
         serialize_with = "serialize_comma_opt",
         skip_serializing_if = "Option::is_none",
         default
     )]
     pub genre_ids: Option<Vec<String>>,
     #[serde(
-        deserialize_with = "deserialize_official_ratings",
+        deserialize_with = "deserialize_separated_str",
         serialize_with = "serialize_comma_opt",
         skip_serializing_if = "Option::is_none",
         default
     )]
     pub official_ratings: Option<Vec<String>>,
     #[serde(
-        deserialize_with = "deserialize_tags",
+        deserialize_with = "deserialize_separated_str",
         serialize_with = "serialize_comma_opt",
         skip_serializing_if = "Option::is_none",
         default
     )]
     pub tags: Option<Vec<String>>,
     #[serde(
-        deserialize_with = "deserialize_media_types",
+        deserialize_with = "deserialize_separated_str",
         serialize_with = "serialize_comma_opt",
         skip_serializing_if = "Option::is_none",
         default
@@ -1293,35 +1293,35 @@ pub struct GetItemsQuery {
     pub exclude_artist_ids: Option<Vec<String>>,
     #[serde(
         default,
-        deserialize_with = "deserialize_uuids",
+        deserialize_with = "deserialize_separated_str",
         serialize_with = "serialize_comma_opt",
         skip_serializing_if = "Option::is_none"
     )]
     pub artist_ids: Option<Vec<Uuid>>,
     #[serde(
         default,
-        deserialize_with = "deserialize_uuids",
+        deserialize_with = "deserialize_separated_str",
         serialize_with = "serialize_comma_opt",
         skip_serializing_if = "Option::is_none"
     )]
     pub contributing_artist_ids: Option<Vec<Uuid>>,
     #[serde(
         default,
-        deserialize_with = "deserialize_uuids",
+        deserialize_with = "deserialize_separated_str",
         serialize_with = "serialize_comma_opt",
         skip_serializing_if = "Option::is_none"
     )]
     pub album_artist_ids: Option<Vec<Uuid>>,
     #[serde(
         default,
-        deserialize_with = "deserialize_uuids",
+        deserialize_with = "deserialize_separated_str",
         serialize_with = "serialize_comma_opt",
         skip_serializing_if = "Option::is_none"
     )]
     pub album_ids: Option<Vec<Uuid>>,
     #[serde(
         default,
-        deserialize_with = "deserialize_uuids",
+        deserialize_with = "deserialize_separated_str",
         serialize_with = "serialize_comma_opt",
         skip_serializing_if = "Option::is_none"
     )]
@@ -1435,7 +1435,10 @@ where
 
 /// Generic helper: deserializes an optional comma-separated (or repeated) query-param
 /// value into `Option<Vec<T>>` for any `T: FromStr`.
-fn deserialize_comma_str<'de, D, T>(deserializer: D) -> Result<Option<Vec<T>>, D::Error>
+/// Deserialize a comma- or pipe-separated list into `Vec<T>`.
+pub fn deserialize_separated_str<'de, D, T>(
+    deserializer: D,
+) -> Result<Option<Vec<T>>, D::Error>
 where
     D: Deserializer<'de>,
     T: FromStr,
@@ -1450,99 +1453,18 @@ where
 
     let input = Option::<Input>::deserialize(deserializer)?;
     let type_name = std::any::type_name::<T>();
-
-    let values = match input {
-        Some(Input::Single(s)) => s
-            .split(',')
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .filter_map(|s| match s.parse::<T>() {
-                Ok(v) => Some(v),
-                Err(e) => {
-                    tracing::warn!(value = %s, error = %e, type_name, "parse failed, ignoring value");
-                    None
-                }
-            })
-            .collect(),
-        Some(Input::Multiple(ss)) => ss
-            .iter()
-            .flat_map(|s| s.split(','))
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .filter_map(|s| match s.parse::<T>() {
-                Ok(v) => Some(v),
-                Err(e) => {
-                    tracing::warn!(value = %s, error = %e, type_name, "parse failed, ignoring value");
-                    None
-                }
-            })
-            .collect(),
-        None => return Ok(None),
-    };
-
-    Ok(Some(values))
-}
-
-pub fn deserialize_fields<'de, D>(d: D) -> Result<Option<Vec<ItemFields>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    deserialize_comma_str(d)
-}
-
-pub fn deserialize_media_types<'de, D>(d: D) -> Result<Option<Vec<MediaType>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    deserialize_comma_str(d)
-}
-
-pub fn deserialize_sort_by<'de, D>(d: D) -> Result<Option<Vec<ItemSortBy>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    deserialize_comma_str(d)
-}
-
-pub fn deserialize_sort_order<'de, D>(d: D) -> Result<Option<Vec<SortOrder>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    deserialize_comma_str(d)
-}
-
-/// Deserialize `Years=2020,2021` into `Vec<i64>` (comma-separated, Jellyfin style).
-pub fn deserialize_years<'de, D>(d: D) -> Result<Option<Vec<i64>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    deserialize_comma_str(d)
-}
-
-/// Deserialize string filters that Jellyfin clients send pipe-separated.
-/// Jellyfin uses `|` for multi-value genre/rating/tag filters (e.g.
-/// `Genres=Action|Comedy`, `OfficialRatings=PG|R`). We also accept commas so the
-/// field round-trips through our own `serialize_comma_opt` serializer.
-fn deserialize_pipe_comma_str<'de, D>(
-    deserializer: D,
-) -> Result<Option<Vec<String>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum Input {
-        Single(String),
-        Multiple(Vec<String>),
-    }
-
-    let input = Option::<Input>::deserialize(deserializer)?;
     let split_one = |s: &str| {
         s.split([',', '|'])
             .map(str::trim)
             .filter(|s| !s.is_empty())
-            .map(|s| s.to_string())
-            .collect::<Vec<String>>()
+            .filter_map(|s| match s.parse::<T>() {
+                Ok(v) => Some(v),
+                Err(e) => {
+                    tracing::warn!(value = %s, error = %e, type_name, "parse failed, ignoring value");
+                    None
+                }
+            })
+            .collect::<Vec<T>>()
     };
     let values = match input {
         Some(Input::Single(s)) => split_one(&s),
@@ -1552,48 +1474,8 @@ where
             .collect(),
         None => return Ok(None),
     };
+
     Ok(Some(values))
-}
-
-/// `Genres=Action|Comedy` → `vec!["Action", "Comedy"]`.
-pub fn deserialize_genres<'de, D>(d: D) -> Result<Option<Vec<String>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    deserialize_pipe_comma_str(d)
-}
-
-/// `OfficialRatings=PG|R` → `vec!["PG", "R"]`.
-pub fn deserialize_official_ratings<'de, D>(
-    d: D,
-) -> Result<Option<Vec<String>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    deserialize_pipe_comma_str(d)
-}
-
-/// `Tags=Christmas|Halloween` → `vec!["Christmas", "Halloween"]`.
-pub fn deserialize_tags<'de, D>(d: D) -> Result<Option<Vec<String>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    deserialize_pipe_comma_str(d)
-}
-
-/// `GenreIds=id1,id2` → comma-separated string ids (UUIDs may be unresolved yet).
-pub fn deserialize_genre_ids<'de, D>(d: D) -> Result<Option<Vec<String>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    deserialize_pipe_comma_str(d)
-}
-
-pub fn deserialize_uuids<'de, D>(d: D) -> Result<Option<Vec<Uuid>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    deserialize_comma_str(d)
 }
 
 #[cfg(test)]
@@ -1662,8 +1544,6 @@ mod tests {
         );
     }
 
-    // --- Filter query deserialization ---
-
     fn parse_query(q: &str) -> GetItemsQuery {
         serde_urlencoded::from_str::<GetItemsQuery>(q).unwrap()
     }
@@ -1682,8 +1562,6 @@ mod tests {
 
     #[test]
     fn years_filter_skips_garbage_values() {
-        // deserialize_comma_str logs and drops values it cannot parse rather
-        // than failing the whole request.
         let q = parse_query("Years=2020,notayear,2021");
         assert_eq!(q.years, Some(vec![2020, 2021]));
     }
@@ -4030,7 +3908,7 @@ pub struct SearchHintsQuery {
     pub start_index: Option<u32>,
     pub limit: Option<u32>,
     pub user_id: Option<Uuid>,
-    #[serde(deserialize_with = "deserialize_media_types", default)]
+    #[serde(deserialize_with = "deserialize_separated_str", default)]
     pub include_item_types: Option<Vec<MediaType>>,
 }
 

--- a/crates/remux-server/src/lib.rs
+++ b/crates/remux-server/src/lib.rs
@@ -541,11 +541,9 @@ pub fn rewrite_request_uri<B>(mut req: http::Request<B>) -> http::Request<B> {
             || lower_path.starts_with("/mediasegments/")
             || lower_path.starts_with("/sessions/"));
 
-    // Smart-lowercase: lowercase route-keyword segments (Sessions, Items, …) but
-    // leave path-parameter values (UUIDs, base64 device/session ids, …) untouched,
-    // since they are looked up case-sensitively. A segment is lowercased when it
-    // is purely alphabetic, or when it matches a known keyword that contains digits
-    // (Filters2, Hls1).
+    // Lowercase route keywords, but never case-sensitive path params (UUIDs,
+    // base64 device/session ids). Pure-alpha segments are keywords; a few carry
+    // digits (Filters2, Hls1) and are matched explicitly.
     static DIGIT_KEYWORDS: &[&str] = &["filters2", "hls1"];
     let smart_lower_path: String = path
         .split('/')
@@ -709,8 +707,6 @@ mod rewrite_uri_tests {
 
     #[test]
     fn preserves_alphanumeric_session_ids() {
-        // Device/session ids in /Sessions/{sessionid} are case-sensitive and must
-        // not be lowercased, even though they may be purely alphanumeric.
         let did =
             "TW96aWxsYS81LjAgV2luNjQ7eDY0O3J2OjE1Mi4wKUdlY2tvfDE3ODQ0MTE1NTc2MDMNdQ";
         assert_eq!(
@@ -725,9 +721,9 @@ mod rewrite_uri_tests {
 
     #[test]
     fn leaves_base64_device_ids_with_special_chars_alone() {
-        let path = "/Sessions/Play/YWJjMTIz|abc";
+        let path = "/Sessions/Play/YWJjMTIz%7Cabc";
         let rewritten = rewrite(path);
         assert!(rewritten.starts_with("/sessions/play/"));
-        assert!(rewritten.contains("YWJjMTIz|abc"));
+        assert!(rewritten.contains("YWJjMTIz%7Cabc"));
     }
 }

--- a/crates/remux-server/src/lib.rs
+++ b/crates/remux-server/src/lib.rs
@@ -541,16 +541,22 @@ pub fn rewrite_request_uri<B>(mut req: http::Request<B>) -> http::Request<B> {
             || lower_path.starts_with("/mediasegments/")
             || lower_path.starts_with("/sessions/"));
 
-    // Smart-lowercase: only lowercase purely-alphabetic segments (route
-    // keywords like "Sessions", "Playing"). Path parameter values — UUIDs,
-    // base64 device IDs — contain digits and are preserved unchanged.
+    // Smart-lowercase: lowercase route-keyword segments (Sessions, Items, …) but
+    // leave path-parameter values (UUIDs, base64 device/session ids, …) untouched,
+    // since they are looked up case-sensitively. A segment is lowercased when it
+    // is purely alphabetic, or when it matches a known keyword that contains digits
+    // (Filters2, Hls1).
+    static DIGIT_KEYWORDS: &[&str] = &["filters2", "hls1"];
     let smart_lower_path: String = path
         .split('/')
         .map(|seg| {
-            if seg
+            let is_alpha = seg
                 .chars()
-                .all(|c| c.is_ascii_alphabetic())
-            {
+                .all(|c| c.is_ascii_alphabetic());
+            let is_known_digit_keyword = DIGIT_KEYWORDS
+                .iter()
+                .any(|kw| seg.eq_ignore_ascii_case(kw));
+            if is_alpha || is_known_digit_keyword {
                 seg.to_ascii_lowercase()
             } else {
                 seg.to_string()
@@ -660,3 +666,67 @@ async fn handle_static_404(req: Request<Body>) -> ApiResult<impl IntoResponse> {
 
 #[cfg(test)]
 pub mod integration_test;
+
+#[cfg(test)]
+mod rewrite_uri_tests {
+    use super::rewrite_request_uri;
+
+    fn rewrite(path: &str) -> String {
+        let req = http::Request::builder()
+            .method("GET")
+            .uri(path)
+            .body(())
+            .unwrap();
+        rewrite_request_uri(req)
+            .uri()
+            .path()
+            .to_string()
+    }
+
+    #[test]
+    fn lowercases_alpha_keyword_segments() {
+        assert_eq!(rewrite("/Items/Sessions"), "/items/sessions");
+        assert_eq!(rewrite("/Genres"), "/genres");
+    }
+
+    #[test]
+    fn lowercases_known_digit_keywords() {
+        assert_eq!(rewrite("/Items/Filters2"), "/items/filters2");
+        assert_eq!(rewrite("/Hls1"), "/hls1");
+    }
+
+    #[test]
+    fn preserves_uuid_param_values() {
+        assert_eq!(
+            rewrite("/Items/f27caa37-e514-2225-cced-ed48f6553502"),
+            "/items/f27caa37-e514-2225-cced-ed48f6553502"
+        );
+        assert_eq!(
+            rewrite("/Items/F27CAA37-E514-2225-CCED-ED48F6553502"),
+            "/items/F27CAA37-E514-2225-CCED-ED48F6553502"
+        );
+    }
+
+    #[test]
+    fn preserves_alphanumeric_session_ids() {
+        // Device/session ids in /Sessions/{sessionid} are case-sensitive and must
+        // not be lowercased, even though they may be purely alphanumeric.
+        let did = "TW96aWxsYS81LjAgV2luNjQ7eDY0O3J2OjE1Mi4wKUdlY2tvfDE3ODQ0MTE1NTc2MDMNdQ";
+        assert_eq!(
+            rewrite(&format!("/Sessions/{did}/Command")),
+            format!("/sessions/{did}/command")
+        );
+        assert_eq!(
+            rewrite("/Sessions/MyDevice123/Command"),
+            "/sessions/MyDevice123/command"
+        );
+    }
+
+    #[test]
+    fn leaves_base64_device_ids_with_special_chars_alone() {
+        let path = "/Sessions/Play/YWJjMTIz|abc";
+        let rewritten = rewrite(path);
+        assert!(rewritten.starts_with("/sessions/play/"));
+        assert!(rewritten.contains("YWJjMTIz|abc"));
+    }
+}

--- a/crates/remux-server/src/lib.rs
+++ b/crates/remux-server/src/lib.rs
@@ -711,7 +711,8 @@ mod rewrite_uri_tests {
     fn preserves_alphanumeric_session_ids() {
         // Device/session ids in /Sessions/{sessionid} are case-sensitive and must
         // not be lowercased, even though they may be purely alphanumeric.
-        let did = "TW96aWxsYS81LjAgV2luNjQ7eDY0O3J2OjE1Mi4wKUdlY2tvfDE3ODQ0MTE1NTc2MDMNdQ";
+        let did =
+            "TW96aWxsYS81LjAgV2luNjQ7eDY0O3J2OjE1Mi4wKUdlY2tvfDE3ODQ0MTE1NTc2MDMNdQ";
         assert_eq!(
             rewrite(&format!("/Sessions/{did}/Command")),
             format!("/sessions/{did}/command")

--- a/crates/remux-server/src/lib.rs
+++ b/crates/remux-server/src/lib.rs
@@ -541,20 +541,13 @@ pub fn rewrite_request_uri<B>(mut req: http::Request<B>) -> http::Request<B> {
             || lower_path.starts_with("/mediasegments/")
             || lower_path.starts_with("/sessions/"));
 
-    // Lowercase route keywords, but never case-sensitive path params (UUIDs,
-    // base64 device/session ids). Pure-alpha segments are keywords; a few carry
-    // digits (Filters2, Hls1) and are matched explicitly.
-    static DIGIT_KEYWORDS: &[&str] = &["filters2", "hls1"];
     let smart_lower_path: String = path
         .split('/')
         .map(|seg| {
-            let is_alpha = seg
+            if seg
                 .chars()
-                .all(|c| c.is_ascii_alphabetic());
-            let is_known_digit_keyword = DIGIT_KEYWORDS
-                .iter()
-                .any(|kw| seg.eq_ignore_ascii_case(kw));
-            if is_alpha || is_known_digit_keyword {
+                .all(|c| c.is_ascii_alphanumeric())
+            {
                 seg.to_ascii_lowercase()
             } else {
                 seg.to_string()
@@ -688,7 +681,7 @@ mod rewrite_uri_tests {
     }
 
     #[test]
-    fn lowercases_known_digit_keywords() {
+    fn lowercases_keyword_with_digits() {
         assert_eq!(rewrite("/Items/Filters2"), "/items/filters2");
         assert_eq!(rewrite("/Hls1"), "/hls1");
     }
@@ -706,21 +699,7 @@ mod rewrite_uri_tests {
     }
 
     #[test]
-    fn preserves_alphanumeric_session_ids() {
-        let did =
-            "TW96aWxsYS81LjAgV2luNjQ7eDY0O3J2OjE1Mi4wKUdlY2tvfDE3ODQ0MTE1NTc2MDMNdQ";
-        assert_eq!(
-            rewrite(&format!("/Sessions/{did}/Command")),
-            format!("/sessions/{did}/command")
-        );
-        assert_eq!(
-            rewrite("/Sessions/MyDevice123/Command"),
-            "/sessions/MyDevice123/command"
-        );
-    }
-
-    #[test]
-    fn leaves_base64_device_ids_with_special_chars_alone() {
+    fn leaves_special_char_device_ids_alone() {
         let path = "/Sessions/Play/YWJjMTIz%7Cabc";
         let rewritten = rewrite(path);
         assert!(rewritten.starts_with("/sessions/play/"));


### PR DESCRIPTION
Connected the Swiparr client to remux and noticed that applying filters (by year, genre, etc.) caused everything to crash with an error. Dug into it and found two issues, both related to compatibility with the public Jellyfin API.

1. GET /Items/Filters2 → 400. Clients send paths in TitleCase, while remux routes use lowercase. Case conversion was skipping segments containing digits, so Filters2 was not being converted to filters2. As a result, the route fell back to /items/{id} and attempted to parse the word "Filters2" as a UUID. Now, purely alphabetical segments along with known keywords containing digits (like Filters2 and Hls1) are converted to lowercase. UUIDs and device/session IDs remain untouched.

2. GET ?Years=2020,2021 → 400. The years, genres, official_ratings, and tags fields were unable to parse string values into arrays. Added deserializers: comma-separated for years, and pipe-separated (|) for genres, ratings, and tags (matching Jellyfin's implementation).

Tested on a live setup with remux + Swiparr: filters are working properly, and basic requests haven't broken. 
And added 13 unit tests.

Drafted with AI, reviewed and tested by me.