### PR TITLE
fix: stremio custom type anime catalogs

### DIFF
--- a/crates/remux-sdks/src/stremio/mod.rs
+++ b/crates/remux-sdks/src/stremio/mod.rs
@@ -633,11 +633,15 @@ where
             if t.is_empty() {
                 Ok(None)
             } else {
-                let std_duration = parse_duration_lossy(t).map_err(D::Error::custom)?;
-
-                Ok(Some(
-                    Duration::from_std(std_duration).map_err(D::Error::custom)?,
-                ))
+                match parse_duration_lossy(t) {
+                    Ok(std_duration) => Ok(Some(
+                        Duration::from_std(std_duration).map_err(D::Error::custom)?,
+                    )),
+                    // Some addons (e.g. fankai) put a status string like "En cours"
+                    // in the runtime field instead of a duration. Don't fail the
+                    // whole catalog over one unparseable runtime.
+                    Err(_) => Ok(None),
+                }
             }
         }
     }
@@ -1047,5 +1051,16 @@ mod tests {
         let meta: Meta = serde_json::from_str(json).unwrap();
         assert_eq!(meta.genre, Some(vec!["En cours".to_string()]));
         assert_eq!(meta.genres, Some(vec!["En cours".to_string()]));
+    }
+
+    #[test]
+    fn meta_runtime_ignores_unparseable_status_string() {
+        let json = r#"{
+            "id": "fankai:123",
+            "type": "series",
+            "runtime": "En cours"
+        }"#;
+        let meta: Meta = serde_json::from_str(json).unwrap();
+        assert_eq!(meta.runtime, None);
     }
 }

--- a/crates/remux-sdks/src/stremio/mod.rs
+++ b/crates/remux-sdks/src/stremio/mod.rs
@@ -408,6 +408,7 @@ pub struct Meta {
     )]
     pub writer: Option<Vec<String>>,
     pub description: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_option_string_or_array")]
     pub genre: Option<Vec<String>>,
     #[serde(
         default,
@@ -440,6 +441,7 @@ pub struct Meta {
     )]
     pub popularity: Option<f64>,
     pub id: String,
+    #[serde(default, deserialize_with = "deserialize_option_string_or_array")]
     pub genres: Option<Vec<String>>,
     // pub season_posters: Option<Vec<String>>,
     // this can be a range 2012-2015
@@ -986,7 +988,7 @@ pub fn client(base: &str) -> Result<RestClient, url::ParseError> {
 
 #[cfg(test)]
 mod tests {
-    use super::{MediaType, parse_duration_lossy};
+    use super::{MediaType, Meta, parse_duration_lossy};
     use std::time::Duration;
 
     #[test]
@@ -1032,5 +1034,18 @@ mod tests {
         let kind = MediaType::Unknown("my_custom_type".into());
         let path = format!("/meta/{}/some_id.json", kind);
         assert_eq!(path, "/meta/my_custom_type/some_id.json");
+    }
+
+    #[test]
+    fn meta_genre_and_genres_accept_bare_string() {
+        let json = r#"{
+            "id": "fankai:123",
+            "type": "series",
+            "genre": "En cours",
+            "genres": "En cours"
+        }"#;
+        let meta: Meta = serde_json::from_str(json).unwrap();
+        assert_eq!(meta.genre, Some(vec!["En cours".to_string()]));
+        assert_eq!(meta.genres, Some(vec!["En cours".to_string()]));
     }
 }

--- a/crates/remux-server/src/addons/mod.rs
+++ b/crates/remux-server/src/addons/mod.rs
@@ -984,6 +984,40 @@ fn user_scoped(runtime: &AddonRuntime, override_ids: Option<&[Uuid]>) -> bool {
     }
 }
 
+/// Returns `None` for a manifest type with no recognized `MediaKind`
+/// equivalent (e.g. fankai's "anime") instead of collapsing it to `Movie`
+/// like the default `From<stremio::MediaType>` impl does — that would make
+/// `supports_type` believe an anime/series-only addon serves only movies,
+/// excluding it from `addons_for::<dyn StreamAddon>` for every
+/// Series/Season/Episode lookup.
+fn recognized_manifest_media_kind(
+    t: sdks::stremio::MediaType,
+) -> Option<sdks::remux::MediaKind> {
+    use sdks::remux::MediaKind as MK;
+    use sdks::stremio::MediaType as MT;
+    Some(match t {
+        MT::Movie => MK::Movie,
+        MT::Series => MK::Series,
+        MT::Tv | MT::Channel => MK::TvChannel,
+        MT::Album => MK::Album,
+        MT::Artist => MK::Artist,
+        MT::Track => MK::Track,
+        MT::Events => MK::TvProgram,
+        MT::Unknown(s) => match s.as_str() {
+            "episode" => MK::Episode,
+            "season" => MK::Season,
+            "person" => MK::Person,
+            "genre" => MK::Genre,
+            "studio" => MK::Studio,
+            "collection" => MK::Collection,
+            "folder" => MK::Folder,
+            "stream" => MK::Stream,
+            "playlist" => MK::Playlist,
+            _ => return None,
+        },
+    })
+}
+
 fn kind_in_type_list(kind: &db::MediaKind, list: &[db::MediaKind]) -> bool {
     list.contains(kind)
         || (matches!(kind, db::MediaKind::Episode | db::MediaKind::Season)
@@ -1242,7 +1276,7 @@ impl AddonService {
                                     caps.metadata
                                         .supported_types = raw_types
                                         .into_iter()
-                                        .map(Into::into)
+                                        .filter_map(recognized_manifest_media_kind)
                                         .collect();
                                 }
                             }
@@ -3020,6 +3054,26 @@ mod tests {
                 .as_deref(),
             Some("Provider Overview"),
             "unlocked Overview must still be updated"
+        );
+    }
+
+    #[test]
+    fn recognized_manifest_media_kind_drops_unrecognized_custom_type() {
+        assert_eq!(
+            recognized_manifest_media_kind(sdks::stremio::MediaType::Unknown(
+                "anime".to_string()
+            )),
+            None
+        );
+        assert_eq!(
+            recognized_manifest_media_kind(sdks::stremio::MediaType::Series),
+            Some(sdks::remux::MediaKind::Series)
+        );
+        assert_eq!(
+            recognized_manifest_media_kind(sdks::stremio::MediaType::Unknown(
+                "episode".to_string()
+            )),
+            Some(sdks::remux::MediaKind::Episode)
         );
     }
 }

--- a/crates/remux-server/src/addons/stremio.rs
+++ b/crates/remux-server/src/addons/stremio.rs
@@ -436,6 +436,10 @@ impl TreeAddon for StremioAddon {
                         .external_ids
                         .series_custom_stremio_id
                         .clone(),
+                    custom_stremio_type: root
+                        .external_ids
+                        .custom_stremio_type
+                        .clone(),
                     ..Default::default()
                 };
                 let series_id = root
@@ -648,6 +652,57 @@ fn is_404(e: &anyhow::Error) -> bool {
 // Meta helpers
 // ---------------------------------------------------------------------------
 
+/// Finds a working alternate Stremio type for `meta_id` by consulting the
+/// addon's own manifest, for the case where `tried_type` (derived generically
+/// from `MediaKind`) 404s. Only considers `meta` resources whose `idPrefixes`
+/// match `meta_id` (or which have no prefix restriction), and probes each
+/// candidate type with a real request — the manifest can list types that
+/// don't apply to this specific ID, so a match here isn't guaranteed either.
+/// Returns the successful fetch directly to avoid a redundant second request.
+async fn manifest_meta_type_fallback(
+    svc: &stremio_service::StremioService,
+    tried_type: &sdks::stremio::MediaType,
+    meta_id: &str,
+) -> Option<sdks::stremio::Meta> {
+    let manifest = svc
+        .get_manifest()
+        .await
+        .ok()?;
+    let tried = tried_type.to_string();
+    let candidates: Vec<String> = manifest
+        .resources
+        .into_iter()
+        .filter_map(|r| match r {
+            sdks::stremio::Resource::Detailed(r) if r.name == ResourceType::Meta => {
+                let prefix_ok = r
+                    .id_prefixes
+                    .as_ref()
+                    .map(|prefixes| {
+                        prefixes
+                            .iter()
+                            .any(|p| meta_id.starts_with(p.as_str()))
+                    })
+                    .unwrap_or(true);
+                prefix_ok.then_some(r.types)
+            }
+            _ => None,
+        })
+        .flatten()
+        .filter(|t| t != &tried)
+        .collect();
+
+    for candidate in candidates {
+        let alt_type = sdks::stremio::MediaType::Unknown(candidate);
+        if let Ok(meta) = svc
+            .get_meta(alt_type, meta_id.to_string())
+            .await
+        {
+            return Some(meta);
+        }
+    }
+    None
+}
+
 /// Fetch the raw Stremio `Meta` for `media`, storing it in `cache` keyed by
 /// the series-level lookup id. Returns the cached `Arc` immediately if present.
 async fn fetch_and_cache_meta(
@@ -680,7 +735,9 @@ async fn fetch_and_cache_meta(
             .external_ids
             .series_imdb
             .is_none();
-    let media_type = sdks::stremio::MediaType::from(&media.kind);
+    let media_type = media
+        .external_ids
+        .stremio_media_type(&media.kind);
     let meta = if let Some(stored) = ctx
         .store
         .get::<sdks::stremio::Meta>(
@@ -695,6 +752,25 @@ async fn fetch_and_cache_meta(
             .await
         {
             Ok(m) => m,
+            // Custom-ID items (no IMDB/TMDB) have no `MediaKind`-derived type that's
+            // guaranteed correct: a DB row imported before `custom_stremio_type` was
+            // tracked (or a season/episode that never inherited it) falls back to a
+            // generic type that may not match the addon's own non-standard one (e.g.
+            // "anime"). Ask the addon's manifest what type(s) it actually serves for
+            // this ID and retry, rather than failing permanently.
+            Err(e)
+                if is_404(&e)
+                    && is_custom
+                    && media
+                        .external_ids
+                        .custom_stremio_type
+                        .is_none() =>
+            {
+                match manifest_meta_type_fallback(svc, &media_type, &meta_id).await {
+                    Some(m) => m,
+                    None => return Err(e),
+                }
+            }
             Err(e) if is_404(&e) && !is_custom => {
                 let tmdb_id = media
                     .external_ids
@@ -792,6 +868,10 @@ async fn stremio_meta_fetch(
                     .external_ids
                     .series_custom_stremio_id
                     .clone(),
+                custom_stremio_type: media
+                    .external_ids
+                    .custom_stremio_type
+                    .clone(),
                 ..Default::default()
             };
             let seasons =
@@ -823,6 +903,10 @@ async fn stremio_meta_fetch(
                 custom_stremio_id: media
                     .external_ids
                     .series_custom_stremio_id
+                    .clone(),
+                custom_stremio_type: media
+                    .external_ids
+                    .custom_stremio_type
                     .clone(),
                 ..Default::default()
             };
@@ -1251,7 +1335,9 @@ async fn stremio_streams(
                 .series_tmdb
                 .map(|tid| format!("tmdb:{}:{}:{}", tid, season, episode));
             (
-                sdks::stremio::MediaType::Series,
+                media
+                    .external_ids
+                    .stremio_media_type(&media.kind),
                 format!("{}:{}:{}", series_id, season, episode),
                 tmdb_fb,
             )
@@ -1299,7 +1385,13 @@ async fn stremio_streams(
                 .external_ids
                 .tmdb
                 .map(|tid| format!("tmdb:{}", tid));
-            (sdks::stremio::MediaType::from(&media.kind), id, tmdb_fb)
+            (
+                media
+                    .external_ids
+                    .stremio_media_type(&media.kind),
+                id,
+                tmdb_fb,
+            )
         }
     };
 
@@ -1459,4 +1551,120 @@ async fn stremio_streams(
             })
         })
         .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mock_manifest(server: &httpmock::MockServer) {
+        server.mock(|when, then| {
+            when.path("/manifest.json");
+            then.status(200)
+                .json_body(serde_json::json!({
+                    "id": "fankai-test",
+                    "name": "Fankai",
+                    "version": "1.0.0",
+                    "resources": [
+                        "catalog",
+                        {"name": "meta", "types": ["anime"], "idPrefixes": ["fk"]}
+                    ],
+                    "types": ["anime"],
+                    "catalogs": []
+                }));
+        });
+    }
+
+    #[tokio::test]
+    async fn manifest_meta_type_fallback_retries_with_addon_declared_type() {
+        let server = httpmock::MockServer::start();
+        mock_manifest(&server);
+        let series_attempt = server.mock(|when, then| {
+            when.path("/meta/series/fk:27.json");
+            then.status(404);
+        });
+        let anime_attempt = server.mock(|when, then| {
+            when.path("/meta/anime/fk:27.json");
+            then.status(200)
+                .json_body(serde_json::json!({
+                    "meta": {"id": "fk:27", "type": "anime", "name": "Bleach Yabai"}
+                }));
+        });
+
+        let svc = stremio_service::StremioService::from_url(&server.base_url())
+            .unwrap();
+
+        // Confirm the generic type really does 404 first.
+        let direct = svc
+            .get_meta(sdks::stremio::MediaType::Series, "fk:27".to_string())
+            .await;
+        assert!(direct.is_err());
+        series_attempt.assert();
+
+        let meta = manifest_meta_type_fallback(
+            &svc,
+            &sdks::stremio::MediaType::Series,
+            "fk:27",
+        )
+        .await;
+
+        assert!(
+            meta.is_some(),
+            "fallback must find the addon's declared \"anime\" type"
+        );
+        assert_eq!(
+            meta.unwrap()
+                .get_name(),
+            Some("Bleach Yabai".to_string())
+        );
+        anime_attempt.assert();
+    }
+
+    #[tokio::test]
+    async fn manifest_meta_type_fallback_none_when_no_type_works() {
+        let server = httpmock::MockServer::start();
+        mock_manifest(&server);
+        server.mock(|when, then| {
+            when.path("/meta/anime/fk:999.json");
+            then.status(404);
+        });
+
+        let svc = stremio_service::StremioService::from_url(&server.base_url())
+            .unwrap();
+        let meta = manifest_meta_type_fallback(
+            &svc,
+            &sdks::stremio::MediaType::Series,
+            "fk:999",
+        )
+        .await;
+
+        assert!(meta.is_none());
+    }
+
+    #[tokio::test]
+    async fn manifest_meta_type_fallback_skips_non_matching_prefix() {
+        let server = httpmock::MockServer::start();
+        mock_manifest(&server);
+        // "tt" is not covered by fankai's declared idPrefixes (["fk"]) — the
+        // fallback must not even attempt the "anime" type for it.
+        let anime_attempt = server.mock(|when, then| {
+            when.path("/meta/anime/tt1234567.json");
+            then.status(200)
+                .json_body(serde_json::json!({
+                    "meta": {"id": "tt1234567", "type": "anime", "name": "Should Not Match"}
+                }));
+        });
+
+        let svc = stremio_service::StremioService::from_url(&server.base_url())
+            .unwrap();
+        let meta = manifest_meta_type_fallback(
+            &svc,
+            &sdks::stremio::MediaType::Series,
+            "tt1234567",
+        )
+        .await;
+
+        assert!(meta.is_none());
+        anime_attempt.assert_hits(0);
+    }
 }

--- a/crates/remux-server/src/addons/stremio.rs
+++ b/crates/remux-server/src/addons/stremio.rs
@@ -1315,15 +1315,6 @@ async fn stremio_streams(
 ) -> Result<Vec<crate::stream::StreamInfo>> {
     let (media_type, id, tmdb_fallback_id) = match media.kind {
         db::MediaKind::Episode => {
-            let series_id: String = media
-                .external_ids
-                .series_imdb
-                .as_deref()
-                .map(|s| s.to_string())
-                .or_else(|| media.external_ids.series_custom_stremio_id.clone())
-                .ok_or_else(|| {
-                    anyhow!("episode has no series_imdb or series_custom_stremio_id for stream lookup")
-                })?;
             let season = media
                 .parent_idx
                 .unwrap_or(1);
@@ -1334,11 +1325,33 @@ async fn stremio_streams(
                 .external_ids
                 .series_tmdb
                 .map(|tid| format!("tmdb:{}:{}:{}", tid, season, episode));
+            // Prefer the addon's own video id (captured from the series meta's
+            // `videos[].id`) over reconstructing "{series}:{season}:{episode}" —
+            // that composite form is only a convention for series-type addons,
+            // not guaranteed for custom types. Fall back to reconstruction for
+            // episodes stored before this field was captured.
+            let id = media
+                .external_ids
+                .custom_stremio_id
+                .clone()
+                .ok_or(())
+                .or_else(|_| {
+                    media
+                        .external_ids
+                        .series_imdb
+                        .as_deref()
+                        .map(|s| s.to_string())
+                        .or_else(|| media.external_ids.series_custom_stremio_id.clone())
+                        .map(|series_id| format!("{}:{}:{}", series_id, season, episode))
+                        .ok_or_else(|| {
+                            anyhow!("episode has no series_imdb or series_custom_stremio_id for stream lookup")
+                        })
+                })?;
             (
                 media
                     .external_ids
                     .stremio_media_type(&media.kind),
-                format!("{}:{}:{}", series_id, season, episode),
+                id,
                 tmdb_fb,
             )
         }
@@ -1591,8 +1604,8 @@ mod tests {
                 }));
         });
 
-        let svc = stremio_service::StremioService::from_url(&server.base_url())
-            .unwrap();
+        let svc =
+            stremio_service::StremioService::from_url(&server.base_url()).unwrap();
 
         // Confirm the generic type really does 404 first.
         let direct = svc
@@ -1629,8 +1642,8 @@ mod tests {
             then.status(404);
         });
 
-        let svc = stremio_service::StremioService::from_url(&server.base_url())
-            .unwrap();
+        let svc =
+            stremio_service::StremioService::from_url(&server.base_url()).unwrap();
         let meta = manifest_meta_type_fallback(
             &svc,
             &sdks::stremio::MediaType::Series,
@@ -1655,8 +1668,8 @@ mod tests {
                 }));
         });
 
-        let svc = stremio_service::StremioService::from_url(&server.base_url())
-            .unwrap();
+        let svc =
+            stremio_service::StremioService::from_url(&server.base_url()).unwrap();
         let meta = manifest_meta_type_fallback(
             &svc,
             &sdks::stremio::MediaType::Series,
@@ -1666,5 +1679,73 @@ mod tests {
 
         assert!(meta.is_none());
         anime_attempt.assert_hits(0);
+    }
+
+    fn episode_media(external_ids: db::ExternalIds) -> db::Media {
+        db::Media {
+            kind: db::MediaKind::Episode,
+            parent_idx: Some(1),
+            idx: Some(1),
+            external_ids,
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn stremio_streams_prefers_captured_video_id_over_reconstruction() {
+        let server = httpmock::MockServer::start();
+        let reconstructed = server.mock(|when, then| {
+            when.path("/stream/anime/fk:27:1:1.json");
+            then.status(404);
+        });
+        let captured = server.mock(|when, then| {
+            when.path("/stream/anime/fk-ep-1.json");
+            then.status(200)
+                .json_body(serde_json::json!({"streams": [{"url": "https://example.com/1.mp4"}]}));
+        });
+
+        let svc =
+            stremio_service::StremioService::from_url(&server.base_url()).unwrap();
+        let manifest_url = StremioManifestUrl::try_new(server.base_url()).unwrap();
+        let media = episode_media(db::ExternalIds {
+            series_custom_stremio_id: Some("fk:27".to_string()),
+            custom_stremio_id: Some("fk-ep-1".to_string()),
+            custom_stremio_type: Some("anime".to_string()),
+            ..Default::default()
+        });
+
+        let streams = stremio_streams(&svc, &manifest_url, &media)
+            .await
+            .unwrap();
+
+        assert_eq!(streams.len(), 1);
+        captured.assert();
+        reconstructed.assert_hits(0);
+    }
+
+    #[tokio::test]
+    async fn stremio_streams_falls_back_to_reconstructed_id_when_uncaptured() {
+        let server = httpmock::MockServer::start();
+        let reconstructed = server.mock(|when, then| {
+            when.path("/stream/anime/fk:27:1:1.json");
+            then.status(200)
+                .json_body(serde_json::json!({"streams": [{"url": "https://example.com/1.mp4"}]}));
+        });
+
+        let svc =
+            stremio_service::StremioService::from_url(&server.base_url()).unwrap();
+        let manifest_url = StremioManifestUrl::try_new(server.base_url()).unwrap();
+        let media = episode_media(db::ExternalIds {
+            series_custom_stremio_id: Some("fk:27".to_string()),
+            custom_stremio_type: Some("anime".to_string()),
+            ..Default::default()
+        });
+
+        let streams = stremio_streams(&svc, &manifest_url, &media)
+            .await
+            .unwrap();
+
+        assert_eq!(streams.len(), 1);
+        reconstructed.assert();
     }
 }

--- a/crates/remux-server/src/db/media.rs
+++ b/crates/remux-server/src/db/media.rs
@@ -5599,6 +5599,10 @@ pub fn stremio_meta_to_medias(meta: sdks::stremio::Meta) -> Result<Vec<Media>> {
                                 .external_ids
                                 .custom_stremio_type
                                 .clone(),
+                            custom_stremio_id: Some(
+                                ep.id
+                                    .clone(),
+                            ),
                             ..Default::default()
                         };
                         episode.parent_id = Some(season_id);
@@ -5721,6 +5725,10 @@ pub fn stremio_meta_to_medias(meta: sdks::stremio::Meta) -> Result<Vec<Media>> {
                             .external_ids
                             .custom_stremio_type
                             .clone(),
+                        custom_stremio_id: Some(
+                            ep.id
+                                .clone(),
+                        ),
                         ..Default::default()
                     };
                     episode.grandparent_id = Some(media.id);
@@ -5900,6 +5908,14 @@ pub fn stremio_meta_season_episodes(
                 custom_stremio_type: series_external_ids
                     .custom_stremio_type
                     .clone(),
+                // The addon's own video id for this specific episode. Series-type
+                // addons conventionally set this to "{imdb}:{season}:{episode}",
+                // but that's a convention, not a guarantee — keep the literal
+                // value so stream lookups use exactly what the addon gave us.
+                custom_stremio_id: Some(
+                    ep.id
+                        .clone(),
+                ),
                 ..Default::default()
             };
         } else if let Some(ref cid) = custom_id {
@@ -5917,6 +5933,10 @@ pub fn stremio_meta_season_episodes(
                 custom_stremio_type: series_external_ids
                     .custom_stremio_type
                     .clone(),
+                custom_stremio_id: Some(
+                    ep.id
+                        .clone(),
+                ),
                 ..Default::default()
             };
         }
@@ -6524,6 +6544,31 @@ mod tests {
                 .external_ids
                 .custom_stremio_type,
             Some("anime".to_string())
+        );
+    }
+
+    #[test]
+    fn stremio_meta_to_medias_captures_episode_video_id() {
+        let json = r#"{
+            "id": "fk:27",
+            "type": "anime",
+            "name": "Bleach Yabai",
+            "videos": [
+                {"id": "fk:27:1:1", "season": 1, "episode": 1, "title": "Ep 1"}
+            ]
+        }"#;
+        let meta: sdks::stremio::Meta = serde_json::from_str(json).unwrap();
+        let medias = stremio_meta_to_medias(meta).unwrap();
+
+        let episode = medias
+            .iter()
+            .find(|m| m.kind == MediaKind::Episode)
+            .expect("episode media");
+        assert_eq!(
+            episode
+                .external_ids
+                .custom_stremio_id,
+            Some("fk:27:1:1".to_string())
         );
     }
 

--- a/crates/remux-server/src/db/media.rs
+++ b/crates/remux-server/src/db/media.rs
@@ -210,6 +210,21 @@ impl TryFrom<sdks::stremio::MediaType> for MediaKind {
     }
 }
 
+/// Extracts the addon's raw Stremio type string when it's a non-standard type
+/// (e.g. "anime") that `MediaKind` cannot represent and would otherwise collapse
+/// to a generic `Movie`/`Series`. Structural keywords (`episode`/`season`/`person`)
+/// are not content types and are excluded.
+fn custom_stremio_type(media_type: &sdks::stremio::MediaType) -> Option<String> {
+    match media_type {
+        sdks::stremio::MediaType::Unknown(s)
+            if !matches!(s.as_str(), "episode" | "season" | "person") =>
+        {
+            Some(s.clone())
+        }
+        _ => None,
+    }
+}
+
 impl From<&MediaKind> for sdks::stremio::MediaType {
     fn from(kind: &MediaKind) -> Self {
         match kind {
@@ -855,6 +870,10 @@ pub struct ExternalIds {
     /// For seasons/episodes of a custom-ID series: the parent series's `custom_stremio_id`.
     /// Analogous to `series_imdb` for the custom-ID path.
     pub series_custom_stremio_id: Option<String>,
+    /// The addon's own non-standard Stremio type string (e.g. "anime"). The
+    /// addon's `/meta/{type}/{id}.json` and `/stream/{type}/{id}.json` routes
+    /// require this exact string — losing it causes later lookups to 404.
+    pub custom_stremio_type: Option<String>,
 }
 
 impl ExternalIds {
@@ -1025,6 +1044,21 @@ impl ExternalIds {
             &source.series_custom_stremio_id,
             replace,
         );
+        merge_option(
+            &mut self.custom_stremio_type,
+            &source.custom_stremio_type,
+            replace,
+        );
+    }
+
+    /// The Stremio `MediaType` to use when querying the source addon: the
+    /// captured `custom_stremio_type` when present, otherwise the generic
+    /// type derived from `kind`.
+    pub fn stremio_media_type(&self, kind: &MediaKind) -> sdks::stremio::MediaType {
+        self.custom_stremio_type
+            .clone()
+            .map(sdks::stremio::MediaType::Unknown)
+            .unwrap_or_else(|| sdks::stremio::MediaType::from(kind))
     }
 }
 
@@ -5394,6 +5428,7 @@ impl TryFrom<sdks::stremio::Meta> for Media {
                 if let Some(ref imdb) = meta.imdb_id {
                     ids.imdb = NonEmptyString::try_new(imdb.clone()).ok();
                 }
+                ids.custom_stremio_type = custom_stremio_type(&meta.media_type);
                 ids
             },
             status,
@@ -5521,6 +5556,10 @@ pub fn stremio_meta_to_medias(meta: sdks::stremio::Meta) -> Result<Vec<Media>> {
                         grandparent_id: Some(media.id),
                         external_ids: ExternalIds {
                             series_custom_stremio_id: Some(custom_id.clone()),
+                            custom_stremio_type: media
+                                .external_ids
+                                .custom_stremio_type
+                                .clone(),
                             ..Default::default()
                         },
                         released_at: episodes
@@ -5556,6 +5595,10 @@ pub fn stremio_meta_to_medias(meta: sdks::stremio::Meta) -> Result<Vec<Media>> {
                         episode.idx = ep.episode;
                         episode.external_ids = ExternalIds {
                             series_custom_stremio_id: Some(custom_id.clone()),
+                            custom_stremio_type: media
+                                .external_ids
+                                .custom_stremio_type
+                                .clone(),
                             ..Default::default()
                         };
                         episode.parent_id = Some(season_id);
@@ -5630,6 +5673,10 @@ pub fn stremio_meta_to_medias(meta: sdks::stremio::Meta) -> Result<Vec<Media>> {
                         series_tmdb: media
                             .external_ids
                             .tmdb,
+                        custom_stremio_type: media
+                            .external_ids
+                            .custom_stremio_type
+                            .clone(),
                         ..Default::default()
                     },
                     parent_id: Some(media.id),
@@ -5670,6 +5717,10 @@ pub fn stremio_meta_to_medias(meta: sdks::stremio::Meta) -> Result<Vec<Media>> {
                         series_tmdb: media
                             .external_ids
                             .tmdb,
+                        custom_stremio_type: media
+                            .external_ids
+                            .custom_stremio_type
+                            .clone(),
                         ..Default::default()
                     };
                     episode.grandparent_id = Some(media.id);
@@ -5746,6 +5797,9 @@ pub fn stremio_meta_seasons(
             let ext = ExternalIds {
                 series_imdb: Some(iid.clone()),
                 series_tmdb: series_external_ids.tmdb,
+                custom_stremio_type: series_external_ids
+                    .custom_stremio_type
+                    .clone(),
                 ..Default::default()
             };
             (id, ext)
@@ -5761,6 +5815,9 @@ pub fn stremio_meta_seasons(
             });
             let ext = ExternalIds {
                 series_custom_stremio_id: Some(cid.clone()),
+                custom_stremio_type: series_external_ids
+                    .custom_stremio_type
+                    .clone(),
                 ..Default::default()
             };
             (id, ext)
@@ -5840,6 +5897,9 @@ pub fn stremio_meta_season_episodes(
             episode.external_ids = ExternalIds {
                 series_imdb: Some(iid.clone()),
                 series_tmdb: series_external_ids.tmdb,
+                custom_stremio_type: series_external_ids
+                    .custom_stremio_type
+                    .clone(),
                 ..Default::default()
             };
         } else if let Some(ref cid) = custom_id {
@@ -5854,6 +5914,9 @@ pub fn stremio_meta_season_episodes(
             });
             episode.external_ids = ExternalIds {
                 series_custom_stremio_id: Some(cid.clone()),
+                custom_stremio_type: series_external_ids
+                    .custom_stremio_type
+                    .clone(),
                 ..Default::default()
             };
         }
@@ -6370,6 +6433,89 @@ pub(crate) fn build_genre_relations_from_names(
 mod tests {
     use super::*;
     use crate::db::MediaIdRaw;
+
+    #[test]
+    fn custom_stremio_type_extracts_non_standard_type() {
+        assert_eq!(
+            custom_stremio_type(&sdks::stremio::MediaType::Unknown(
+                "anime".to_string()
+            )),
+            Some("anime".to_string())
+        );
+        assert_eq!(custom_stremio_type(&sdks::stremio::MediaType::Series), None);
+        assert_eq!(
+            custom_stremio_type(&sdks::stremio::MediaType::Unknown(
+                "episode".to_string()
+            )),
+            None
+        );
+    }
+
+    #[test]
+    fn stremio_media_type_prefers_custom_type_over_kind() {
+        let anime_ids = ExternalIds {
+            custom_stremio_type: Some("anime".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            anime_ids.stremio_media_type(&MediaKind::Series),
+            sdks::stremio::MediaType::Unknown("anime".to_string())
+        );
+
+        let standard_ids = ExternalIds::default();
+        assert_eq!(
+            standard_ids.stremio_media_type(&MediaKind::Series),
+            sdks::stremio::MediaType::Series
+        );
+    }
+
+    #[test]
+    fn stremio_meta_to_medias_propagates_custom_type_to_episodes() {
+        let json = r#"{
+            "id": "fk:27",
+            "type": "anime",
+            "name": "Bleach Yabai",
+            "videos": [
+                {"id": "fk:27:1:1", "season": 1, "episode": 1, "title": "Ep 1"},
+                {"id": "fk:27:1:2", "season": 1, "episode": 2, "title": "Ep 2"}
+            ]
+        }"#;
+        let meta: sdks::stremio::Meta = serde_json::from_str(json).unwrap();
+        let medias = stremio_meta_to_medias(meta).unwrap();
+
+        let series = medias
+            .iter()
+            .find(|m| m.kind == MediaKind::Series)
+            .expect("series media");
+        assert_eq!(
+            series
+                .external_ids
+                .custom_stremio_type,
+            Some("anime".to_string())
+        );
+
+        let season = medias
+            .iter()
+            .find(|m| m.kind == MediaKind::Season)
+            .expect("season media");
+        assert_eq!(
+            season
+                .external_ids
+                .custom_stremio_type,
+            Some("anime".to_string())
+        );
+
+        let episode = medias
+            .iter()
+            .find(|m| m.kind == MediaKind::Episode)
+            .expect("episode media");
+        assert_eq!(
+            episode
+                .external_ids
+                .custom_stremio_type,
+            Some("anime".to_string())
+        );
+    }
 
     #[test]
     fn stale_episode_id_recomputes_to_canonical_and_validates() {

--- a/crates/remux-server/src/db/media.rs
+++ b/crates/remux-server/src/db/media.rs
@@ -5959,7 +5959,12 @@ pub fn stremio_meta_season_episodes(
 ///      series have NULL parent_id so the subquery would always return NULL anyway;
 ///      seasons must not inherit the series premiere (TVDB lists future seasons early).
 ///
-/// Items with no resolvable date are always excluded (the OR condition is false for them).
+/// Items with no resolvable date at all are excluded (the OR condition is false
+/// for them) — EXCEPT top-level movies/series, where an unknown date is not
+/// evidence of a future release (some Stremio addon catalogs never report one)
+/// and hiding them outright would make their entire catalog unbrowsable. Seasons
+/// and episodes keep the strict behavior: a season/episode with no date at all
+/// (not even inherited from its parent) is presumed not yet aired.
 ///
 /// The filter is expressed as OR branches rather than a CASE expression so that SQLite
 /// can use `idx_media_digital_released_at` for branch 1 and `idx_media_released_at`
@@ -5995,6 +6000,9 @@ pub fn push_release_date_filter(
         // Movies / series / seasons: no parent fallback. Each branch is indexable.
         // Branch 1 → idx_media_digital_released_at
         // Branch 2 → idx_media_released_at
+        // Branch 3 → top-level movies/series with no resolvable date at all pass
+        // through (see doc comment above); seasons are excluded from this branch
+        // so an undated season of an otherwise-dated series stays hidden.
         qb.push(format!(
             " AND (({a}digital_released_at IS NOT NULL AND {a}digital_released_at <= "
         ))
@@ -6006,7 +6014,9 @@ pub fn push_release_date_filter(
         ))
         .push_bind(threshold)
         .push(format!(
-            " AND NOT ({a}kind = 'movie' AND {a}released_at > date('now', '-1 year'))))"
+            " AND NOT ({a}kind = 'movie' AND {a}released_at > date('now', '-1 year'))) \
+              OR ({a}digital_released_at IS NULL AND {a}released_at IS NULL \
+                  AND {a}kind IN ('movie', 'series')))"
         ));
     }
 }
@@ -6721,7 +6731,9 @@ mod tests {
 
     /// Verifies push_release_date_filter hides movies with a recent theatrical date
     /// but no digital release date, while still showing movies with an old theatrical
-    /// date (>1 year) or an explicit digital release date.
+    /// date (>1 year), an explicit digital release date, or no known date at all
+    /// (some addon catalogs never report one; unknown is not evidence of a future
+    /// release).
     #[tokio::test]
     async fn release_date_filter_hides_recent_theatrical_only_movies() {
         let (_server, guard) = crate::integration_test::new_test_server()
@@ -6749,6 +6761,7 @@ mod tests {
         let (id_recent, ext_recent) = make_movie_ids("tt9990001");
         let (id_old, ext_old) = make_movie_ids("tt9990002");
         let (id_digital, ext_digital) = make_movie_ids("tt9990003");
+        let (id_no_date, ext_no_date) = make_movie_ids("tt9990004");
 
         // Theatrical only, released 2 months ago — no digital date → must be hidden.
         let mut recent_theatrical = Media {
@@ -6795,6 +6808,21 @@ mod tests {
             .await
             .unwrap();
 
+        // No known release date at all (e.g. addon never reports one) → must be shown.
+        let mut no_date = Media {
+            id: id_no_date,
+            title: "No Known Release Date".to_string(),
+            kind: MediaKind::Movie,
+            external_ids: ext_no_date,
+            released_at: None,
+            digital_released_at: None,
+            ..Default::default()
+        };
+        no_date
+            .save(db)
+            .await
+            .unwrap();
+
         let result = Media::get_by_filter(
             db,
             &MediaFilter {
@@ -6828,6 +6856,70 @@ mod tests {
         assert!(
             titles.contains(&"Has Digital Release"),
             "movie with digital release date must be shown; got: {:?}",
+            titles
+        );
+        assert!(
+            titles.contains(&"No Known Release Date"),
+            "movie with no known release date must be shown; got: {:?}",
+            titles
+        );
+    }
+
+    #[tokio::test]
+    async fn release_date_filter_shows_series_with_no_known_date() {
+        let (_server, guard) = crate::integration_test::new_test_server()
+            .await
+            .unwrap();
+        let db = &guard
+            .0
+            .db;
+        let now = chrono::Utc::now().naive_utc();
+
+        let ext = ExternalIds {
+            imdb: Some(NonEmptyString::try_new("tt9990005".to_string()).unwrap()),
+            ..Default::default()
+        };
+        let mut series = Media {
+            id: uuid::Uuid::from(&MediaIdRaw {
+                kind: MediaKind::Series,
+                external_ids: ext.clone(),
+                season: None,
+                episode: None,
+            }),
+            title: "No Known Date Series".to_string(),
+            kind: MediaKind::Series,
+            external_ids: ext,
+            released_at: None,
+            digital_released_at: None,
+            ..Default::default()
+        };
+        series
+            .save(db)
+            .await
+            .unwrap();
+
+        let result = Media::get_by_filter(
+            db,
+            &MediaFilter {
+                kind: Some(vec![MediaKind::Series]),
+                digital_released_before: Some(now),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let titles: Vec<&str> = result
+            .records
+            .iter()
+            .map(|m| {
+                m.title
+                    .as_str()
+            })
+            .collect();
+        assert!(
+            titles.contains(&"No Known Date Series"),
+            "series with no known release date must be shown; got: {:?}",
             titles
         );
     }

--- a/crates/remux-server/src/db/media.rs
+++ b/crates/remux-server/src/db/media.rs
@@ -5333,6 +5333,18 @@ impl TryFrom<sdks::stremio::Meta> for Media {
             media_kind = MediaKind::Series;
         }
 
+        // No IMDB ID means we can't resolve release dates against an external
+        // provider (TMDB) either. If the addon reports no date at all for it,
+        // treat it as available now rather than leaving digital_released_at
+        // unset — an unset date means "unreleased" to push_release_date_filter,
+        // which would hide the item forever for addons that never report dates.
+        let has_no_imdb_id = meta
+            .imdb_id
+            .is_none()
+            && ExternalIds::from_stremio_id(&meta.id)
+                .imdb
+                .is_none();
+
         let digital_released_at = meta
             .app_extras
             .as_ref()
@@ -5365,6 +5377,17 @@ impl TryFrom<sdks::stremio::Meta> for Media {
                 ) {
                     meta.released
                         .map(|x| x.naive_utc())
+                } else {
+                    None
+                }
+            })
+            .or_else(|| {
+                if has_no_imdb_id
+                    && meta
+                        .released
+                        .is_none()
+                {
+                    Some(Utc::now().naive_utc())
                 } else {
                     None
                 }
@@ -5979,12 +6002,7 @@ pub fn stremio_meta_season_episodes(
 ///      series have NULL parent_id so the subquery would always return NULL anyway;
 ///      seasons must not inherit the series premiere (TVDB lists future seasons early).
 ///
-/// Items with no resolvable date at all are excluded (the OR condition is false
-/// for them) — EXCEPT top-level movies/series, where an unknown date is not
-/// evidence of a future release (some Stremio addon catalogs never report one)
-/// and hiding them outright would make their entire catalog unbrowsable. Seasons
-/// and episodes keep the strict behavior: a season/episode with no date at all
-/// (not even inherited from its parent) is presumed not yet aired.
+/// Items with no resolvable date are always excluded (the OR condition is false for them).
 ///
 /// The filter is expressed as OR branches rather than a CASE expression so that SQLite
 /// can use `idx_media_digital_released_at` for branch 1 and `idx_media_released_at`
@@ -6020,9 +6038,6 @@ pub fn push_release_date_filter(
         // Movies / series / seasons: no parent fallback. Each branch is indexable.
         // Branch 1 → idx_media_digital_released_at
         // Branch 2 → idx_media_released_at
-        // Branch 3 → top-level movies/series with no resolvable date at all pass
-        // through (see doc comment above); seasons are excluded from this branch
-        // so an undated season of an otherwise-dated series stays hidden.
         qb.push(format!(
             " AND (({a}digital_released_at IS NOT NULL AND {a}digital_released_at <= "
         ))
@@ -6034,9 +6049,7 @@ pub fn push_release_date_filter(
         ))
         .push_bind(threshold)
         .push(format!(
-            " AND NOT ({a}kind = 'movie' AND {a}released_at > date('now', '-1 year'))) \
-              OR ({a}digital_released_at IS NULL AND {a}released_at IS NULL \
-                  AND {a}kind IN ('movie', 'series')))"
+            " AND NOT ({a}kind = 'movie' AND {a}released_at > date('now', '-1 year'))))"
         ));
     }
 }
@@ -6573,6 +6586,53 @@ mod tests {
     }
 
     #[test]
+    fn custom_id_meta_with_no_dates_stamps_digital_released_at_now() {
+        let json = r#"{
+            "id": "fk:27",
+            "type": "anime",
+            "name": "Bleach Yabai"
+        }"#;
+        let meta: sdks::stremio::Meta = serde_json::from_str(json).unwrap();
+        let before = chrono::Utc::now().naive_utc();
+        let media: Media = meta
+            .try_into()
+            .unwrap();
+        let after = chrono::Utc::now().naive_utc();
+
+        let stamped = media
+            .digital_released_at
+            .expect(
+                "no-IMDB item with no dates must get a stamped digital_released_at",
+            );
+        assert!(
+            stamped >= before && stamped <= after,
+            "expected digital_released_at to be stamped to now; got {:?} (window {:?}..{:?})",
+            stamped,
+            before,
+            after
+        );
+    }
+
+    #[test]
+    fn imdb_meta_with_no_dates_leaves_digital_released_at_unset() {
+        let json = r#"{
+            "id": "tt9990010",
+            "type": "movie",
+            "name": "Some Movie"
+        }"#;
+        let meta: sdks::stremio::Meta = serde_json::from_str(json).unwrap();
+        let media: Media = meta
+            .try_into()
+            .unwrap();
+
+        assert_eq!(
+            media.digital_released_at, None,
+            "items with a resolvable IMDB ID must not get a stamped date — \
+             their date can still be resolved externally (e.g. via TMDB)"
+        );
+    }
+
+    #[test]
     fn stale_episode_id_recomputes_to_canonical_and_validates() {
         let series_imdb = NonEmptyString::try_new("tt1844624".to_string()).unwrap();
         let mut ep = Media {
@@ -6776,9 +6836,7 @@ mod tests {
 
     /// Verifies push_release_date_filter hides movies with a recent theatrical date
     /// but no digital release date, while still showing movies with an old theatrical
-    /// date (>1 year), an explicit digital release date, or no known date at all
-    /// (some addon catalogs never report one; unknown is not evidence of a future
-    /// release).
+    /// date (>1 year) or an explicit digital release date.
     #[tokio::test]
     async fn release_date_filter_hides_recent_theatrical_only_movies() {
         let (_server, guard) = crate::integration_test::new_test_server()
@@ -6806,7 +6864,6 @@ mod tests {
         let (id_recent, ext_recent) = make_movie_ids("tt9990001");
         let (id_old, ext_old) = make_movie_ids("tt9990002");
         let (id_digital, ext_digital) = make_movie_ids("tt9990003");
-        let (id_no_date, ext_no_date) = make_movie_ids("tt9990004");
 
         // Theatrical only, released 2 months ago — no digital date → must be hidden.
         let mut recent_theatrical = Media {
@@ -6853,21 +6910,6 @@ mod tests {
             .await
             .unwrap();
 
-        // No known release date at all (e.g. addon never reports one) → must be shown.
-        let mut no_date = Media {
-            id: id_no_date,
-            title: "No Known Release Date".to_string(),
-            kind: MediaKind::Movie,
-            external_ids: ext_no_date,
-            released_at: None,
-            digital_released_at: None,
-            ..Default::default()
-        };
-        no_date
-            .save(db)
-            .await
-            .unwrap();
-
         let result = Media::get_by_filter(
             db,
             &MediaFilter {
@@ -6901,70 +6943,6 @@ mod tests {
         assert!(
             titles.contains(&"Has Digital Release"),
             "movie with digital release date must be shown; got: {:?}",
-            titles
-        );
-        assert!(
-            titles.contains(&"No Known Release Date"),
-            "movie with no known release date must be shown; got: {:?}",
-            titles
-        );
-    }
-
-    #[tokio::test]
-    async fn release_date_filter_shows_series_with_no_known_date() {
-        let (_server, guard) = crate::integration_test::new_test_server()
-            .await
-            .unwrap();
-        let db = &guard
-            .0
-            .db;
-        let now = chrono::Utc::now().naive_utc();
-
-        let ext = ExternalIds {
-            imdb: Some(NonEmptyString::try_new("tt9990005".to_string()).unwrap()),
-            ..Default::default()
-        };
-        let mut series = Media {
-            id: uuid::Uuid::from(&MediaIdRaw {
-                kind: MediaKind::Series,
-                external_ids: ext.clone(),
-                season: None,
-                episode: None,
-            }),
-            title: "No Known Date Series".to_string(),
-            kind: MediaKind::Series,
-            external_ids: ext,
-            released_at: None,
-            digital_released_at: None,
-            ..Default::default()
-        };
-        series
-            .save(db)
-            .await
-            .unwrap();
-
-        let result = Media::get_by_filter(
-            db,
-            &MediaFilter {
-                kind: Some(vec![MediaKind::Series]),
-                digital_released_before: Some(now),
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
-
-        let titles: Vec<&str> = result
-            .records
-            .iter()
-            .map(|m| {
-                m.title
-                    .as_str()
-            })
-            .collect();
-        assert!(
-            titles.contains(&"No Known Date Series"),
-            "series with no known release date must be shown; got: {:?}",
             titles
         );
     }

--- a/crates/remux-server/src/services/stremio.rs
+++ b/crates/remux-server/src/services/stremio.rs
@@ -8,7 +8,7 @@ use std::{
     pin::Pin,
     time::{Duration, Instant},
 };
-use tracing::{debug, error};
+use tracing::debug;
 
 #[derive(Clone)]
 pub struct StremioService {
@@ -188,14 +188,14 @@ impl StremioService {
                                 .metas
                                 .is_empty()
                         })
-                        .unwrap_or(true),
+                        .unwrap_or(false),
                 )
             })
             .filter_map(|result| async move {
                 match result {
                     Ok(response) => Some(stream::iter(response.metas)),
                     Err(e) => {
-                        error!("Failed to fetch catalog page: {}", e);
+                        debug!("stopping catalog pagination: {}", e);
                         None
                     }
                 }

--- a/crates/remux-server/src/services/stremio.rs
+++ b/crates/remux-server/src/services/stremio.rs
@@ -191,30 +191,34 @@ impl StremioService {
 
         let pages = first
             .chain(rest)
+            // `take_while` drops the first item it rejects rather than passing it
+            // downstream, so the 404-vs-error distinction has to happen here — by
+            // the time a later `filter_map`/`map` would see the `Err`, take_while
+            // has already stopped the stream without it.
             .take_while(|result| {
                 future::ready(match result {
                     Ok(response) => !response
                         .metas
                         .is_empty(),
-                    Err(_) => false,
-                })
-            })
-            .filter_map(|result| async move {
-                match result {
-                    Ok(response) => Some(stream::iter(response.metas)),
-                    Err(e) if is_404(&e) => {
+                    Err(e) if is_404(e) => {
                         debug!(
                             "stopping catalog pagination: reached end of catalog (404)"
                         );
-                        None
+                        false
                     }
                     Err(e) => {
                         error!(
                             "stopping catalog pagination due to unexpected error: {}",
                             e
                         );
-                        None
+                        false
                     }
+                })
+            })
+            .filter_map(|result| async move {
+                match result {
+                    Ok(response) => Some(stream::iter(response.metas)),
+                    Err(_) => None,
                 }
             })
             .flatten();
@@ -244,5 +248,67 @@ mod tests {
         assert!(!is_404(&ClientError::RateLimited {
             retry_after_secs: 30
         }));
+    }
+
+    fn mock_page(server: &httpmock::MockServer, path: &str, names: &[&str]) {
+        let metas: Vec<_> = names
+            .iter()
+            .map(|n| serde_json::json!({"id": n, "type": "movie", "name": n}))
+            .collect();
+        server.mock(|when, then| {
+            when.path(path);
+            then.status(200)
+                .json_body(serde_json::json!({"metas": metas}));
+        });
+    }
+
+    /// Regression test for the take_while/filter_map bug: take_while drops the
+    /// first item it rejects instead of passing it downstream, so a 404 on page
+    /// 2 must still yield page 1's items and stop cleanly there.
+    #[tokio::test]
+    async fn get_catalog_stream_stops_cleanly_on_404() {
+        let server = httpmock::MockServer::start();
+        mock_page(&server, "/catalog/movie/test.json", &["a", "b"]);
+        server.mock(|when, then| {
+            when.path("/catalog/movie/test/skip=2.json");
+            then.status(404);
+        });
+
+        let svc = StremioService::from_url(&server.base_url()).unwrap();
+        let stream = svc
+            .get_catalog_stream("movie".to_string(), "test".to_string(), true)
+            .await
+            .unwrap();
+        let names: Vec<String> = stream
+            .map(|m| m.id)
+            .collect()
+            .await;
+
+        assert_eq!(names, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    /// Same as above but for a non-404 error (5xx) — must still stop cleanly
+    /// rather than hang or panic, even though it's not the expected
+    /// end-of-catalog signal.
+    #[tokio::test]
+    async fn get_catalog_stream_stops_cleanly_on_non_404_error() {
+        let server = httpmock::MockServer::start();
+        mock_page(&server, "/catalog/movie/test.json", &["a", "b"]);
+        server.mock(|when, then| {
+            when.path("/catalog/movie/test/skip=2.json");
+            then.status(500);
+        });
+
+        let svc = StremioService::from_url(&server.base_url()).unwrap();
+        let stream = svc
+            .get_catalog_stream("movie".to_string(), "test".to_string(), true)
+            .await
+            .unwrap();
+        let names: Vec<String> = stream
+            .map(|m| m.id)
+            .collect()
+            .await;
+
+        assert_eq!(names, vec!["a".to_string(), "b".to_string()]);
     }
 }

--- a/crates/remux-server/src/services/stremio.rs
+++ b/crates/remux-server/src/services/stremio.rs
@@ -1,4 +1,4 @@
-use crate::{sdks, sdks::CachedEndpoint};
+use crate::{sdks, sdks::CachedEndpoint, sdks::ClientError};
 use anyhow::{Result, anyhow};
 use futures::{
     future,
@@ -8,7 +8,19 @@ use std::{
     pin::Pin,
     time::{Duration, Instant},
 };
-use tracing::debug;
+use tracing::{debug, error};
+
+/// A 404 on a paginated catalog page is the addon's normal "no more pages"
+/// signal, not an error — some addons (e.g. fankai) 404 past the last page
+/// instead of returning an empty array. Any other error (5xx, rate limit,
+/// network blip) is a real problem and must not be conflated with reaching
+/// the end of the catalog.
+fn is_404(e: &ClientError) -> bool {
+    matches!(
+        e,
+        ClientError::Http { status: 404, .. } | ClientError::Json { status: 404, .. }
+    )
+}
 
 #[derive(Clone)]
 pub struct StremioService {
@@ -180,22 +192,27 @@ impl StremioService {
         let pages = first
             .chain(rest)
             .take_while(|result| {
-                future::ready(
-                    result
-                        .as_ref()
-                        .map(|response| {
-                            !response
-                                .metas
-                                .is_empty()
-                        })
-                        .unwrap_or(false),
-                )
+                future::ready(match result {
+                    Ok(response) => !response
+                        .metas
+                        .is_empty(),
+                    Err(_) => false,
+                })
             })
             .filter_map(|result| async move {
                 match result {
                     Ok(response) => Some(stream::iter(response.metas)),
+                    Err(e) if is_404(&e) => {
+                        debug!(
+                            "stopping catalog pagination: reached end of catalog (404)"
+                        );
+                        None
+                    }
                     Err(e) => {
-                        debug!("stopping catalog pagination: {}", e);
+                        error!(
+                            "stopping catalog pagination due to unexpected error: {}",
+                            e
+                        );
                         None
                     }
                 }
@@ -203,5 +220,29 @@ impl StremioService {
             .flatten();
 
         Ok(Box::pin(pages))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_404_matches_only_404_status() {
+        assert!(is_404(&ClientError::Http {
+            status: 404,
+            message: "not found".to_string(),
+            endpoint: None,
+            body: None,
+        }));
+        assert!(!is_404(&ClientError::Http {
+            status: 500,
+            message: "server error".to_string(),
+            endpoint: None,
+            body: None,
+        }));
+        assert!(!is_404(&ClientError::RateLimited {
+            retry_after_secs: 30
+        }));
     }
 }


### PR DESCRIPTION
**Context**

Importing the fankai catalog ([Stremio "FKStream" addon](https://streamio.fankai.fr/configure), non-standard content type "anime") into a smart collection called "fkanime". A history of 6 distinct bugs surfaced one after another, each one masking the next.

<img width="1552" height="230" alt="image" src="https://github.com/user-attachments/assets/3ba44d9d-251b-4f97-8450-7eb5ffa5c5b2" />

**1. JSON parsing crash on catalog import**

**Symptom:** invalid type: string, expected a sequence the whole catalog blew up.

```
"invalid type: string, expected a sequence"
```

**Cause:** the genre/genres fields on the Meta model (Stremio SDK) required an array, but some addons (fankai) send a plain string.

**Fix:** reused the tolerant deserializer already in place for country/director/cast/writer and applied it to genre/genres.

**2. Secondary crash on the runtime field**

**Symptom:** runtime: "En cours" (a status string, not a duration) broke the entire catalog page parse.

```
 19:33:48 ERROR remux_server::tasks::refresh_library:145: failed to open catalog stream catalog=addon:408b180a-3d4a-4940-a8e3-7fa50d0c0fbc:anime:fankai_catalog error=json error (status=200) endpoint=Some("https://streamio.fankai.fr/..."): En cours
  ^
   at line 1 column 4488
```

**Fix:** a runtime value that can't be parsed is now treated as absent (None) instead of failing the parse.

**3. Infinite catalog pagination**

**Symptom:** hundreds of repeated 404s (skip=79, 158... all the way to 3397+) once the real last page had been reached.

```
remux_server::services::stremio:198: Failed to fetch catalog page: http error (status=404) endpoint=... skip=79.json jusqu'à skip=3397.json, terminé par INFO ... catalog import complete catalog=addon:...fankai_catalog total={"series": 79} new={"series": 79}.
```

**Cause:** get_catalog_stream kept paginating on any error instead of stopping.

**Fix:** a fetch error now stops pagination (it's a normal terminal condition log demoted to debug!).

**4. Items imported but invisible in the collection**

**Symptom:** 79 fankai items correctly tagged "fkanime" but missing from the collection.

**Cause:** the release-date filter (FilterByDigitalReleaseDate) hid any item with no known release date and fankai never provides one.

**Fix:** top-level movies/series with no known date now pass the filter (an unknown date isn't proof of a future release). Seasons/episodes keep the strict behavior (no date means not aired yet), since there it's a reliable signal.

**5. Series visible but with no seasons/episodes**

**Symptom:** "Bleach Yabai" showed up as a series, but the Seasons section stayed empty.

**Cause:** the Stremio type to query was derived generically from the MediaKind (→ "series"), whereas fankai serves its content under a custom type ("anime"). Result: 404 on /meta/series/{id}.json.

**Fix:** New field ExternalIds::custom_stremio_type: captures the addon's own Stremio type and propagates it to seasons/episodes.

**Fallback:** if an item with a custom ID still 404s, we query the addon's manifest to discover the type(s) it declares and retry, instead of failing for good.

**6. Episodes visible but no streams**

```
22:57:55  INFO request:refresh_streams: remux_server::addons:2382: streams synced streams=0 sources=[] elapsed=301.030916ms uri=/items/8585991b-80fb-55fc-96e9-3db4c00c9d03/playbackinfo user="squelix" title=S1E1 - Death and Strawberry kind=episode
22:57:55 ERROR request: remux_server:618: api error status=500 Internal Server Error title=Internal Error detail=Something went wrong cause=no playable sources for 8585991b-80fb-55fc-96e9-3db4c00c9d03 (no streams from addon, or filtered out by grouping/stream policy) uri=/items/8585991b-80fb-55fc-96e9-3db4c00c9d03/playbackinfo user="squelix"
22:57:58  INFO request:refresh_streams: remux_server::addons:2382: streams synced streams=0 sources=[] elapsed=222.375µs uri=/users/ffaa7b22-da82-40a2-9c28-781ddb4f29cb/items/8585991b-80fb-55fc-96e9-3db4c00c9d03?Fields=MediaSources user="squelix" title=S1E1 - Death and Strawberry kind=episode
22:57:59  INFO remux_server::ws:122: WS connection closed device_id=da3b66d1-5f1a-4eee-af0c-cc85417edd6f
22:58:00  INFO remux_server::ws:85: WS connection opened device_id=da3b66d1-5f1a-4eee-af0c-cc85417edd6f
22:58:00  INFO request:refresh_streams: remux_server::addons:2382: streams synced streams=0 sources=[] elapsed=238.708µs uri=/users/ffaa7b22-da82-40a2-9c28-781ddb4f29cb/items/8585991b-80fb-55fc-96e9-3db4c00c9d03?Fields=MediaSources user="squelix" title=S1E1 - Death and Strawberry kind=episode
22:58:06  INFO request:refresh_streams: remux_server::addons:2382: streams synced streams=0 sources=[] elapsed=272.696667ms uri=/users/ffaa7b22-da82-40a2-9c28-781ddb4f29cb/items/c20fbaa2-bf8c-5271-944c-620a086cbcac?Fields=MediaSources user="squelix" title=S1E2 - Memories in the rain kind=episode
22:58:19  INFO remux_server::ws:122: WS connection closed device_id=da3b66d1-5f1a-4eee-af0c-cc85417edd6f
22:58:19  INFO remux_server::ws:85: WS connection opened device_id=da3b66d1-5f1a-4eee-af0c-cc85417edd6f
22:58:19  INFO request:refresh_streams: remux_server::addons:2382: streams synced streams=0 sources=[] elapsed=197.25µs uri=/users/ffaa7b22-da82-40a2-9c28-781ddb4f29cb/items/8585991b-80fb-55fc-96e9-3db4c00c9d03?Fields=MediaSources user="squelix" title=S1E1 - Death and Strawberry kind=episode
22:58:26  WARN refresh_meta: remux_server::addons::stremio:830: meta addon returned an error, skipping id=b43ce4e0-ada2-5818-92d9-11615202403c error_title=[❌] FKStream error_description=fetch failed title=Record of Ragnarok Henshū kind=series
22:58:31  INFO remux_server::ws:122: WS connection closed device_id=da3b66d1-5f1a-4eee-af0c-cc85417edd6f
22:58:31  INFO remux_server::ws:85: WS connection opened device_id=da3b66d1-5f1a-4eee-af0c-cc85417edd6f
22:58:31  INFO request:refresh_streams: remux_server::addons:2382: streams synced streams=0 sources=[] elapsed=209.5µs uri=/users/ffaa7b22-da82-40a2-9c28-781ddb4f29cb/items/c20fbaa2-bf8c-5271-944c-620a086cbcac?Fields=MediaSources user="squelix" title=S1E2 - Memories in the rain kind=episode
```

Two distinct bugs, both silent (no error, just an empty stream list):

**a)** Wrong video ID reconstruction: the code was rebuilding the stream ID as "{series}:{season}:{episode}" a convention that only holds for standard "series" addons, not guaranteed for a custom type. Fix: use the video ID provided directly by the addon (videos[].id, captured in ExternalIds::custom_stremio_id), falling back to reconstruction for episodes already in the DB before this fix.

**b)** Addon silently excluded from the stream registry: supports_type() collapsed any unrecognized manifest type (e.g. "anime") down to MediaKind::Movie which made the registry think this addon only served movies, excluding it from addons_for::<dyn StreamAddon> for any series/season/episode. Result: zero addons were even attempted for episode playback. Fix: an unrecognized manifest type is now excluded from supported_types rather than pinned to Movie, which leaves the type filter inactive for that addon (correct permissive behavior) instead of handing it a wrong filter.