### PR TITLE
feat(users): add Jellyfin personal rating endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4778,6 +4778,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "macro-string"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6588,6 +6599,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tray-icon",
+ "xz2",
  "zip",
 ]
 
@@ -9693,6 +9705,15 @@ name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
 
 [[package]]
 name = "yaml-rust2"

--- a/crates/remux-sdks/src/remux/mod.rs
+++ b/crates/remux-sdks/src/remux/mod.rs
@@ -3010,7 +3010,9 @@ pub struct ProviderIds {
 
 #[dto]
 pub struct UserItemDataDto {
-    pub rating: Option<f32>,
+    /// Jellyfin's `UserItemData.Rating`: a 0-10 double, with `Likes` derived
+    /// from it rather than sent separately.
+    pub rating: Option<f64>,
     #[default(false)]
     pub played: bool,
     pub last_played_date: Option<DateTime<Utc>>,

--- a/crates/remux-server/migrations/202608140001_user_media_state_rating.sql
+++ b/crates/remux-server/migrations/202608140001_user_media_state_rating.sql
@@ -1,0 +1,4 @@
+-- Personal rating, matching Jellyfin's UserItemData.Rating: a 0-10 double.
+-- `Likes` is not stored separately; Jellyfin derives it from this value at a
+-- 6.5 threshold, and its /Rating endpoint writes 10 or 1 through that.
+ALTER TABLE user_media_state ADD COLUMN rating REAL;

--- a/crates/remux-server/src/api/models.rs
+++ b/crates/remux-server/src/api/models.rs
@@ -273,6 +273,8 @@ pub fn db_state_to_dto(
             .unwrap_or(0),
         play_count: state.play_count as i32,
         is_favorite: state.favorite,
+        rating: state.rating,
+        likes: state.likes(),
         // Jellyfin omits PlayedPercentage when it is 0
         played_percentage: played_percentage.filter(|&p| p > 0.0),
         unplayed_item_count: media.unplayed_item_count,

--- a/crates/remux-server/src/api/users.rs
+++ b/crates/remux-server/src/api/users.rs
@@ -10,7 +10,7 @@ use axum::{
 };
 use axum_extra::extract::Query;
 use http::StatusCode;
-use remux_macros::{delete, get, post};
+use remux_macros::{delete, get, post, query};
 use serde::Deserialize;
 use sqlx::Row;
 use uuid::Uuid;
@@ -556,6 +556,121 @@ pub async fn unmark_played(
             true,
         )
         .await?;
+    Ok(Json(api::db_state_to_dto(ms, &media)).into_response())
+}
+
+#[query]
+pub struct RatingQuery {
+    /// Jellyfin's shorthand: true stores 10, false stores 1, absent clears it.
+    pub likes: Option<bool>,
+    /// Explicit 0-10 score. Wins over `likes` when both are given.
+    pub rating: Option<f64>,
+}
+
+impl RatingQuery {
+    /// The score to store, or `None` to clear.
+    fn parse(&self) -> Result<Option<db::UserRating>> {
+        match self.rating {
+            Some(r) => Ok(Some(
+                db::UserRating::try_from(r)
+                    .context_bad_request("rating must be between 0 and 10")?,
+            )),
+            None => Ok(self
+                .likes
+                .map(db::UserRating::from_likes)),
+        }
+    }
+}
+
+/// Jellyfin's /Rating endpoint is a shorthand over the 0-10 `Rating`, writing
+/// 10 or 1 rather than a separate field.
+#[post("/useritems/{id}/rating")]
+pub async fn update_item_rating(
+    State(state): State<AppState>,
+    session: auth::AuthSession,
+    auth::TargetUser(user): auth::TargetUser,
+    Path(id): Path<Uuid>,
+    Query(q): Query<RatingQuery>,
+) -> Result<impl IntoResponse> {
+    let media = MediaResolveService::resolve_item(id, &state.ctx)
+        .await?
+        .context_not_found("not found")?;
+    let ms = db::UserMediaState::set_rating(
+        &state
+            .ctx
+            .db,
+        &user,
+        &media,
+        q.parse()?,
+    )
+    .await?;
+    Ok(Json(api::db_state_to_dto(ms, &media)).into_response())
+}
+
+#[delete("/useritems/{id}/rating")]
+pub async fn delete_item_rating(
+    State(state): State<AppState>,
+    session: auth::AuthSession,
+    auth::TargetUser(user): auth::TargetUser,
+    Path(id): Path<Uuid>,
+) -> Result<impl IntoResponse> {
+    let media = MediaResolveService::resolve_item(id, &state.ctx)
+        .await?
+        .context_not_found("not found")?;
+    let ms = db::UserMediaState::set_rating(
+        &state
+            .ctx
+            .db,
+        &user,
+        &media,
+        None,
+    )
+    .await?;
+    Ok(Json(api::db_state_to_dto(ms, &media)).into_response())
+}
+
+#[post("/users/{user_id}/items/{id}/rating")]
+pub async fn update_item_rating_legacy(
+    State(state): State<AppState>,
+    session: auth::AuthSession,
+    auth::TargetUser(user): auth::TargetUser,
+    Path((_, id)): Path<(Uuid, Uuid)>,
+    Query(q): Query<RatingQuery>,
+) -> Result<impl IntoResponse> {
+    let media = MediaResolveService::resolve_item(id, &state.ctx)
+        .await?
+        .context_not_found("not found")?;
+    let ms = db::UserMediaState::set_rating(
+        &state
+            .ctx
+            .db,
+        &user,
+        &media,
+        q.parse()?,
+    )
+    .await?;
+    Ok(Json(api::db_state_to_dto(ms, &media)).into_response())
+}
+
+#[delete("/users/{user_id}/items/{id}/rating")]
+pub async fn delete_item_rating_legacy(
+    State(state): State<AppState>,
+    session: auth::AuthSession,
+    auth::TargetUser(user): auth::TargetUser,
+    Path((_, id)): Path<(Uuid, Uuid)>,
+) -> Result<impl IntoResponse> {
+    let media = MediaResolveService::resolve_item(id, &state.ctx)
+        .await?
+        .context_not_found("not found")?;
+    let ms = db::UserMediaState::set_rating(
+        &state
+            .ctx
+            .db,
+        &user,
+        &media,
+        None,
+    )
+    .await?;
     Ok(Json(api::db_state_to_dto(ms, &media)).into_response())
 }
 
@@ -2981,5 +3096,220 @@ mod e2e_tests {
         assert_eq!(body["Configuration"]["SubtitleLanguagePreference"], "jpn");
         assert_eq!(body["Configuration"]["SubtitleMode"], "Always");
         assert_eq!(body["Configuration"]["DisplayMissingEpisodes"], true);
+    }
+
+    #[tokio::test]
+    async fn rating_endpoint_stores_jellyfin_like_values_and_derives_likes() {
+        let (server, ctx, token) = authenticated_server().await;
+        let item = insert_test_source(&ctx.0).await;
+        let auth = || {
+            (
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth_header_with_token(&token)).unwrap(),
+            )
+        };
+
+        // Jellyfin's /Rating endpoint is a shorthand over the 0-10 Rating: a
+        // like stores 10, a dislike stores 1, and Likes is derived at 6.5.
+        let resp = server
+            .post(&format!("/useritems/{}/rating?likes=true", item.id))
+            .add_header(auth().0, auth().1)
+            .await;
+        let body: serde_json::Value = resp.json();
+        assert_eq!(body["Rating"], 10.0);
+        assert_eq!(body["Likes"], true);
+
+        let resp = server
+            .post(&format!("/useritems/{}/rating?likes=false", item.id))
+            .add_header(auth().0, auth().1)
+            .await;
+        let body: serde_json::Value = resp.json();
+        assert_eq!(body["Rating"], 1.0);
+        assert_eq!(body["Likes"], false);
+    }
+
+    #[tokio::test]
+    async fn deleting_a_rating_clears_both_rating_and_likes() {
+        let (server, ctx, token) = authenticated_server().await;
+        let item = insert_test_source(&ctx.0).await;
+        let auth = || {
+            (
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth_header_with_token(&token)).unwrap(),
+            )
+        };
+
+        server
+            .post(&format!("/useritems/{}/rating?likes=true", item.id))
+            .add_header(auth().0, auth().1)
+            .await;
+        let resp = server
+            .delete(&format!("/useritems/{}/rating", item.id))
+            .add_header(auth().0, auth().1)
+            .await;
+        let body: serde_json::Value = resp.json();
+        assert!(body["Rating"].is_null());
+        assert!(body["Likes"].is_null());
+    }
+
+    #[tokio::test]
+    async fn a_rating_survives_a_reload() {
+        let (server, ctx, token) = authenticated_server().await;
+        let item = insert_test_source(&ctx.0).await;
+        let auth = || {
+            (
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth_header_with_token(&token)).unwrap(),
+            )
+        };
+
+        server
+            .post(&format!("/useritems/{}/rating?likes=true", item.id))
+            .add_header(auth().0, auth().1)
+            .await;
+
+        // Read it back through the item endpoint rather than the write's
+        // response, so a column that never persisted would be caught.
+        let resp = server
+            .get(&format!("/items/{}", item.id))
+            .add_header(auth().0, auth().1)
+            .await;
+        let body: serde_json::Value = resp.json();
+        assert_eq!(body["UserData"]["Rating"], 10.0);
+        assert_eq!(body["UserData"]["Likes"], true);
+    }
+
+    #[tokio::test]
+    async fn a_user_cannot_rate_another_users_item() {
+        let (server, _ctx, token) = authenticated_server().await;
+        let other = Uuid::new_v4();
+        let resp = server
+            .post(&format!(
+                "/users/{}/items/{}/rating?likes=true",
+                other,
+                Uuid::new_v4()
+            ))
+            .add_header(
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth_header_with_token(&token)).unwrap(),
+            )
+            .expect_failure()
+            .await;
+        assert_ne!(resp.status_code(), http::StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn an_explicit_rating_is_stored_and_beats_likes() {
+        let (server, ctx, token) = authenticated_server().await;
+        let item = insert_test_source(&ctx.0).await;
+        let auth = || {
+            (
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth_header_with_token(&token)).unwrap(),
+            )
+        };
+
+        let resp = server
+            .post(&format!("/useritems/{}/rating?rating=7", item.id))
+            .add_header(auth().0, auth().1)
+            .await;
+        let body: serde_json::Value = resp.json();
+        assert_eq!(body["Rating"], 7.0);
+        // 7 is above the 6.5 threshold, so it reads as liked.
+        assert_eq!(body["Likes"], true);
+
+        // When both are given, rating wins.
+        let resp = server
+            .post(&format!(
+                "/useritems/{}/rating?likes=true&rating=3",
+                item.id
+            ))
+            .add_header(auth().0, auth().1)
+            .await;
+        let body: serde_json::Value = resp.json();
+        assert_eq!(body["Rating"], 3.0);
+        assert_eq!(body["Likes"], false);
+    }
+
+    /// Range and threshold boundaries are pinned as unit tests on
+    /// [`db::UserRating`]; this covers the endpoint rejecting rather than storing.
+    #[tokio::test]
+    async fn ratings_outside_the_range_are_rejected_with_400() {
+        let (server, ctx, token) = authenticated_server().await;
+        let item = insert_test_source(&ctx.0).await;
+
+        for bad in [
+            "-0.000000000000001",
+            "-1",
+            "10.000000000000002",
+            "11",
+            "NaN",
+            "inf",
+            "-inf",
+            "abc",
+        ] {
+            let resp = server
+                .post(&format!("/useritems/{}/rating?rating={bad}", item.id))
+                .add_header(
+                    http::header::AUTHORIZATION,
+                    HeaderValue::from_str(&auth_header_with_token(&token)).unwrap(),
+                )
+                .expect_failure()
+                .await;
+            assert_eq!(
+                resp.status_code(),
+                http::StatusCode::BAD_REQUEST,
+                "rating={bad} should be rejected"
+            );
+        }
+
+        // A rejected write must not have stored anything.
+        let resp = server
+            .get(&format!("/items/{}", item.id))
+            .add_header(
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth_header_with_token(&token)).unwrap(),
+            )
+            .await;
+        let body: serde_json::Value = resp.json();
+        assert!(body["UserData"]["Rating"].is_null());
+    }
+
+    #[tokio::test]
+    async fn the_boundary_rating_values_are_accepted() {
+        let (server, ctx, token) = authenticated_server().await;
+        let item = insert_test_source(&ctx.0).await;
+        let auth = || {
+            (
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth_header_with_token(&token)).unwrap(),
+            )
+        };
+
+        for (value, expect_liked) in [
+            ("0", false),
+            ("6.499999999999999", false),
+            ("6.5", true),
+            ("10", true),
+        ] {
+            let resp = server
+                .post(&format!("/useritems/{}/rating?rating={value}", item.id))
+                .add_header(auth().0, auth().1)
+                .await;
+            let body: serde_json::Value = resp.json();
+            assert_eq!(
+                body["Rating"]
+                    .as_f64()
+                    .unwrap(),
+                value
+                    .parse::<f64>()
+                    .unwrap(),
+                "rating={value} was not stored as sent"
+            );
+            assert_eq!(
+                body["Likes"], expect_liked,
+                "rating={value} derived the wrong Likes"
+            );
+        }
     }
 }

--- a/crates/remux-server/src/db/user.rs
+++ b/crates/remux-server/src/db/user.rs
@@ -419,6 +419,57 @@ pub struct UserMediaState {
     pub last_played_at: Option<NaiveDateTime>,
     pub subtitle_idx: Option<i64>,
     pub audio_idx: Option<i64>,
+    /// Set via [`UserMediaState::set_rating`] so it only holds parsed [`UserRating`]s.
+    pub rating: Option<f64>,
+}
+
+/// A personal rating on Jellyfin's 0-10 scale. Jellyfin stores no `Likes`
+/// field, deriving it from this at [`UserRating::LIKE_THRESHOLD`].
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub struct UserRating(f64);
+
+#[derive(Debug, Clone, Copy, PartialEq, thiserror::Error)]
+pub enum UserRatingError {
+    #[error("rating must be a finite number")]
+    NotFinite,
+    #[error("rating must be between 0 and 10")]
+    OutOfRange(f64),
+}
+
+impl UserRating {
+    /// Jellyfin's `UserItemData.MinLikeValue`.
+    pub const LIKE_THRESHOLD: f64 = 6.5;
+    pub const MIN: f64 = 0.0;
+    pub const MAX: f64 = 10.0;
+
+    /// Jellyfin's `Likes` setter: a like is 10, a dislike is 1.
+    pub fn from_likes(likes: bool) -> Self {
+        Self(if likes { 10.0 } else { 1.0 })
+    }
+
+    pub fn value(self) -> f64 {
+        self.0
+    }
+
+    pub fn likes(self) -> bool {
+        self.0 >= Self::LIKE_THRESHOLD
+    }
+}
+
+impl TryFrom<f64> for UserRating {
+    type Error = UserRatingError;
+
+    fn try_from(value: f64) -> std::result::Result<Self, Self::Error> {
+        // NaN needs its own arm: every comparison against it is false, so a
+        // bare range check would pass it through to the database.
+        if !value.is_finite() {
+            return Err(UserRatingError::NotFinite);
+        }
+        if !(Self::MIN..=Self::MAX).contains(&value) {
+            return Err(UserRatingError::OutOfRange(value));
+        }
+        Ok(Self(value))
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -503,6 +554,26 @@ impl UserMediaState {
         })
     }
 
+    /// Set or clear the personal rating.
+    pub async fn set_rating(
+        db: &SqlitePool,
+        user: &User,
+        media: &super::Media,
+        rating: Option<UserRating>,
+    ) -> Result<Self> {
+        let mut ms = Self::get_or_new(db, user, media).await?;
+        ms.rating = rating.map(UserRating::value);
+        ms.save(db)
+            .await?;
+        Ok(ms)
+    }
+
+    /// Jellyfin does not persist `Likes`; it derives it from the rating.
+    pub fn likes(&self) -> Option<bool> {
+        self.rating
+            .map(|r| r >= UserRating::LIKE_THRESHOLD)
+    }
+
     /// Persist playback position (and optionally stream-selection preferences)
     /// for a user/media pair.
     ///
@@ -579,9 +650,10 @@ impl UserMediaState {
                 playback_position,
                 last_played_at,
                 subtitle_idx,
-                audio_idx
+                audio_idx,
+                rating
             )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
             ON CONFLICT(user_id, media_id)
             DO UPDATE SET
                 media_raw = excluded.media_raw,
@@ -592,7 +664,8 @@ impl UserMediaState {
                 playback_position = excluded.playback_position,
                 last_played_at = excluded.last_played_at,
                 subtitle_idx = excluded.subtitle_idx,
-                audio_idx = excluded.audio_idx
+                audio_idx = excluded.audio_idx,
+                rating = excluded.rating
             "#,
         )
         .bind(self.user_id)
@@ -606,6 +679,7 @@ impl UserMediaState {
         .bind(now)
         .bind(self.subtitle_idx)
         .bind(self.audio_idx)
+        .bind(self.rating)
         .execute(db)
         .await?;
 
@@ -884,5 +958,112 @@ impl FromRequestParts<crate::AppState> for User {
         .await
         .map_err(|e| anyhow!(e).context_internal("db error"))?
         .context_not_found("user not found")
+    }
+}
+
+#[cfg(test)]
+mod rating_tests {
+    use super::*;
+
+    /// The representable value immediately below the threshold, so the `>=`
+    /// is pinned rather than merely exercised.
+    fn just_under_threshold() -> f64 {
+        UserRating::LIKE_THRESHOLD.next_down()
+    }
+
+    #[test]
+    fn the_range_bounds_are_inclusive() {
+        for v in [
+            UserRating::MIN,
+            0.5,
+            UserRating::LIKE_THRESHOLD,
+            9.5,
+            UserRating::MAX,
+        ] {
+            assert_eq!(
+                UserRating::try_from(v).map(UserRating::value),
+                Ok(v),
+                "{v} should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn values_outside_the_range_are_rejected() {
+        for v in [
+            UserRating::MIN.next_down(),
+            -1.0,
+            UserRating::MAX.next_up(),
+            11.0,
+            f64::MIN,
+            f64::MAX,
+        ] {
+            assert_eq!(
+                UserRating::try_from(v),
+                Err(UserRatingError::OutOfRange(v)),
+                "{v} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn non_finite_values_are_rejected() {
+        for v in [f64::NAN, -f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            assert_eq!(
+                UserRating::try_from(v),
+                Err(UserRatingError::NotFinite),
+                "{v} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn negative_zero_is_in_range() {
+        let r = UserRating::try_from(-0.0).unwrap();
+        assert_eq!(r.value(), 0.0);
+        assert!(!r.likes());
+    }
+
+    #[test]
+    fn likes_flips_at_the_threshold() {
+        assert!(
+            !UserRating::try_from(UserRating::MIN)
+                .unwrap()
+                .likes()
+        );
+        assert!(
+            !UserRating::try_from(just_under_threshold())
+                .unwrap()
+                .likes()
+        );
+        assert!(
+            UserRating::try_from(UserRating::LIKE_THRESHOLD)
+                .unwrap()
+                .likes()
+        );
+        assert!(
+            UserRating::try_from(UserRating::MAX)
+                .unwrap()
+                .likes()
+        );
+    }
+
+    #[test]
+    fn the_likes_shorthand_writes_jellyfins_values() {
+        assert_eq!(UserRating::from_likes(true).value(), 10.0);
+        assert_eq!(UserRating::from_likes(false).value(), 1.0);
+        assert!(UserRating::from_likes(true).likes());
+        assert!(!UserRating::from_likes(false).likes());
+    }
+
+    #[test]
+    fn likes_is_derived_from_the_stored_column() {
+        let state = |rating| UserMediaState {
+            rating,
+            ..Default::default()
+        };
+        assert_eq!(state(None).likes(), None);
+        assert_eq!(state(Some(just_under_threshold())).likes(), Some(false));
+        assert_eq!(state(Some(UserRating::LIKE_THRESHOLD)).likes(), Some(true));
     }
 }


### PR DESCRIPTION
Remux stores no personal rating, so `Rating` and `Likes` are always null and the `/Rating` endpoints 404.

Jellyfin keeps a 0-10 double and derives `Likes` from it at 6.5. This also takes an optional numeric `rating` alongside `likes`, with `rating` winning when both are given. Non-finite values are rejected explicitly, since NaN passes a plain range check.

Includes the legacy `/users/{user_id}/items/{id}/rating` alias.