### PR TITLE
fix: clear the MediaTypes query param

### DIFF
--- a/crates/remux-server/src/api/items.rs
+++ b/crates/remux-server/src/api/items.rs
@@ -795,6 +795,7 @@ pub async fn items_flat(
     session: auth::AuthSession,
     Query(mut q): Query<api::GetItemsQuery>,
 ) -> Result<impl IntoResponse> {
+    q.media_types = None;
     if let Some(parent_id) = q
         .parent_id
         .clone()

--- a/crates/remux-server/src/api/items.rs
+++ b/crates/remux-server/src/api/items.rs
@@ -795,6 +795,8 @@ pub async fn items_flat(
     session: auth::AuthSession,
     Query(mut q): Query<api::GetItemsQuery>,
 ) -> Result<impl IntoResponse> {
+    // Jellyfin ignores the MediaTypes query parameter for this request. 
+    // Without this, supplying a value (e.g. Video) would exclude Series collections.
     q.media_types = None;
     if let Some(parent_id) = q
         .parent_id


### PR DESCRIPTION
Clear the MediaTypes query parameter, as this is ignored in the real jellyfin api for this endpoint.