### PR TITLE
fix: server-side admin gate for dashboard

### DIFF
--- a/crates/remux-dashboard/src/layout.rs
+++ b/crates/remux-dashboard/src/layout.rs
@@ -89,32 +89,6 @@ pub fn DashboardLayout() -> Element {
         None => return rsx! { div { "Not logged in" } },
     };
 
-    if !server.is_admin {
-        let mut logged_in = use_context::<Signal<bool>>();
-        return rsx! {
-            div { class: "login-page",
-                div { class: "login-card",
-                    div { class: "login-header",
-                        span { class: "login-brand-label", "Remux" }
-                        h1 { class: "login-title", "Admin Dashboard" }
-                    }
-                    div { class: "login-body",
-                        div { class: "alert-error", "Admin access required." }
-                        button {
-                            class: "btn btn-primary login-btn",
-                            style: "margin-top:16px",
-                            onclick: move |_| {
-                                LocalStorage::delete(CREDENTIALS_KEY);
-                                logged_in.set(false);
-                            },
-                            "Sign Out"
-                        }
-                    }
-                }
-            }
-        };
-    }
-
     let app_state = AppState::new(server);
     use_context_provider(|| app_state.clone());
 

--- a/crates/remux-dashboard/src/main.rs
+++ b/crates/remux-dashboard/src/main.rs
@@ -2,9 +2,10 @@ use dioxus::prelude::*;
 use gloo_storage::{LocalStorage, Storage};
 use remux_sdks::{
     remux::{
-        AuthenticateUserByName, CountryInfo, GetCountries, GetStartupConfiguration,
-        JellyfinAuth, PostStartupComplete, PostStartupConfiguration, PostStartupUser,
-        PublicSystemInfo, StartupConfiguration, StartupUser, Username,
+        AuthenticateUserByName, CountryInfo, GetCountries, GetCurrentUser,
+        GetStartupConfiguration, JellyfinAuth, PostStartupComplete,
+        PostStartupConfiguration, PostStartupUser, PublicSystemInfo,
+        StartupConfiguration, StartupUser, Username,
     },
     ClientError,
 };
@@ -26,11 +27,20 @@ fn main() {
     dioxus::launch(App);
 }
 
+#[derive(Clone, PartialEq)]
+enum AuthState {
+    Checking,
+    Admin,
+    Unauthorized,
+    LoggedOut,
+}
+
 #[component]
 fn App() -> Element {
     let mut wizard_needed: Signal<Option<bool>> = use_signal(|| None);
-    let mut logged_in = use_signal(|| get_stored_server().is_some());
-    use_context_provider(|| logged_in);
+    let mut auth_state = use_signal(|| AuthState::Checking);
+    let logged_in = use_memo(move || *auth_state.read() == AuthState::Admin);
+    use_context_provider(move || Signal::new(*logged_in.read()));
 
     use_effect(move || {
         let initial_theme =
@@ -47,6 +57,41 @@ fn App() -> Element {
     use_effect(move || {
         spawn(async move {
             let origin = get_origin();
+
+            if let Some(server) = get_stored_server() {
+                let device_id = get_or_create_device_id();
+                let auth = JellyfinAuth::new(&device_id).with_token(
+                    server
+                        .access_token
+                        .clone(),
+                );
+                if let Ok(client) = remux_sdks::remux::client(&server.manual_address) {
+                    match client
+                        .with_auth(auth)
+                        .execute(GetCurrentUser)
+                        .await
+                    {
+                        Ok(u)
+                            if u.policy
+                                .is_administrator =>
+                        {
+                            auth_state.set(AuthState::Admin);
+                        }
+                        Ok(_) | Err(ClientError::Unauthorized) => {
+                            auth_state.set(AuthState::Unauthorized);
+                        }
+                        Err(_) => {
+                            // Network error / server still starting — don't touch credentials.
+                            auth_state.set(AuthState::LoggedOut);
+                        }
+                    }
+                } else {
+                    auth_state.set(AuthState::LoggedOut);
+                }
+            } else {
+                auth_state.set(AuthState::LoggedOut);
+            }
+
             let needed = match remux_sdks::remux::client(&origin) {
                 Ok(c) => c
                     .execute(PublicSystemInfo::default())
@@ -82,10 +127,36 @@ fn App() -> Element {
                 }
             },
             Some(false) => rsx! {
-                if *logged_in.read() {
-                    Router::<Route> {}
-                } else {
-                    Login { on_login: move |_| logged_in.set(true) }
+                match *auth_state.read() {
+                    AuthState::Checking => rsx! {
+                        div { class: "login-page",
+                            div { class: "login-card",
+                                div { class: "login-header",
+                                    a { href: "/", class: "login-brand-label", "Remux" }
+                                    p { class: "connecting", "Starting up…" }
+                                }
+                            }
+                        }
+                    },
+                    AuthState::Admin => rsx! { Router::<Route> {} },
+                    AuthState::Unauthorized => rsx! {
+                        div { class: "login-page",
+                            div { class: "login-card",
+                                div { class: "login-header",
+                                    a { href: "/", class: "login-brand-label", "Remux" }
+                                    h1 { class: "login-title", "Admin Dashboard" }
+                                }
+                                div { class: "login-body",
+                                    div { class: "alert-error", "Admin access required." }
+                                }
+                            }
+                        }
+                    },
+                    AuthState::LoggedOut => rsx! {
+                        Login {
+                            on_login: move |_| auth_state.set(AuthState::Admin),
+                        }
+                    },
                 }
             },
         }}
@@ -184,7 +255,6 @@ fn Login(on_login: EventHandler) -> Element {
                             user_id: user
                                 .id
                                 .to_string(),
-                            is_admin: true,
                             date_last_accessed: 0.0,
                         });
                         on_login.call(());

--- a/crates/remux-dashboard/src/state.rs
+++ b/crates/remux-dashboard/src/state.rs
@@ -18,8 +18,6 @@ pub struct StoredServer {
     pub manual_address: String,
     pub access_token: String,
     pub user_id: String,
-    #[serde(default)]
-    pub is_admin: bool,
     pub date_last_accessed: f64,
 }
 


### PR DESCRIPTION
## Summary

- Reverts the client-side `is_admin` localStorage gate introduced in `9eb06f35` — it was unreliable because the Jellyfin web client overwrites `jellyfin_credentials` without that field, causing intermittent "Admin access required" errors for legitimate admins
- On dashboard startup, calls `GET /Users/Me` with the stored token to verify admin status from the live server — credentials in localStorage are never trusted blindly
- Introduces `AuthState` enum (`Checking` / `Admin` / `Unauthorized` / `LoggedOut`) to cleanly separate the four possible states
- Non-admins see an "Admin access required." page; credentials are never wiped (only cleared on explicit 401); network errors fall through to the login form

## Test plan

- [ ] Admin user with stored credentials: dashboard loads directly on refresh
- [ ] Non-admin user with stored credentials: sees "Admin access required." without being logged out
- [ ] Expired/invalid token (401): login form shown, credentials cleared
- [ ] Server not reachable on startup: login form shown, credentials preserved
- [ ] Fresh install (no credentials): login form shown, wizard runs if needed
- [ ] Login as non-admin via login form: "Admin access required." shown, no credentials stored