### PR TITLE
feat(stream-groups): add Size rule and propagate torznab size

### DIFF
--- a/crates/remux-dashboard/src/pages/streams.rs
+++ b/crates/remux-dashboard/src/pages/streams.rs
@@ -4,9 +4,9 @@ use crate::{
 };
 use dioxus::prelude::*;
 use remux_sdks::remux::{
-    CreateStreamGroup, CreateStreamGroupRequest, DeleteStreamGroup, FilterMatchMode,
-    GetStreamGroupPreview, GetSystemConfiguration, ListStreamGroups,
-    ServerConfiguration, SetOp, StreamCodec, StreamFilter, StreamGroupDto,
+    format_size_rule, CreateStreamGroup, CreateStreamGroupRequest, DeleteStreamGroup,
+    FilterMatchMode, GetStreamGroupPreview, GetSystemConfiguration, ListStreamGroups,
+    NumericOp, ServerConfiguration, SetOp, StreamCodec, StreamFilter, StreamGroupDto,
     StreamGroupPreviewDto, StreamQuality, StreamResolution, StreamRule,
     UpdateStreamGroup, UpdateStreamGroupRequest, UpdateSystemConfiguration,
 };
@@ -22,11 +22,18 @@ pub(crate) fn StreamRuleRow(
         StreamRule::Resolution { .. } => "resolution",
         StreamRule::Quality { .. } => "quality",
         StreamRule::Codec { .. } => "codec",
+        StreamRule::Size { .. } => "size",
     };
+    let is_size = field_val == "size";
     let op_not_in = match &rule {
         StreamRule::Resolution { op, .. }
         | StreamRule::Quality { op, .. }
         | StreamRule::Codec { op, .. } => matches!(op, SetOp::NotIn),
+        StreamRule::Size { .. } => false,
+    };
+    let size_op = match &rule {
+        StreamRule::Size { op, .. } => Some(*op),
+        _ => None,
     };
 
     rsx! {
@@ -41,6 +48,7 @@ pub(crate) fn StreamRuleRow(
                         *r = match e.value().as_str() {
                             "quality" => StreamRule::Quality { op: SetOp::In, values: vec![] },
                             "codec"  => StreamRule::Codec  { op: SetOp::In, values: vec![] },
+                            "size"   => StreamRule::Size { op: NumericOp::Gt, value: 0 },
                             _        => StreamRule::Resolution { op: SetOp::In, values: vec![] },
                         };
                     }
@@ -48,27 +56,79 @@ pub(crate) fn StreamRuleRow(
                 option { value: "resolution", selected: field_val == "resolution", "Resolution" }
                 option { value: "quality",     selected: field_val == "quality",     "Quality" }
                 option { value: "codec",      selected: field_val == "codec",      "Codec" }
+                option { value: "size",       selected: is_size,                   "Size" }
             }
             // Operator selector
             select {
                 class: "select-input",
                 style: "flex:1",
                 onchange: move |e| {
-                    let new_op = if e.value() == "not_in" { SetOp::NotIn } else { SetOp::In };
                     if let Some(r) = rules.write().get_mut(idx) {
-                        *r = match r.clone() {
-                            StreamRule::Resolution { values, .. } => StreamRule::Resolution { op: new_op, values },
-                            StreamRule::Quality { values, .. }     => StreamRule::Quality { op: new_op, values },
-                            StreamRule::Codec { values, .. }      => StreamRule::Codec  { op: new_op, values },
-                        };
+                        if is_size {
+                            let new_op = match e.value().as_str() {
+                                "lt"     => NumericOp::Lt,
+                                "eq"     => NumericOp::Eq,
+                                "not_eq" => NumericOp::NotEq,
+                                _        => NumericOp::Gt,
+                            };
+                            if let StreamRule::Size { value, .. } = r.clone() {
+                                *r = StreamRule::Size { op: new_op, value };
+                            }
+                        } else {
+                            let new_op = if e.value() == "not_in" { SetOp::NotIn } else { SetOp::In };
+                            *r = match r.clone() {
+                                StreamRule::Resolution { values, .. } => StreamRule::Resolution { op: new_op, values },
+                                StreamRule::Quality { values, .. }     => StreamRule::Quality { op: new_op, values },
+                                StreamRule::Codec { values, .. }      => StreamRule::Codec  { op: new_op, values },
+                                StreamRule::Size { .. } => unreachable!("is_size branch handles Size"),
+                            };
+                        }
                     }
                 },
-                option { value: "in",     selected: !op_not_in, "In" }
-                option { value: "not_in", selected:  op_not_in, "Not in" }
+                if is_size {
+                    option { value: "gt",     selected: size_op == Some(NumericOp::Gt),    ">" }
+                    option { value: "lt",     selected: size_op == Some(NumericOp::Lt),    "<" }
+                    option { value: "eq",     selected: size_op == Some(NumericOp::Eq),    "=" }
+                    option { value: "not_eq", selected: size_op == Some(NumericOp::NotEq), "≠" }
+                } else {
+                    option { value: "in",     selected: !op_not_in, "In" }
+                    option { value: "not_in", selected:  op_not_in, "Not in" }
+                }
             }
             // Value checkboxes
             div { style: "flex:2;display:flex;flex-wrap:wrap;gap:6px;padding-top:2px",
-                if field_val == "resolution" {
+                if is_size {
+                    {
+                        // Stored as bytes; the field shows GiB and converts on edit.
+                        let gib = match &rule {
+                            StreamRule::Size { value, .. } => *value as f64 / (1024.0 * 1024.0 * 1024.0),
+                            _ => 0.0,
+                        };
+                        let gib_str = format!("{gib:.2}");
+                        rsx! {
+                            label { style: "display:flex;align-items:center;gap:4px;font-size:.82rem",
+                                input {
+                                    r#type: "number",
+                                    class: "select-input",
+                                    style: "width:90px",
+                                    step: "0.01",
+                                    min: "0",
+                                    value: "{gib_str}",
+                                    onchange: move |e| {
+                                        let bytes = (e.value().parse::<f64>().unwrap_or(0.0)
+                                            * 1024.0 * 1024.0 * 1024.0) as i64;
+                                        if let Some(r) = rules.write().get_mut(idx) {
+                                            if let StreamRule::Size { op, .. } = r.clone() {
+                                                *r = StreamRule::Size { op, value: bytes };
+                                            }
+                                        }
+                                    },
+                                }
+                                "GiB"
+                            }
+                        }
+                    }
+                } else if field_val == "resolution" {
                     for res in StreamResolution::all() {
                         {
                             let res = res.clone();
@@ -399,6 +459,9 @@ pub fn StreamGroupsCard(app_state: AppState) -> Element {
                                                             StreamRule::Codec { op, values } => {
                                                                 let lbl = values.iter().map(|v| v.label()).collect::<Vec<_>>().join("/");
                                                                 (lbl, matches!(op, SetOp::NotIn), "background:rgba(16,185,129,.12);color:rgb(5,150,105);padding:1px 6px;border-radius:4px")
+                                                            }
+                                                            StreamRule::Size { op, value } => {
+                                                                (format_size_rule(*op, *value), false, "background:rgba(245,158,11,.12);color:rgb(217,119,6);padding:1px 6px;border-radius:4px")
                                                             }
                                                         };
                                                         let prefix = if is_excl { "NOT " } else { "" };

--- a/crates/remux-dashboard/src/pages/streams.rs
+++ b/crates/remux-dashboard/src/pages/streams.rs
@@ -116,7 +116,8 @@ pub(crate) fn StreamRuleRow(
                                     value: "{gib_str}",
                                     onchange: move |e| {
                                         let bytes = (e.value().parse::<f64>().unwrap_or(0.0)
-                                            * 1024.0 * 1024.0 * 1024.0) as i64;
+                                            * 1024.0 * 1024.0 * 1024.0)
+                                            .round() as i64;
                                         if let Some(r) = rules.write().get_mut(idx) {
                                             if let StreamRule::Size { op, .. } = r.clone() {
                                                 *r = StreamRule::Size { op, value: bytes };

--- a/crates/remux-sdks/src/remux/mod.rs
+++ b/crates/remux-sdks/src/remux/mod.rs
@@ -1622,6 +1622,33 @@ mod tests {
                 .is_none()
         );
     }
+
+    #[test]
+    fn stream_rule_size_round_trips() {
+        let rule = StreamRule::Size {
+            op: NumericOp::Gt,
+            value: 20_000_000_000,
+        };
+        let json = serde_json::to_string(&rule).unwrap();
+        assert_eq!(json, r#"{"field":"size","op":"gt","value":20000000000}"#);
+        let back: StreamRule = serde_json::from_str(&json).unwrap();
+        assert_eq!(rule, back);
+    }
+
+    #[test]
+    fn format_size_rule_picks_gib_for_large_values() {
+        let v = 20 * 1024 * 1024 * 1024;
+        assert_eq!(format_size_rule(NumericOp::Gt, v), "> 20.00 GiB");
+        assert_eq!(format_size_rule(NumericOp::Lt, v), "< 20.00 GiB");
+        assert_eq!(format_size_rule(NumericOp::Eq, v), "= 20.00 GiB");
+        assert_eq!(format_size_rule(NumericOp::NotEq, v), "≠ 20.00 GiB");
+    }
+
+    #[test]
+    fn format_size_rule_falls_back_to_mib() {
+        let v = 500 * 1024 * 1024;
+        assert_eq!(format_size_rule(NumericOp::Gt, v), "> 500.00 MiB");
+    }
 }
 
 #[derive(Default, Debug, Deserialize)]
@@ -2766,8 +2793,8 @@ impl From<stremio::MediaType> for MediaKind {
     }
 }
 
-/// Operators for numeric fields (Year, Rating).
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+/// Operators for numeric fields (Year, Rating, Size).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum NumericOp {
     Eq,
@@ -5616,6 +5643,24 @@ impl StreamCodec {
     }
 }
 
+/// Human-readable label for a [`StreamRule::Size`] condition, e.g. `"> 18.63 GiB"`.
+pub fn format_size_rule(op: NumericOp, value: i64) -> String {
+    let sym = match op {
+        NumericOp::Eq => "=",
+        NumericOp::NotEq => "≠",
+        NumericOp::Gt => ">",
+        NumericOp::Lt => "<",
+    };
+    const GIB: u64 = 1024 * 1024 * 1024;
+    const MIB: u64 = 1024 * 1024;
+    let (n, unit) = if value.unsigned_abs() >= GIB {
+        (value as f64 / GIB as f64, "GiB")
+    } else {
+        (value as f64 / MIB as f64, "MiB")
+    };
+    format!("{sym} {n:.2} {unit}")
+}
+
 /// One condition in a stream group filter. Mirrors `FilterRule` but for stream attributes.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "field", rename_all = "snake_case")]
@@ -5631,6 +5676,12 @@ pub enum StreamRule {
     Codec {
         op: SetOp,
         values: Vec<StreamCodec>,
+    },
+    /// Minimum/maximum file size in bytes. A stream with unknown size (`None`)
+    /// passes the rule so HTTP/debrid/IPTV sources are not silently dropped.
+    Size {
+        op: NumericOp,
+        value: i64,
     },
 }
 

--- a/crates/remux-server/src/addons/torznab.rs
+++ b/crates/remux-server/src/addons/torznab.rs
@@ -223,6 +223,7 @@ impl TorznabAddon {
                 Some(crate::stream::StreamInfo {
                     descriptor,
                     name: Some(item.label(&self.name)),
+                    size: item.size,
                     probe_data: Some(api::MediaSourceInfo {
                         media_streams: vec![api::MediaStream {
                             index: 0,
@@ -311,6 +312,7 @@ impl TorznabAddon {
                 Some(crate::stream::StreamInfo {
                     descriptor: magnet_to_descriptor(&item.url()?, None)?,
                     name: Some(item.label(&self.name)),
+                    size: item.size,
                     ..Default::default()
                 })
             })
@@ -384,6 +386,7 @@ impl TorznabAddon {
                 Some(crate::stream::StreamInfo {
                     descriptor: magnet_to_descriptor(&item.url()?, None)?,
                     name: Some(item.label(&self.name)),
+                    size: item.size,
                     ..Default::default()
                 })
             })
@@ -928,6 +931,7 @@ mod tests {
         assert_eq!(items[0].title, "Artist - Track [FLAC]");
         assert_eq!(items[0].seeders, 7);
         assert_eq!(items[0].peers, 9);
+        assert_eq!(items[0].size, Some(104857600));
         assert_eq!(
             items[0]
                 .category

--- a/crates/remux-server/src/api/remux.rs
+++ b/crates/remux-server/src/api/remux.rs
@@ -491,7 +491,7 @@ async fn streams_metadata(state: &AppState, id: Uuid) -> AnyResult<StreamsRespon
 
         let best = matching[0];
         let description = {
-            use remux_sdks::remux::StreamRule;
+            use remux_sdks::remux::{StreamRule, format_size_rule};
             let parts: Vec<String> = group
                 .filter
                 .rules
@@ -512,6 +512,7 @@ async fn streams_metadata(state: &AppState, id: Uuid) -> AnyResult<StreamsRespon
                         .map(|v| v.label())
                         .collect::<Vec<_>>()
                         .join("/"),
+                    StreamRule::Size { op, value } => format_size_rule(*op, *value),
                 })
                 .filter(|s| !s.is_empty())
                 .collect();

--- a/crates/remux-server/src/db/stream_group.rs
+++ b/crates/remux-server/src/db/stream_group.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use chrono::Utc;
 use remux_sdks::remux::{
-    FilterMatchMode, SetOp, StreamCodec, StreamFilter, StreamQuality, StreamResolution,
-    StreamRule,
+    FilterMatchMode, NumericOp, SetOp, StreamCodec, StreamFilter, StreamQuality,
+    StreamResolution, StreamRule, format_size_rule,
 };
 use sqlx::SqlitePool;
 use std::collections::HashSet;
@@ -402,6 +402,17 @@ impl StreamGroup {
                 let hit = values.contains(&codec);
                 matches!(op, SetOp::In | SetOp::Is) == hit
             }
+            // Unknown size (None) passes so HTTP/debrid/IPTV sources are not
+            // silently dropped — the rule only filters when size is known.
+            StreamRule::Size { op, value } => match info.size {
+                None => true,
+                Some(s) => match op {
+                    NumericOp::Eq => s == *value,
+                    NumericOp::NotEq => s != *value,
+                    NumericOp::Gt => s > *value,
+                    NumericOp::Lt => s < *value,
+                },
+            },
         };
 
         match filter.match_mode {
@@ -512,19 +523,23 @@ fn auto_name(filter: &StreamFilter) -> String {
         .rules
         .iter()
         .filter_map(|r| {
-            let labels: Vec<&str> = match r {
+            let labels: Vec<String> = match r {
                 StreamRule::Resolution { values, .. } => values
                     .iter()
                     .map(|v| v.label())
+                    .map(str::to_owned)
                     .collect(),
                 StreamRule::Quality { values, .. } => values
                     .iter()
                     .map(|v| v.label())
+                    .map(str::to_owned)
                     .collect(),
                 StreamRule::Codec { values, .. } => values
                     .iter()
                     .map(|v| v.label())
+                    .map(str::to_owned)
                     .collect(),
+                StreamRule::Size { op, value } => vec![format_size_rule(*op, *value)],
             };
             if labels.is_empty() {
                 None
@@ -645,6 +660,112 @@ mod tests {
         let group = group_1080p_bluray();
         assert!(!group.matches(&info(
             "The Martian 2015 UHD BluRay 2160p HDR10 DoVi Atmos x265-GROUP.mkv"
+        )));
+    }
+
+    fn group_size(op: NumericOp, value: i64) -> StreamGroup {
+        StreamGroup {
+            id: Uuid::nil(),
+            name: "size".to_string(),
+            filter: StreamFilter {
+                match_mode: FilterMatchMode::All,
+                rules: vec![StreamRule::Size { op, value }],
+            },
+            priority: 0,
+            enabled: true,
+            hidden: false,
+            created_at: String::new(),
+        }
+    }
+
+    fn info_with_size(filename: &str, size: Option<i64>) -> StreamInfo {
+        StreamInfo {
+            descriptor: StreamDescriptor::default(),
+            filename: Some(filename.to_string()),
+            size,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn size_gt_matches_large_release() {
+        let group = group_size(NumericOp::Gt, 20_000_000_000);
+        assert!(group.matches(&info_with_size(
+            "Movie.2024.1080p.BluRay.mkv",
+            Some(35_000_000_000)
+        )));
+    }
+
+    #[test]
+    fn size_gt_rejects_small_release() {
+        let group = group_size(NumericOp::Gt, 20_000_000_000);
+        assert!(!group.matches(&info_with_size(
+            "Movie.2024.1080p.WEBRip.mkv",
+            Some(2_000_000_000)
+        )));
+    }
+
+    // Regression guard: HTTP/debrid/IPTV sources almost never report a size.
+    // An unknown size must NOT be filtered out — only known sizes are filtered.
+    #[test]
+    fn size_unknown_passes() {
+        let group = group_size(NumericOp::Gt, 20_000_000_000);
+        assert!(group.matches(&info_with_size("Movie.2024.1080p.mkv", None)));
+    }
+
+    #[test]
+    fn size_ops_eq_not_eq_lt() {
+        let v = 5_000_000_000;
+        assert!(
+            group_size(NumericOp::Eq, v).matches(&info_with_size("a.mkv", Some(v)))
+        );
+        assert!(
+            !group_size(NumericOp::Eq, v)
+                .matches(&info_with_size("a.mkv", Some(v + 1)))
+        );
+        assert!(
+            group_size(NumericOp::NotEq, v)
+                .matches(&info_with_size("a.mkv", Some(v + 1)))
+        );
+        assert!(
+            group_size(NumericOp::Lt, v).matches(&info_with_size("a.mkv", Some(v - 1)))
+        );
+    }
+
+    #[test]
+    fn size_combined_with_resolution_all() {
+        let group = StreamGroup {
+            id: Uuid::nil(),
+            name: "1080p · big".to_string(),
+            filter: StreamFilter {
+                match_mode: FilterMatchMode::All,
+                rules: vec![
+                    StreamRule::Resolution {
+                        op: SetOp::In,
+                        values: vec![StreamResolution::R1080p],
+                    },
+                    StreamRule::Size {
+                        op: NumericOp::Gt,
+                        value: 20_000_000_000,
+                    },
+                ],
+            },
+            priority: 0,
+            enabled: true,
+            hidden: false,
+            created_at: String::new(),
+        };
+        assert!(group.matches(&info_with_size(
+            "Movie.2024.1080p.BluRay.mkv",
+            Some(35_000_000_000)
+        )));
+        assert!(!group.matches(&info_with_size(
+            "Movie.2024.1080p.WEBRip.mkv",
+            Some(1_000_000_000)
+        )));
+        assert!(!group.matches(&info_with_size(
+            "Movie.2024.720p.BluRay.mkv",
+            Some(35_000_000_000)
         )));
     }
 }


### PR DESCRIPTION
Added a Size rule to stream groups so they can filter releases by file
size (e.g. pick large BluRay Remux encodes over compressed WebRips).
Streams with unknown size pass the rule.

Also fixed torznab dropping the parsed release size — it now propagates
into StreamInfo.

Drafted with AI, reviewed and tested by me.