### PR TITLE
fix: correct gregorian day constant in dashboard uptime parser

### DIFF
--- a/crates/remux-dashboard/src/components/server_info.rs
+++ b/crates/remux-dashboard/src/components/server_info.rs
@@ -39,7 +39,7 @@ fn parse_rfc3339(s: &str) -> Option<u64> {
     };
     // Days since 1970-01-01
     let days =
-        y * 365 + y / 4 - y / 100 + y / 400 + (153 * m + 3) / 5 + day as i64 - 719469;
+        y * 365 + y / 4 - y / 100 + y / 400 + (153 * m + 3) / 5 + day as i64 - 719561;
     Some((days * 86400 + hour as i64 * 3600 + min as i64 * 60 + sec as i64) as u64)
 }
 


### PR DESCRIPTION
The day-count constant in parse_rfc3339 was wrong, shifting started_at 92 days into the future and making uptime always show as N/A. Fixed the constant to match the single-era days-from-civil form and verified the result against a few known dates.