### PR TITLE
feat(stream-groups): add AudioLanguage rule from probe_data

### DIFF
--- a/crates/remux-dashboard/src/pages/streams.rs
+++ b/crates/remux-dashboard/src/pages/streams.rs
@@ -121,26 +121,28 @@ pub(crate) fn StreamRuleRow(
                         }
                     }
                 } else if field_val == "audio_language" {
-                    for (code, name) in common_audio_languages() {
-                        {
-                            let code = code.to_string();
-                            let checked = match &rule {
-                                StreamRule::AudioLanguage { values, .. } => values.contains(&code),
-                                _ => false,
-                            };
-                            rsx! {
-                                label { style: "display:flex;align-items:center;gap:3px;font-size:.82rem;cursor:pointer",
-                                    input {
-                                        r#type: "checkbox",
-                                        checked,
-                                        onchange: move |e| {
-                                            if let Some(StreamRule::AudioLanguage { values, .. }) = rules.write().get_mut(idx) {
-                                                if e.checked() { if !values.contains(&code) { values.push(code.clone()); } }
-                                                else { values.retain(|c| c != &code); }
-                                            }
-                                        },
+                    div { style: "display:grid;grid-template-columns:1fr 1fr;gap:6px;width:100%",
+                        for (code, name) in common_audio_languages() {
+                            {
+                                let code = code.to_string();
+                                let checked = match &rule {
+                                    StreamRule::AudioLanguage { values, .. } => values.contains(&code),
+                                    _ => false,
+                                };
+                                rsx! {
+                                    label { style: "display:flex;align-items:center;gap:3px;font-size:.82rem;cursor:pointer",
+                                        input {
+                                            r#type: "checkbox",
+                                            checked,
+                                            onchange: move |e| {
+                                                if let Some(StreamRule::AudioLanguage { values, .. }) = rules.write().get_mut(idx) {
+                                                    if e.checked() { if !values.contains(&code) { values.push(code.clone()); } }
+                                                    else { values.retain(|c| c != &code); }
+                                                }
+                                            },
+                                        }
+                                        "{name}"
                                     }
-                                    "{name}"
                                 }
                             }
                         }

--- a/crates/remux-dashboard/src/pages/streams.rs
+++ b/crates/remux-dashboard/src/pages/streams.rs
@@ -4,7 +4,8 @@ use crate::{
 };
 use dioxus::prelude::*;
 use remux_sdks::remux::{
-    CreateStreamGroup, CreateStreamGroupRequest, DeleteStreamGroup, FilterMatchMode,
+    common_audio_languages, language_label, CreateStreamGroup,
+    CreateStreamGroupRequest, DeleteStreamGroup, FilterMatchMode,
     GetStreamGroupPreview, GetSystemConfiguration, ListStreamGroups,
     ServerConfiguration, SetOp, StreamCodec, StreamFilter, StreamGroupDto,
     StreamGroupPreviewDto, StreamQuality, StreamResolution, StreamRule,
@@ -22,11 +23,13 @@ pub(crate) fn StreamRuleRow(
         StreamRule::Resolution { .. } => "resolution",
         StreamRule::Quality { .. } => "quality",
         StreamRule::Codec { .. } => "codec",
+        StreamRule::AudioLanguage { .. } => "audio_language",
     };
     let op_not_in = match &rule {
         StreamRule::Resolution { op, .. }
         | StreamRule::Quality { op, .. }
-        | StreamRule::Codec { op, .. } => matches!(op, SetOp::NotIn),
+        | StreamRule::Codec { op, .. }
+        | StreamRule::AudioLanguage { op, .. } => matches!(op, SetOp::NotIn),
     };
 
     rsx! {
@@ -41,6 +44,9 @@ pub(crate) fn StreamRuleRow(
                         *r = match e.value().as_str() {
                             "quality" => StreamRule::Quality { op: SetOp::In, values: vec![] },
                             "codec"  => StreamRule::Codec  { op: SetOp::In, values: vec![] },
+                            "audio_language" => {
+                                StreamRule::AudioLanguage { op: SetOp::In, values: vec![] }
+                            }
                             _        => StreamRule::Resolution { op: SetOp::In, values: vec![] },
                         };
                     }
@@ -48,6 +54,7 @@ pub(crate) fn StreamRuleRow(
                 option { value: "resolution", selected: field_val == "resolution", "Resolution" }
                 option { value: "quality",     selected: field_val == "quality",     "Quality" }
                 option { value: "codec",      selected: field_val == "codec",      "Codec" }
+                option { value: "audio_language", selected: field_val == "audio_language", "Audio Language" }
             }
             // Operator selector
             select {
@@ -60,6 +67,7 @@ pub(crate) fn StreamRuleRow(
                             StreamRule::Resolution { values, .. } => StreamRule::Resolution { op: new_op, values },
                             StreamRule::Quality { values, .. }     => StreamRule::Quality { op: new_op, values },
                             StreamRule::Codec { values, .. }      => StreamRule::Codec  { op: new_op, values },
+                            StreamRule::AudioLanguage { values, .. } => StreamRule::AudioLanguage { op: new_op, values },
                         };
                     }
                 },
@@ -108,6 +116,31 @@ pub(crate) fn StreamRuleRow(
                                         },
                                     }
                                     "{src.label()}"
+                                }
+                            }
+                        }
+                    }
+                } else if field_val == "audio_language" {
+                    for (code, name) in common_audio_languages() {
+                        {
+                            let code = code.to_string();
+                            let checked = match &rule {
+                                StreamRule::AudioLanguage { values, .. } => values.contains(&code),
+                                _ => false,
+                            };
+                            rsx! {
+                                label { style: "display:flex;align-items:center;gap:3px;font-size:.82rem;cursor:pointer",
+                                    input {
+                                        r#type: "checkbox",
+                                        checked,
+                                        onchange: move |e| {
+                                            if let Some(StreamRule::AudioLanguage { values, .. }) = rules.write().get_mut(idx) {
+                                                if e.checked() { if !values.contains(&code) { values.push(code.clone()); } }
+                                                else { values.retain(|c| c != &code); }
+                                            }
+                                        },
+                                    }
+                                    "{name}"
                                 }
                             }
                         }
@@ -399,6 +432,10 @@ pub fn StreamGroupsCard(app_state: AppState) -> Element {
                                                             StreamRule::Codec { op, values } => {
                                                                 let lbl = values.iter().map(|v| v.label()).collect::<Vec<_>>().join("/");
                                                                 (lbl, matches!(op, SetOp::NotIn), "background:rgba(16,185,129,.12);color:rgb(5,150,105);padding:1px 6px;border-radius:4px")
+                                                            }
+                                                            StreamRule::AudioLanguage { op, values } => {
+                                                                let lbl = values.iter().map(|c| language_label(c)).collect::<Vec<_>>().join("/");
+                                                                (lbl, matches!(op, SetOp::NotIn), "background:rgba(245,158,11,.12);color:rgb(217,119,6);padding:1px 6px;border-radius:4px")
                                                             }
                                                         };
                                                         let prefix = if is_excl { "NOT " } else { "" };

--- a/crates/remux-sdks/src/remux/mod.rs
+++ b/crates/remux-sdks/src/remux/mod.rs
@@ -1643,8 +1643,15 @@ mod tests {
         assert_eq!(language_label("rus"), "Russian");
         assert_eq!(language_label("ENG"), "English");
         assert_eq!(language_label("fra"), "French");
-        // Unknown code falls back to the raw string.
+        assert_eq!(language_label("deu"), "German");
         assert_eq!(language_label("xxx"), "xxx");
+    }
+
+    #[test]
+    fn normalize_lang_code_maps_terminologic_to_bibliographic() {
+        assert_eq!(normalize_lang_code("fra"), "fre");
+        assert_eq!(normalize_lang_code("DEU"), "ger");
+        assert_eq!(normalize_lang_code("rus"), "rus");
     }
 
     #[test]
@@ -1655,6 +1662,8 @@ mod tests {
             .collect();
         assert!(codes.contains(&"rus"));
         assert!(codes.contains(&"eng"));
+        assert!(!codes.contains(&"fra"));
+        assert!(!codes.contains(&"deu"));
     }
 }
 
@@ -5652,34 +5661,46 @@ impl StreamCodec {
 
 /// Common audio languages for the stream-group UI, alphabetical by display name.
 /// Key = ISO 639-2/B code (`MediaStream.language`), value = display name.
-/// `fre`/`fra` and `ger`/`deu` are both listed because ffprobe may emit either.
 pub fn common_audio_languages() -> &'static [(&'static str, &'static str)] {
     &[
         ("ara", "Arabic"),
         ("chi", "Chinese"),
         ("eng", "English"),
         ("fre", "French"),
-        ("fra", "French"),
         ("ger", "German"),
-        ("deu", "German"),
+        ("heb", "Hebrew"),
         ("hin", "Hindi"),
         ("ita", "Italian"),
         ("jpn", "Japanese"),
         ("kor", "Korean"),
         ("pol", "Polish"),
         ("por", "Portuguese"),
+        ("ron", "Romanian"),
         ("rus", "Russian"),
         ("spa", "Spanish"),
         ("tur", "Turkish"),
         ("ukr", "Ukrainian"),
+        ("vie", "Vietnamese"),
     ]
+}
+
+pub fn normalize_lang_code(code: &str) -> String {
+    match code
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "fra" => "fre".to_string(),
+        "deu" => "ger".to_string(),
+        other => other.to_string(),
+    }
 }
 
 /// Display name for an ISO 639-2/B code, falling back to the raw code.
 pub fn language_label(code: &str) -> String {
+    let canon = normalize_lang_code(code);
     common_audio_languages()
         .iter()
-        .find(|(c, _)| c.eq_ignore_ascii_case(code))
+        .find(|(c, _)| c.eq_ignore_ascii_case(&canon))
         .map(|(_, name)| (*name).to_string())
         .unwrap_or_else(|| code.to_string())
 }

--- a/crates/remux-sdks/src/remux/mod.rs
+++ b/crates/remux-sdks/src/remux/mod.rs
@@ -1622,6 +1622,40 @@ mod tests {
                 .is_none()
         );
     }
+
+    #[test]
+    fn stream_rule_audio_language_round_trips() {
+        let rule = StreamRule::AudioLanguage {
+            op: SetOp::Is,
+            values: vec!["rus".to_string()],
+        };
+        let json = serde_json::to_string(&rule).unwrap();
+        assert_eq!(
+            json,
+            r#"{"field":"audio_language","op":"is","values":["rus"]}"#
+        );
+        let back: StreamRule = serde_json::from_str(&json).unwrap();
+        assert_eq!(rule, back);
+    }
+
+    #[test]
+    fn language_label_maps_known_codes_and_falls_back() {
+        assert_eq!(language_label("rus"), "Russian");
+        assert_eq!(language_label("ENG"), "English");
+        assert_eq!(language_label("fra"), "French");
+        // Unknown code falls back to the raw string.
+        assert_eq!(language_label("xxx"), "xxx");
+    }
+
+    #[test]
+    fn common_audio_languages_includes_russian_and_english() {
+        let codes: Vec<&str> = common_audio_languages()
+            .iter()
+            .map(|(c, _)| *c)
+            .collect();
+        assert!(codes.contains(&"rus"));
+        assert!(codes.contains(&"eng"));
+    }
 }
 
 #[derive(Default, Debug, Deserialize)]
@@ -5616,6 +5650,40 @@ impl StreamCodec {
     }
 }
 
+/// Common audio languages for the stream-group UI, alphabetical by display name.
+/// Key = ISO 639-2/B code (`MediaStream.language`), value = display name.
+/// `fre`/`fra` and `ger`/`deu` are both listed because ffprobe may emit either.
+pub fn common_audio_languages() -> &'static [(&'static str, &'static str)] {
+    &[
+        ("ara", "Arabic"),
+        ("chi", "Chinese"),
+        ("eng", "English"),
+        ("fre", "French"),
+        ("fra", "French"),
+        ("ger", "German"),
+        ("deu", "German"),
+        ("hin", "Hindi"),
+        ("ita", "Italian"),
+        ("jpn", "Japanese"),
+        ("kor", "Korean"),
+        ("pol", "Polish"),
+        ("por", "Portuguese"),
+        ("rus", "Russian"),
+        ("spa", "Spanish"),
+        ("tur", "Turkish"),
+        ("ukr", "Ukrainian"),
+    ]
+}
+
+/// Display name for an ISO 639-2/B code, falling back to the raw code.
+pub fn language_label(code: &str) -> String {
+    common_audio_languages()
+        .iter()
+        .find(|(c, _)| c.eq_ignore_ascii_case(code))
+        .map(|(_, name)| (*name).to_string())
+        .unwrap_or_else(|| code.to_string())
+}
+
 /// One condition in a stream group filter. Mirrors `FilterRule` but for stream attributes.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "field", rename_all = "snake_case")]
@@ -5631,6 +5699,13 @@ pub enum StreamRule {
     Codec {
         op: SetOp,
         values: Vec<StreamCodec>,
+    },
+    /// Audio track language (ISO 639-2/B code, e.g. "rus", "eng"). Matches if any
+    /// audio stream in `probe_data` has a listed language. A stream with no probe
+    /// data passes the rule so unprobed sources are not silently dropped.
+    AudioLanguage {
+        op: SetOp,
+        values: Vec<String>,
     },
 }
 

--- a/crates/remux-server/src/api/remux.rs
+++ b/crates/remux-server/src/api/remux.rs
@@ -478,11 +478,11 @@ async fn streams_metadata(state: &AppState, id: Uuid) -> AnyResult<StreamsRespon
                 s.stream_info
                     .as_ref()
                     .map_or(false, |info| {
-                        group.matches(
+                        group.match_outcome(
                             info,
                             s.probe_data
                                 .as_ref(),
-                        )
+                        ) == db::MatchOutcome::Match
                     })
             })
             .collect();

--- a/crates/remux-server/src/api/remux.rs
+++ b/crates/remux-server/src/api/remux.rs
@@ -477,7 +477,13 @@ async fn streams_metadata(state: &AppState, id: Uuid) -> AnyResult<StreamsRespon
             .filter(|s| {
                 s.stream_info
                     .as_ref()
-                    .map_or(false, |info| group.matches(info))
+                    .map_or(false, |info| {
+                        group.matches(
+                            info,
+                            s.probe_data
+                                .as_ref(),
+                        )
+                    })
             })
             .collect();
 
@@ -491,7 +497,7 @@ async fn streams_metadata(state: &AppState, id: Uuid) -> AnyResult<StreamsRespon
 
         let best = matching[0];
         let description = {
-            use remux_sdks::remux::StreamRule;
+            use remux_sdks::remux::{StreamRule, language_label};
             let parts: Vec<String> = group
                 .filter
                 .rules
@@ -510,6 +516,11 @@ async fn streams_metadata(state: &AppState, id: Uuid) -> AnyResult<StreamsRespon
                     StreamRule::Codec { values, .. } => values
                         .iter()
                         .map(|v| v.label())
+                        .collect::<Vec<_>>()
+                        .join("/"),
+                    StreamRule::AudioLanguage { values, .. } => values
+                        .iter()
+                        .map(|c| language_label(c))
                         .collect::<Vec<_>>()
                         .join("/"),
                 })

--- a/crates/remux-server/src/api/stream_group.rs
+++ b/crates/remux-server/src/api/stream_group.rs
@@ -12,7 +12,9 @@ use uuid::Uuid;
 
 use crate::{
     AppState,
-    db::{ExternalIds, Media, MediaKind, NonEmptyString, StreamGroup, auth},
+    db::{
+        ExternalIds, MatchOutcome, Media, MediaKind, NonEmptyString, StreamGroup, auth,
+    },
 };
 use axum_anyhow::ApiResult as Result;
 
@@ -216,11 +218,11 @@ pub async fn stream_group_preview(
                 s.stream_info
                     .as_ref()
                     .map_or(false, |info| {
-                        group.matches(
+                        group.match_outcome(
                             info,
                             s.probe_data
                                 .as_ref(),
-                        )
+                        ) == MatchOutcome::Match
                     })
             })
             .collect();

--- a/crates/remux-server/src/api/stream_group.rs
+++ b/crates/remux-server/src/api/stream_group.rs
@@ -215,7 +215,13 @@ pub async fn stream_group_preview(
             .filter(|s| {
                 s.stream_info
                     .as_ref()
-                    .map_or(false, |info| group.matches(info))
+                    .map_or(false, |info| {
+                        group.matches(
+                            info,
+                            s.probe_data
+                                .as_ref(),
+                        )
+                    })
             })
             .collect();
 

--- a/crates/remux-server/src/db/stream_group.rs
+++ b/crates/remux-server/src/db/stream_group.rs
@@ -2,13 +2,14 @@ use anyhow::Result;
 use chrono::Utc;
 use remux_sdks::remux::{
     FilterMatchMode, SetOp, StreamCodec, StreamFilter, StreamQuality, StreamResolution,
-    StreamRule,
+    StreamRule, language_label,
 };
 use sqlx::SqlitePool;
 use std::collections::HashSet;
 use uuid::Uuid;
 
 use crate::{
+    api::MediaStreamType,
     db::{Media, Settings, StreamGroupData},
     stream::StreamInfo,
 };
@@ -249,7 +250,13 @@ impl StreamGroup {
                 .filter(|s| {
                     s.stream_info
                         .as_ref()
-                        .map_or(false, |info| group.matches(info))
+                        .map_or(false, |info| {
+                            group.matches(
+                                info,
+                                s.probe_data
+                                    .as_ref(),
+                            )
+                        })
                 })
                 .collect();
 
@@ -308,15 +315,27 @@ pub fn apply_stream_filter(filter: &StreamFilter, sources: Vec<Media>) -> Vec<Me
         .filter(|s| {
             s.stream_info
                 .as_ref()
-                .map_or(true, |info| temp.matches(info))
+                .map_or(true, |info| {
+                    temp.matches(
+                        info,
+                        s.probe_data
+                            .as_ref(),
+                    )
+                })
         })
         .collect()
 }
 
 impl StreamGroup {
-    /// Returns true if the given StreamInfo matches this group's filter.
-    /// An empty filter (no rules) matches everything.
-    pub fn matches(&self, info: &StreamInfo) -> bool {
+    /// Returns true if the given source matches this group's filter.
+    /// `info` carries filename/resolution inputs; `probe_data` (from the parent
+    /// `Media`, NOT `StreamInfo.probe_data`, which is usually empty) supplies
+    /// audio-language data. An empty filter matches everything.
+    pub fn matches(
+        &self,
+        info: &StreamInfo,
+        probe_data: Option<&crate::api::MediaSourceInfo>,
+    ) -> bool {
         let filter = &self.filter;
         if filter
             .rules
@@ -402,6 +421,34 @@ impl StreamGroup {
                 let hit = values.contains(&codec);
                 matches!(op, SetOp::In | SetOp::Is) == hit
             }
+            // No probe data → no match. Unprobed sources must NOT be absorbed
+            // by the group (which only shows one representative); they fall
+            // through to the ungrouped list so they remain visible.
+            StreamRule::AudioLanguage { op, values } => match probe_data {
+                None => false,
+                Some(pd) => {
+                    let wanted: Vec<String> = values
+                        .iter()
+                        .map(|v| v.to_ascii_lowercase())
+                        .collect();
+                    let hit = pd
+                        .media_streams
+                        .iter()
+                        .any(|s| {
+                            s.type_ == Some(MediaStreamType::Audio)
+                                && s.language
+                                    .as_deref()
+                                    .map_or(false, |l| {
+                                        let l = l.to_ascii_lowercase();
+                                        !matches!(
+                                            l.as_str(),
+                                            "und" | "mis" | "zxx" | "mul"
+                                        ) && wanted.contains(&l)
+                                    })
+                        });
+                    matches!(op, SetOp::In | SetOp::Is) == hit
+                }
+            },
         };
 
         match filter.match_mode {
@@ -422,7 +469,13 @@ impl StreamGroup {
             .filter(|s| {
                 s.stream_info
                     .as_ref()
-                    .map_or(false, |info| group.matches(info))
+                    .map_or(false, |info| {
+                        group.matches(
+                            info,
+                            s.probe_data
+                                .as_ref(),
+                        )
+                    })
             })
             .cloned()
             .collect();
@@ -512,18 +565,25 @@ fn auto_name(filter: &StreamFilter) -> String {
         .rules
         .iter()
         .filter_map(|r| {
-            let labels: Vec<&str> = match r {
+            let labels: Vec<String> = match r {
                 StreamRule::Resolution { values, .. } => values
                     .iter()
                     .map(|v| v.label())
+                    .map(str::to_owned)
                     .collect(),
                 StreamRule::Quality { values, .. } => values
                     .iter()
                     .map(|v| v.label())
+                    .map(str::to_owned)
                     .collect(),
                 StreamRule::Codec { values, .. } => values
                     .iter()
                     .map(|v| v.label())
+                    .map(str::to_owned)
+                    .collect(),
+                StreamRule::AudioLanguage { values, .. } => values
+                    .iter()
+                    .map(|c| language_label(c))
                     .collect(),
             };
             if labels.is_empty() {
@@ -629,22 +689,144 @@ mod tests {
     #[test]
     fn uhd_bluray_source_with_explicit_1080p_matches_1080p_group() {
         let group = group_1080p_bluray();
-        assert!(group.matches(&info(
-            "The Martian 2015 Extended Cut UHD BluRay 1080p DD Atmos 5 1 DoVi HDR10 x265-SM737.mkv"
-        )));
-        assert!(group.matches(&info(
-            "The.Housemaid.2025.UHD.BluRay.1080p.DD+Atmos.5.1.DoVi.HDR10+.x265-SM737.mkv"
-        )));
-        assert!(group.matches(&info(
-            "The Housemaid 2025 REPACK UHD BluRay 1080p DD Atmos 5 1 DoVi HDR10 x265-SM737.mkv"
-        )));
+        assert!(group.matches(
+            &info(
+                "The Martian 2015 Extended Cut UHD BluRay 1080p DD Atmos 5 1 DoVi HDR10 x265-SM737.mkv"
+            ),
+            None
+        ));
+        assert!(group.matches(
+            &info(
+                "The.Housemaid.2025.UHD.BluRay.1080p.DD+Atmos.5.1.DoVi.HDR10+.x265-SM737.mkv"
+            ),
+            None
+        ));
+        assert!(group.matches(
+            &info(
+                "The Housemaid 2025 REPACK UHD BluRay 1080p DD Atmos 5 1 DoVi HDR10 x265-SM737.mkv"
+            ),
+            None
+        ));
     }
 
     #[test]
     fn genuine_2160p_release_does_not_match_1080p_group() {
         let group = group_1080p_bluray();
-        assert!(!group.matches(&info(
-            "The Martian 2015 UHD BluRay 2160p HDR10 DoVi Atmos x265-GROUP.mkv"
-        )));
+        assert!(!group.matches(
+            &info("The Martian 2015 UHD BluRay 2160p HDR10 DoVi Atmos x265-GROUP.mkv"),
+            None
+        ));
+    }
+
+    fn group_audio_lang(op: SetOp, values: &[&str]) -> StreamGroup {
+        StreamGroup {
+            id: Uuid::nil(),
+            name: "audio".to_string(),
+            filter: StreamFilter {
+                match_mode: FilterMatchMode::All,
+                rules: vec![StreamRule::AudioLanguage {
+                    op,
+                    values: values
+                        .iter()
+                        .map(|s| s.to_string())
+                        .collect(),
+                }],
+            },
+            priority: 0,
+            enabled: true,
+            hidden: false,
+            created_at: String::new(),
+        }
+    }
+
+    fn probe_with_langs(langs: &[&str]) -> crate::api::MediaSourceInfo {
+        use crate::api::MediaStream;
+        let media_streams = langs
+            .iter()
+            .map(|l| MediaStream {
+                type_: Some(MediaStreamType::Audio),
+                language: Some(l.to_string()),
+                ..Default::default()
+            })
+            .collect();
+        crate::api::MediaSourceInfo {
+            media_streams,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn audio_lang_matches_when_listed() {
+        let group = group_audio_lang(SetOp::Is, &["rus"]);
+        let probe = probe_with_langs(&["rus"]);
+        assert!(group.matches(&info("a.mkv"), Some(&probe)));
+    }
+
+    #[test]
+    fn audio_lang_rejects_when_language_differs() {
+        let group = group_audio_lang(SetOp::Is, &["rus"]);
+        let probe = probe_with_langs(&["eng"]);
+        assert!(!group.matches(&info("a.mkv"), Some(&probe)));
+    }
+
+    // An unprobed source (no probe_data) must NOT match the group: the group
+    // only shows one representative, so absorbing an unmatched source would
+    // hide it. It falls through to the ungrouped list instead.
+    #[test]
+    fn audio_lang_unprobed_does_not_match() {
+        let group = group_audio_lang(SetOp::Is, &["rus"]);
+        assert!(!group.matches(&info("a.mkv"), None));
+    }
+
+    #[test]
+    fn audio_lang_case_insensitive_and_any_track() {
+        let group = group_audio_lang(SetOp::In, &["rus"]);
+        assert!(group.matches(&info("a.mkv"), Some(&probe_with_langs(&["RUS"]))));
+        assert!(
+            group.matches(&info("a.mkv"), Some(&probe_with_langs(&["eng", "rus"])))
+        );
+    }
+
+    #[test]
+    fn audio_lang_isnot_inverts() {
+        let group = group_audio_lang(SetOp::NotIn, &["rus"]);
+        assert!(!group.matches(&info("a.mkv"), Some(&probe_with_langs(&["rus"]))));
+        assert!(group.matches(&info("a.mkv"), Some(&probe_with_langs(&["eng"]))));
+    }
+
+    // Special "no-linguistic-content" codes are treated as no language.
+    #[test]
+    fn audio_lang_ignores_special_codes() {
+        let group = group_audio_lang(SetOp::Is, &["rus"]);
+        assert!(!group.matches(&info("a.mkv"), Some(&probe_with_langs(&["und"]))));
+        assert!(!group.matches(&info("a.mkv"), Some(&probe_with_langs(&["mul"]))));
+    }
+
+    // A Resolution rule is inferred via hunch from the filename, so a source
+    // without a filename cannot match a Resolution-only group.
+    #[test]
+    fn resolution_group_rejects_source_without_filename() {
+        let group = StreamGroup {
+            id: Uuid::nil(),
+            name: "1080p".to_string(),
+            filter: StreamFilter {
+                match_mode: FilterMatchMode::All,
+                rules: vec![StreamRule::Resolution {
+                    op: SetOp::In,
+                    values: vec![StreamResolution::R1080p],
+                }],
+            },
+            priority: 0,
+            enabled: true,
+            hidden: false,
+            created_at: String::new(),
+        };
+        let si = StreamInfo {
+            descriptor: StreamDescriptor::default(),
+            filename: None,
+            name: None,
+            ..Default::default()
+        };
+        assert!(!group.matches(&si, None));
     }
 }

--- a/crates/remux-server/src/db/stream_group.rs
+++ b/crates/remux-server/src/db/stream_group.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use chrono::Utc;
 use remux_sdks::remux::{
     FilterMatchMode, SetOp, StreamCodec, StreamFilter, StreamQuality, StreamResolution,
-    StreamRule, language_label,
+    StreamRule, language_label, normalize_lang_code,
 };
 use sqlx::SqlitePool;
 use std::collections::HashSet;
@@ -429,7 +429,7 @@ impl StreamGroup {
                 Some(pd) => {
                     let wanted: Vec<String> = values
                         .iter()
-                        .map(|v| v.to_ascii_lowercase())
+                        .map(|v| normalize_lang_code(v))
                         .collect();
                     let hit = pd
                         .media_streams
@@ -439,7 +439,7 @@ impl StreamGroup {
                                 && s.language
                                     .as_deref()
                                     .map_or(false, |l| {
-                                        let l = l.to_ascii_lowercase();
+                                        let l = normalize_lang_code(l);
                                         !matches!(
                                             l.as_str(),
                                             "und" | "mis" | "zxx" | "mul"

--- a/crates/remux-server/src/db/stream_group.rs
+++ b/crates/remux-server/src/db/stream_group.rs
@@ -27,6 +27,21 @@ pub struct StreamGroup {
     pub created_at: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MatchOutcome {
+    Match,
+    PassThrough,
+    NoMatch,
+}
+
+fn bool_to_outcome(hit: bool) -> MatchOutcome {
+    if hit {
+        MatchOutcome::Match
+    } else {
+        MatchOutcome::NoMatch
+    }
+}
+
 impl StreamGroup {
     pub fn display_name(&self) -> String {
         if !self
@@ -251,11 +266,11 @@ impl StreamGroup {
                     s.stream_info
                         .as_ref()
                         .map_or(false, |info| {
-                            group.matches(
+                            group.match_outcome(
                                 info,
                                 s.probe_data
                                     .as_ref(),
-                            )
+                            ) == MatchOutcome::Match
                         })
                 })
                 .collect();
@@ -316,32 +331,28 @@ pub fn apply_stream_filter(filter: &StreamFilter, sources: Vec<Media>) -> Vec<Me
             s.stream_info
                 .as_ref()
                 .map_or(true, |info| {
-                    temp.matches(
+                    temp.match_outcome(
                         info,
                         s.probe_data
                             .as_ref(),
-                    )
+                    ) != MatchOutcome::NoMatch
                 })
         })
         .collect()
 }
 
 impl StreamGroup {
-    /// Returns true if the given source matches this group's filter.
-    /// `info` carries filename/resolution inputs; `probe_data` (from the parent
-    /// `Media`, NOT `StreamInfo.probe_data`, which is usually empty) supplies
-    /// audio-language data. An empty filter matches everything.
-    pub fn matches(
+    pub fn match_outcome(
         &self,
         info: &StreamInfo,
         probe_data: Option<&crate::api::MediaSourceInfo>,
-    ) -> bool {
+    ) -> MatchOutcome {
         let filter = &self.filter;
         if filter
             .rules
             .is_empty()
         {
-            return true;
+            return MatchOutcome::Match;
         }
 
         let raw = match info
@@ -352,13 +363,9 @@ impl StreamGroup {
                 .as_deref())
         {
             Some(s) => s,
-            None => return false,
+            None => return MatchOutcome::NoMatch,
         };
 
-        // Stremio/addon sources often use a multi-line name where the first
-        // line is a provider prefix and later lines contain the actual filename.
-        // Parse each non-empty line with hunch and use the one that yields the
-        // richest result (has at least a resolution or source hit).
         let candidates: Vec<&str> = if raw.contains('\n') {
             raw.lines()
                 .filter(|l| {
@@ -382,7 +389,7 @@ impl StreamGroup {
 
         let parsed = match best {
             Some(p) => p,
-            None => return false,
+            None => return MatchOutcome::NoMatch,
         };
 
         let resolution = min_screen_size(&parsed)
@@ -401,65 +408,88 @@ impl StreamGroup {
             .and_then(StreamCodec::from_hunch)
             .unwrap_or(StreamCodec::Unknown);
 
-        let eval = |rule: &StreamRule| match rule {
-            StreamRule::Resolution { op, values } => {
-                // When resolution is unknown and the rule doesn't explicitly target Unknown,
-                // let the stream through so source/codec rules can still match.
-                if resolution == StreamResolution::Unknown
-                    && !values.contains(&StreamResolution::Unknown)
-                {
-                    return true;
+        let eval = |rule: &StreamRule| -> MatchOutcome {
+            match rule {
+                StreamRule::Resolution { op, values } => {
+                    if resolution == StreamResolution::Unknown
+                        && !values.contains(&StreamResolution::Unknown)
+                    {
+                        return MatchOutcome::PassThrough;
+                    }
+                    let hit = values.contains(&resolution);
+                    bool_to_outcome(matches!(op, SetOp::In | SetOp::Is) == hit)
                 }
-                let hit = values.contains(&resolution);
-                matches!(op, SetOp::In | SetOp::Is) == hit
-            }
-            StreamRule::Quality { op, values } => {
-                let hit = values.contains(&source);
-                matches!(op, SetOp::In | SetOp::Is) == hit
-            }
-            StreamRule::Codec { op, values } => {
-                let hit = values.contains(&codec);
-                matches!(op, SetOp::In | SetOp::Is) == hit
-            }
-            // No probe data → no match. Unprobed sources must NOT be absorbed
-            // by the group (which only shows one representative); they fall
-            // through to the ungrouped list so they remain visible.
-            StreamRule::AudioLanguage { op, values } => match probe_data {
-                None => false,
-                Some(pd) => {
-                    let wanted: Vec<String> = values
-                        .iter()
-                        .map(|v| normalize_lang_code(v))
-                        .collect();
-                    let hit = pd
-                        .media_streams
-                        .iter()
-                        .any(|s| {
-                            s.type_ == Some(MediaStreamType::Audio)
-                                && s.language
-                                    .as_deref()
-                                    .map_or(false, |l| {
-                                        let l = normalize_lang_code(l);
-                                        !matches!(
-                                            l.as_str(),
-                                            "und" | "mis" | "zxx" | "mul"
-                                        ) && wanted.contains(&l)
-                                    })
-                        });
-                    matches!(op, SetOp::In | SetOp::Is) == hit
+                StreamRule::Quality { op, values } => {
+                    let hit = values.contains(&source);
+                    bool_to_outcome(matches!(op, SetOp::In | SetOp::Is) == hit)
                 }
-            },
+                StreamRule::Codec { op, values } => {
+                    let hit = values.contains(&codec);
+                    bool_to_outcome(matches!(op, SetOp::In | SetOp::Is) == hit)
+                }
+                // No probe data → PassThrough: we can't confirm or deny the
+                // language, so the source must not be absorbed by the group
+                // (which shows only one representative) but also must not be
+                // hidden — it stays visible via the ungrouped list.
+                StreamRule::AudioLanguage { op, values } => match probe_data {
+                    None => MatchOutcome::PassThrough,
+                    Some(pd) => {
+                        let wanted: Vec<String> = values
+                            .iter()
+                            .map(|v| normalize_lang_code(v))
+                            .collect();
+                        let hit = pd
+                            .media_streams
+                            .iter()
+                            .any(|s| {
+                                s.type_ == Some(MediaStreamType::Audio)
+                                    && s.language
+                                        .as_deref()
+                                        .map_or(false, |l| {
+                                            let l = normalize_lang_code(l);
+                                            !matches!(
+                                                l.as_str(),
+                                                "und" | "mis" | "zxx" | "mul"
+                                            ) && wanted.contains(&l)
+                                        })
+                            });
+                        bool_to_outcome(matches!(op, SetOp::In | SetOp::Is) == hit)
+                    }
+                },
+            }
         };
 
+        let outcomes: Vec<MatchOutcome> = filter
+            .rules
+            .iter()
+            .map(eval)
+            .collect();
         match filter.match_mode {
-            FilterMatchMode::All => filter
-                .rules
-                .iter()
-                .all(eval),
-            FilterMatchMode::Any => filter
-                .rules
-                .iter()
-                .any(eval),
+            FilterMatchMode::All => {
+                if outcomes
+                    .iter()
+                    .any(|o| matches!(o, MatchOutcome::NoMatch))
+                {
+                    MatchOutcome::NoMatch
+                } else if outcomes
+                    .iter()
+                    .any(|o| matches!(o, MatchOutcome::PassThrough))
+                {
+                    MatchOutcome::PassThrough
+                } else {
+                    MatchOutcome::Match
+                }
+            }
+            FilterMatchMode::Any => {
+                if outcomes
+                    .iter()
+                    .any(|o| matches!(o, MatchOutcome::Match))
+                {
+                    MatchOutcome::Match
+                } else {
+                    MatchOutcome::NoMatch
+                }
+            }
         }
     }
 
@@ -470,11 +500,11 @@ impl StreamGroup {
                 s.stream_info
                     .as_ref()
                     .map_or(false, |info| {
-                        group.matches(
+                        group.match_outcome(
                             info,
                             s.probe_data
                                 .as_ref(),
-                        )
+                        ) == MatchOutcome::Match
                     })
             })
             .cloned()
@@ -689,33 +719,47 @@ mod tests {
     #[test]
     fn uhd_bluray_source_with_explicit_1080p_matches_1080p_group() {
         let group = group_1080p_bluray();
-        assert!(group.matches(
-            &info(
-                "The Martian 2015 Extended Cut UHD BluRay 1080p DD Atmos 5 1 DoVi HDR10 x265-SM737.mkv"
+        assert_eq!(
+            group.match_outcome(
+                &info(
+                    "The Martian 2015 Extended Cut UHD BluRay 1080p DD Atmos 5 1 DoVi HDR10 x265-SM737.mkv"
+                ),
+                None
             ),
-            None
-        ));
-        assert!(group.matches(
-            &info(
-                "The.Housemaid.2025.UHD.BluRay.1080p.DD+Atmos.5.1.DoVi.HDR10+.x265-SM737.mkv"
+            MatchOutcome::Match
+        );
+        assert_eq!(
+            group.match_outcome(
+                &info(
+                    "The.Housemaid.2025.UHD.BluRay.1080p.DD+Atmos.5.1.DoVi.HDR10+.x265-SM737.mkv"
+                ),
+                None
             ),
-            None
-        ));
-        assert!(group.matches(
-            &info(
-                "The Housemaid 2025 REPACK UHD BluRay 1080p DD Atmos 5 1 DoVi HDR10 x265-SM737.mkv"
+            MatchOutcome::Match
+        );
+        assert_eq!(
+            group.match_outcome(
+                &info(
+                    "The Housemaid 2025 REPACK UHD BluRay 1080p DD Atmos 5 1 DoVi HDR10 x265-SM737.mkv"
+                ),
+                None
             ),
-            None
-        ));
+            MatchOutcome::Match
+        );
     }
 
     #[test]
     fn genuine_2160p_release_does_not_match_1080p_group() {
         let group = group_1080p_bluray();
-        assert!(!group.matches(
-            &info("The Martian 2015 UHD BluRay 2160p HDR10 DoVi Atmos x265-GROUP.mkv"),
-            None
-        ));
+        assert_eq!(
+            group.match_outcome(
+                &info(
+                    "The Martian 2015 UHD BluRay 2160p HDR10 DoVi Atmos x265-GROUP.mkv"
+                ),
+                None
+            ),
+            MatchOutcome::NoMatch
+        );
     }
 
     fn group_audio_lang(op: SetOp, values: &[&str]) -> StreamGroup {
@@ -759,51 +803,76 @@ mod tests {
     fn audio_lang_matches_when_listed() {
         let group = group_audio_lang(SetOp::Is, &["rus"]);
         let probe = probe_with_langs(&["rus"]);
-        assert!(group.matches(&info("a.mkv"), Some(&probe)));
+        assert_eq!(
+            group.match_outcome(&info("a.mkv"), Some(&probe)),
+            MatchOutcome::Match
+        );
     }
 
     #[test]
     fn audio_lang_rejects_when_language_differs() {
         let group = group_audio_lang(SetOp::Is, &["rus"]);
         let probe = probe_with_langs(&["eng"]);
-        assert!(!group.matches(&info("a.mkv"), Some(&probe)));
+        assert_eq!(
+            group.match_outcome(&info("a.mkv"), Some(&probe)),
+            MatchOutcome::NoMatch
+        );
     }
 
-    // An unprobed source (no probe_data) must NOT match the group: the group
-    // only shows one representative, so absorbing an unmatched source would
-    // hide it. It falls through to the ungrouped list instead.
+    // An unprobed source passes through (not absorbed by the group, but stays
+    // visible via ungrouped). This matches the Size rule's None behavior.
     #[test]
-    fn audio_lang_unprobed_does_not_match() {
+    fn audio_lang_unprobed_is_passthrough() {
         let group = group_audio_lang(SetOp::Is, &["rus"]);
-        assert!(!group.matches(&info("a.mkv"), None));
+        assert_eq!(
+            group.match_outcome(&info("a.mkv"), None),
+            MatchOutcome::PassThrough
+        );
     }
 
     #[test]
     fn audio_lang_case_insensitive_and_any_track() {
         let group = group_audio_lang(SetOp::In, &["rus"]);
-        assert!(group.matches(&info("a.mkv"), Some(&probe_with_langs(&["RUS"]))));
-        assert!(
-            group.matches(&info("a.mkv"), Some(&probe_with_langs(&["eng", "rus"])))
+        assert_eq!(
+            group.match_outcome(&info("a.mkv"), Some(&probe_with_langs(&["RUS"]))),
+            MatchOutcome::Match
+        );
+        assert_eq!(
+            group.match_outcome(
+                &info("a.mkv"),
+                Some(&probe_with_langs(&["eng", "rus"]))
+            ),
+            MatchOutcome::Match
         );
     }
 
     #[test]
     fn audio_lang_isnot_inverts() {
         let group = group_audio_lang(SetOp::NotIn, &["rus"]);
-        assert!(!group.matches(&info("a.mkv"), Some(&probe_with_langs(&["rus"]))));
-        assert!(group.matches(&info("a.mkv"), Some(&probe_with_langs(&["eng"]))));
+        assert_eq!(
+            group.match_outcome(&info("a.mkv"), Some(&probe_with_langs(&["rus"]))),
+            MatchOutcome::NoMatch
+        );
+        assert_eq!(
+            group.match_outcome(&info("a.mkv"), Some(&probe_with_langs(&["eng"]))),
+            MatchOutcome::Match
+        );
     }
 
     // Special "no-linguistic-content" codes are treated as no language.
     #[test]
     fn audio_lang_ignores_special_codes() {
         let group = group_audio_lang(SetOp::Is, &["rus"]);
-        assert!(!group.matches(&info("a.mkv"), Some(&probe_with_langs(&["und"]))));
-        assert!(!group.matches(&info("a.mkv"), Some(&probe_with_langs(&["mul"]))));
+        assert_eq!(
+            group.match_outcome(&info("a.mkv"), Some(&probe_with_langs(&["und"]))),
+            MatchOutcome::NoMatch
+        );
+        assert_eq!(
+            group.match_outcome(&info("a.mkv"), Some(&probe_with_langs(&["mul"]))),
+            MatchOutcome::NoMatch
+        );
     }
 
-    // A Resolution rule is inferred via hunch from the filename, so a source
-    // without a filename cannot match a Resolution-only group.
     #[test]
     fn resolution_group_rejects_source_without_filename() {
         let group = StreamGroup {
@@ -827,6 +896,70 @@ mod tests {
             name: None,
             ..Default::default()
         };
-        assert!(!group.matches(&si, None));
+        assert_eq!(group.match_outcome(&si, None), MatchOutcome::NoMatch);
+    }
+
+    // Mixed filter (All): Resolution Match + AudioLanguage PassThrough → PassThrough.
+    // The source is not confidently Russian, so it must NOT be shown as the group
+    // representative, but it must also stay visible via ungrouped.
+    #[test]
+    fn audio_lang_combined_with_resolution_passes_through_in_all_mode() {
+        let group = StreamGroup {
+            id: Uuid::nil(),
+            name: "1080p · rus".to_string(),
+            filter: StreamFilter {
+                match_mode: FilterMatchMode::All,
+                rules: vec![
+                    StreamRule::Resolution {
+                        op: SetOp::In,
+                        values: vec![StreamResolution::R1080p],
+                    },
+                    StreamRule::AudioLanguage {
+                        op: SetOp::Is,
+                        values: vec!["rus".to_string()],
+                    },
+                ],
+            },
+            priority: 0,
+            enabled: true,
+            hidden: false,
+            created_at: String::new(),
+        };
+        assert_eq!(
+            group.match_outcome(&info("Movie.2024.1080p.BluRay.mkv"), None),
+            MatchOutcome::PassThrough
+        );
+    }
+
+    // Any mode: PassThrough is NOT a success. AudioLanguage PassThrough OR
+    // Quality NoMatch → NoMatch (no confident match on any rule).
+    #[test]
+    fn audio_lang_passthrough_is_not_a_success_in_any_mode() {
+        let group = StreamGroup {
+            id: Uuid::nil(),
+            name: "rus or bluray".to_string(),
+            filter: StreamFilter {
+                match_mode: FilterMatchMode::Any,
+                rules: vec![
+                    StreamRule::AudioLanguage {
+                        op: SetOp::Is,
+                        values: vec!["rus".to_string()],
+                    },
+                    StreamRule::Quality {
+                        op: SetOp::In,
+                        values: vec![StreamQuality::BluRay],
+                    },
+                ],
+            },
+            priority: 0,
+            enabled: true,
+            hidden: false,
+            created_at: String::new(),
+        };
+        // WEBRip → Quality NoMatch, AudioLanguage PassThrough (no probe) → NoMatch.
+        assert_eq!(
+            group.match_outcome(&info("Movie.2024.1080p.WEBRip.mkv"), None),
+            MatchOutcome::NoMatch
+        );
     }
 }


### PR DESCRIPTION
Added an AudioLanguage rule to stream groups that reads audio track languages from probe data (populated by RemuxDB), so a group can select e.g. only English-audio sources.

matches() now takes the parent Media's probe_data, since StreamInfo.probe_data is almost always empty. 

Drafted with AI, reviewed and tested by me.