### PR TITLE
fix: use known runtime when ffprobe reports short duration

### DIFF
--- a/crates/remux-server/src/playback/engine.rs
+++ b/crates/remux-server/src/playback/engine.rs
@@ -675,14 +675,7 @@ pub(crate) fn build_hls_args(params: &TranscodeParams) -> Vec<String> {
             .map(VideoCodec::is_hevc)
             .unwrap_or(false);
 
-    let mut args: Vec<String> = vec![
-        "-v".into(),
-        "error".into(),
-        "-analyzeduration".into(),
-        "1000000".into(),
-        "-probesize".into(),
-        "1000000".into(),
-    ];
+    let mut args: Vec<String> = vec!["-v".into(), "error".into()];
 
     let burn_subtitle_filter = params.burn_subtitle
         && params
@@ -1501,10 +1494,6 @@ pub(crate) fn build_progressive_args(
     let mut args: Vec<String> = vec![
         "-v".into(),
         "error".into(),
-        "-analyzeduration".into(),
-        "5000000".into(),
-        "-probesize".into(),
-        "5000000".into(),
         "-reconnect".into(),
         "1".into(),
         "-reconnect_at_eof".into(),


### PR DESCRIPTION
## Scenario:
1. Open Streamyfin, try to play any MKV content sourced via MediaFusion/RealDebrid where the episode is longer than ~10 minutes
2. It'll fail with "no usable streams found"
3. Server logs show `stream is suspiciously short` with `probed_ticks=1209600000` (always exactly 120.96s)

The root cause is the fast probe flags (`-analyzeduration 0 -probesize 500000`).
ffprobe can't determine the real duration from MKV containers over HTTP with those limits, so it always reports ~121s. The short-duration check then rejects it because 121s < 5min threshold.

This PR is to fix that.