### PR TITLE
fix(playlists): return all media kinds from playlist items endpoint

### DIFF
--- a/crates/remux-server/src/api/playlists.rs
+++ b/crates/remux-server/src/api/playlists.rs
@@ -230,9 +230,6 @@ pub async fn get_playlist_items(
         )
         .await?
         {
-            if media.kind != db::MediaKind::Track {
-                continue;
-            }
             let mut dto = api::db_media_to_item(media, false);
             dto.playlist_item_id = Some(
                 rel.relation_id


### PR DESCRIPTION
Previously created playlists showed only music