### PR TITLE
fix: never serve an empty fMP4 init segment (HEVC 10-bit browser playback)

### DIFF
--- a/crates/remux-server/src/api/hls.rs
+++ b/crates/remux-server/src/api/hls.rs
@@ -7,9 +7,8 @@ use axum::{
 };
 use axum_anyhow::ApiResult as Result;
 use axum_extra::extract::Query;
-use http::{Response, StatusCode, header::HeaderMap};
+use http::{Response, StatusCode};
 use remux_macros::get;
-use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use tokio_util::io::ReaderStream;
 use tracing::{debug, error, info, trace, warn};
 use uuid::Uuid;
@@ -793,10 +792,9 @@ pub async fn hls_segment(
     State(state): State<AppState>,
     Path((id, segment_file)): Path<(Uuid, String)>,
     Query(q): Query<api::HlsVideoQuery>,
-    headers: HeaderMap,
 ) -> Result<impl IntoResponse> {
     let segment_id = strip_segment_extension(&segment_file);
-    hls_segment_inner(state, segment_id, q, headers).await
+    hls_segment_inner(state, segment_id, q).await
 }
 
 /// Segment route at the same level as main.m3u8 — browsers resolve bare
@@ -806,10 +804,9 @@ pub async fn hls_segment_flat(
     State(state): State<AppState>,
     Path((id, segment_file)): Path<(Uuid, String)>,
     Query(q): Query<api::HlsVideoQuery>,
-    headers: HeaderMap,
 ) -> Result<impl IntoResponse> {
     let segment_id = strip_segment_extension(&segment_file);
-    hls_segment_inner(state, segment_id, q, headers).await
+    hls_segment_inner(state, segment_id, q).await
 }
 
 /// Jellyfin-compatible HLS segment route: /Videos/{id}/hls1/{playlistId}/{segmentFile}
@@ -818,10 +815,9 @@ pub async fn hls1_segment(
     State(state): State<AppState>,
     Path((id, _playlist_id, segment_file)): Path<(Uuid, String, String)>,
     Query(q): Query<api::HlsVideoQuery>,
-    headers: HeaderMap,
 ) -> Result<impl IntoResponse> {
     let segment_id = strip_segment_extension(&segment_file);
-    hls_segment_inner(state, segment_id, q, headers).await
+    hls_segment_inner(state, segment_id, q).await
 }
 
 fn strip_segment_extension(filename: &str) -> String {
@@ -855,15 +851,13 @@ fn get_current_transcoding_index(dir: &std::path::Path) -> Option<u32> {
     max_idx
 }
 
-/// Serve a complete on-disk file with `Content-Length` and HTTP Range support.
+/// Serve a complete on-disk file with a `Content-Length` header.
 ///
-/// Jellyfin serves HLS init/fragments with `Content-Length` + `Accept-Ranges`.
-/// Serving them chunked without a length trips Safari's native HLS stack into
-/// `MEDIA_ERR_DECODE` on the first fMP4 segment, so we match Jellyfin's
-/// behaviour here.
-async fn serve_file_with_range(
+/// HLS init/fragments are always fetched whole by players, so byte-range
+/// handling isn't needed — but the length header lets the browser size the
+/// response up front instead of reading a chunked stream.
+async fn serve_file_with_length(
     path: &std::path::Path,
-    headers: &HeaderMap,
     content_type: &str,
 ) -> Result<Response<Body>> {
     let file = tokio::fs::File::open(path).await?;
@@ -871,42 +865,11 @@ async fn serve_file_with_range(
         .metadata()
         .await?
         .len();
-    let range_str = headers
-        .get(http::header::RANGE)
-        .and_then(|v| {
-            v.to_str()
-                .ok()
-        });
-
-    if let Some(range) = range_str {
-        let (start, end) = crate::stream::parse_range(range, file_size)
-            .context_bad_request("invalid Range header")?;
-        let length = end - start + 1;
-        let mut file = file;
-        file.seek(std::io::SeekFrom::Start(start))
-            .await
-            .context_bad_request("seek failed")?;
-        let body = Body::from_stream(ReaderStream::new(file.take(length)));
-        return Ok(Response::builder()
-            .status(StatusCode::PARTIAL_CONTENT)
-            .header("Content-Type", content_type)
-            .header("Content-Length", length)
-            .header("Accept-Ranges", "bytes")
-            .header(
-                "Content-Range",
-                format!("bytes {}-{}/{}", start, end, file_size),
-            )
-            .header("Cache-Control", "public, max-age=86400")
-            .body(body)
-            .unwrap());
-    }
-
     let body = Body::from_stream(ReaderStream::new(file));
     Ok(Response::builder()
         .status(StatusCode::OK)
         .header("Content-Type", content_type)
         .header("Content-Length", file_size)
-        .header("Accept-Ranges", "bytes")
         .header("Cache-Control", "public, max-age=86400")
         .body(body)
         .unwrap())
@@ -955,7 +918,6 @@ async fn hls_segment_inner(
     state: AppState,
     segment_id: String,
     q: api::HlsVideoQuery,
-    headers: HeaderMap,
 ) -> Result<impl IntoResponse> {
     let play_session_id = q
         .play_session_id
@@ -1005,7 +967,7 @@ async fn hls_segment_inner(
             .ctx
             .sessions
             .ping(&play_session_id);
-        return serve_file_with_range(&init_path, &headers, "video/mp4").await;
+        return serve_file_with_length(&init_path, "video/mp4").await;
     }
 
     // Derive the segment path — either from the live session or from the base
@@ -1312,7 +1274,7 @@ async fn hls_segment_inner(
         "video/mp2t"
     };
 
-    serve_file_with_range(&segment_path, &headers, content_type).await
+    serve_file_with_length(&segment_path, content_type).await
 }
 
 #[cfg(test)]

--- a/crates/remux-server/src/api/hls.rs
+++ b/crates/remux-server/src/api/hls.rs
@@ -820,6 +820,70 @@ pub async fn hls1_segment(
     hls_segment_inner(state, segment_id, q).await
 }
 
+/// Remove every `edts` box from the init.mp4 bytes.
+///
+/// ffmpeg copies the source file's edit list into the fMP4 init segment.  For
+/// HEVC content with B-frames the edit list typically starts with an ~83 ms
+/// empty edit (`media_time = -1`).  When the browser applies this edit the MSE
+/// SourceBuffer's `buffered` range begins at 83 ms instead of 0, so
+/// `video.currentTime = 0` falls before `buffered.start` and the browser fires
+/// a stall/error before playback ever starts.  Stripping the `edts` box lets
+/// the SourceBuffer report `buffered = [0, …]` so the player can seek to time 0
+/// without triggering a stall.
+fn strip_edts_from_init(mut data: Vec<u8>) -> Vec<u8> {
+    let mut out = Vec::with_capacity(data.len());
+    strip_edts_boxes(&data, 0, data.len(), &mut out, false);
+    out
+}
+
+fn strip_edts_boxes(
+    src: &[u8],
+    start: usize,
+    end: usize,
+    out: &mut Vec<u8>,
+    inside_trak: bool,
+) {
+    let mut o = start;
+    while o + 8 <= end {
+        if o + 4 > src.len() {
+            break;
+        }
+        let size =
+            u32::from_be_bytes([src[o], src[o + 1], src[o + 2], src[o + 3]]) as usize;
+        if size < 8 || o + size > src.len() {
+            break;
+        }
+        let name = &src[o + 4..o + 8];
+        if inside_trak && name == b"edts" {
+            // Drop the entire edts box (which contains the elst).
+            o += size;
+            // Also shrink the parent trak size accordingly — we do this by
+            // re-writing the trak size in `out` after recursion returns, so
+            // here we just skip and let the caller patch the size.
+            continue;
+        }
+        let containers: &[&[u8]] =
+            &[b"moov", b"trak", b"mdia", b"minf", b"stbl", b"mvex"];
+        let is_container = containers
+            .iter()
+            .any(|c| name == *c);
+        let is_trak = name == b"trak";
+        if is_container {
+            // Write placeholder size + name, then recurse, then patch size.
+            let header_start = out.len();
+            out.extend_from_slice(&src[o..o + 8]); // placeholder size + name
+            strip_edts_boxes(src, o + 8, o + size, out, inside_trak || is_trak);
+            // Patch the written size to reflect any dropped edts boxes.
+            let actual_size = (out.len() - header_start) as u32;
+            out[header_start..header_start + 4]
+                .copy_from_slice(&actual_size.to_be_bytes());
+        } else {
+            out.extend_from_slice(&src[o..o + size]);
+        }
+        o += size;
+    }
+}
+
 fn strip_segment_extension(filename: &str) -> String {
     filename
         .rsplit_once('.')
@@ -901,13 +965,19 @@ async fn hls_segment_inner(
             .ctx
             .sessions
             .ping(&play_session_id);
-        let file = tokio::fs::File::open(&init_path).await?;
-        let stream = ReaderStream::new(file);
+        let raw = tokio::fs::read(&init_path).await?;
+        // Strip `edts` boxes (which contain the empty-edit that shifts the
+        // presentation start to ~83 ms).  With the edit list present the MSE
+        // SourceBuffer's buffered range begins at 83 ms, so Jellyfin Web's
+        // video.currentTime = 0 falls before buffered.start and the browser
+        // reports a stall/error on the very first segment.  Without it the
+        // buffered range starts at 0 and currentTime = 0 works correctly.
+        let body = strip_edts_from_init(raw);
         return Ok(Response::builder()
             .status(StatusCode::OK)
             .header("Content-Type", "video/mp4")
             .header("Cache-Control", "public, max-age=86400")
-            .body(Body::from_stream(stream))
+            .body(Body::from(body))
             .unwrap());
     }
 

--- a/crates/remux-server/src/api/hls.rs
+++ b/crates/remux-server/src/api/hls.rs
@@ -7,8 +7,9 @@ use axum::{
 };
 use axum_anyhow::ApiResult as Result;
 use axum_extra::extract::Query;
-use http::{Response, StatusCode};
+use http::{Response, StatusCode, header::HeaderMap};
 use remux_macros::get;
+use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use tokio_util::io::ReaderStream;
 use tracing::{debug, error, info, trace, warn};
 use uuid::Uuid;
@@ -792,9 +793,10 @@ pub async fn hls_segment(
     State(state): State<AppState>,
     Path((id, segment_file)): Path<(Uuid, String)>,
     Query(q): Query<api::HlsVideoQuery>,
+    headers: HeaderMap,
 ) -> Result<impl IntoResponse> {
     let segment_id = strip_segment_extension(&segment_file);
-    hls_segment_inner(state, segment_id, q).await
+    hls_segment_inner(state, segment_id, q, headers).await
 }
 
 /// Segment route at the same level as main.m3u8 — browsers resolve bare
@@ -804,9 +806,10 @@ pub async fn hls_segment_flat(
     State(state): State<AppState>,
     Path((id, segment_file)): Path<(Uuid, String)>,
     Query(q): Query<api::HlsVideoQuery>,
+    headers: HeaderMap,
 ) -> Result<impl IntoResponse> {
     let segment_id = strip_segment_extension(&segment_file);
-    hls_segment_inner(state, segment_id, q).await
+    hls_segment_inner(state, segment_id, q, headers).await
 }
 
 /// Jellyfin-compatible HLS segment route: /Videos/{id}/hls1/{playlistId}/{segmentFile}
@@ -815,73 +818,10 @@ pub async fn hls1_segment(
     State(state): State<AppState>,
     Path((id, _playlist_id, segment_file)): Path<(Uuid, String, String)>,
     Query(q): Query<api::HlsVideoQuery>,
+    headers: HeaderMap,
 ) -> Result<impl IntoResponse> {
     let segment_id = strip_segment_extension(&segment_file);
-    hls_segment_inner(state, segment_id, q).await
-}
-
-/// Remove every `edts` box from the init.mp4 bytes.
-///
-/// ffmpeg copies the source file's edit list into the fMP4 init segment.  For
-/// HEVC content with B-frames the edit list typically starts with an ~83 ms
-/// empty edit (`media_time = -1`).  When the browser applies this edit the MSE
-/// SourceBuffer's `buffered` range begins at 83 ms instead of 0, so
-/// `video.currentTime = 0` falls before `buffered.start` and the browser fires
-/// a stall/error before playback ever starts.  Stripping the `edts` box lets
-/// the SourceBuffer report `buffered = [0, …]` so the player can seek to time 0
-/// without triggering a stall.
-fn strip_edts_from_init(mut data: Vec<u8>) -> Vec<u8> {
-    let mut out = Vec::with_capacity(data.len());
-    strip_edts_boxes(&data, 0, data.len(), &mut out, false);
-    out
-}
-
-fn strip_edts_boxes(
-    src: &[u8],
-    start: usize,
-    end: usize,
-    out: &mut Vec<u8>,
-    inside_trak: bool,
-) {
-    let mut o = start;
-    while o + 8 <= end {
-        if o + 4 > src.len() {
-            break;
-        }
-        let size =
-            u32::from_be_bytes([src[o], src[o + 1], src[o + 2], src[o + 3]]) as usize;
-        if size < 8 || o + size > src.len() {
-            break;
-        }
-        let name = &src[o + 4..o + 8];
-        if inside_trak && name == b"edts" {
-            // Drop the entire edts box (which contains the elst).
-            o += size;
-            // Also shrink the parent trak size accordingly — we do this by
-            // re-writing the trak size in `out` after recursion returns, so
-            // here we just skip and let the caller patch the size.
-            continue;
-        }
-        let containers: &[&[u8]] =
-            &[b"moov", b"trak", b"mdia", b"minf", b"stbl", b"mvex"];
-        let is_container = containers
-            .iter()
-            .any(|c| name == *c);
-        let is_trak = name == b"trak";
-        if is_container {
-            // Write placeholder size + name, then recurse, then patch size.
-            let header_start = out.len();
-            out.extend_from_slice(&src[o..o + 8]); // placeholder size + name
-            strip_edts_boxes(src, o + 8, o + size, out, inside_trak || is_trak);
-            // Patch the written size to reflect any dropped edts boxes.
-            let actual_size = (out.len() - header_start) as u32;
-            out[header_start..header_start + 4]
-                .copy_from_slice(&actual_size.to_be_bytes());
-        } else {
-            out.extend_from_slice(&src[o..o + size]);
-        }
-        o += size;
-    }
+    hls_segment_inner(state, segment_id, q, headers).await
 }
 
 fn strip_segment_extension(filename: &str) -> String {
@@ -915,10 +855,107 @@ fn get_current_transcoding_index(dir: &std::path::Path) -> Option<u32> {
     max_idx
 }
 
+/// Serve a complete on-disk file with `Content-Length` and HTTP Range support.
+///
+/// Jellyfin serves HLS init/fragments with `Content-Length` + `Accept-Ranges`.
+/// Serving them chunked without a length trips Safari's native HLS stack into
+/// `MEDIA_ERR_DECODE` on the first fMP4 segment, so we match Jellyfin's
+/// behaviour here.
+async fn serve_file_with_range(
+    path: &std::path::Path,
+    headers: &HeaderMap,
+    content_type: &str,
+) -> Result<Response<Body>> {
+    let file = tokio::fs::File::open(path).await?;
+    let file_size = file
+        .metadata()
+        .await?
+        .len();
+    let range_str = headers
+        .get(http::header::RANGE)
+        .and_then(|v| {
+            v.to_str()
+                .ok()
+        });
+
+    if let Some(range) = range_str {
+        let (start, end) = crate::stream::parse_range(range, file_size)
+            .context_bad_request("invalid Range header")?;
+        let length = end - start + 1;
+        let mut file = file;
+        file.seek(std::io::SeekFrom::Start(start))
+            .await
+            .context_bad_request("seek failed")?;
+        let body = Body::from_stream(ReaderStream::new(file.take(length)));
+        return Ok(Response::builder()
+            .status(StatusCode::PARTIAL_CONTENT)
+            .header("Content-Type", content_type)
+            .header("Content-Length", length)
+            .header("Accept-Ranges", "bytes")
+            .header(
+                "Content-Range",
+                format!("bytes {}-{}/{}", start, end, file_size),
+            )
+            .header("Cache-Control", "public, max-age=86400")
+            .body(body)
+            .unwrap());
+    }
+
+    let body = Body::from_stream(ReaderStream::new(file));
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header("Content-Type", content_type)
+        .header("Content-Length", file_size)
+        .header("Accept-Ranges", "bytes")
+        .header("Cache-Control", "public, max-age=86400")
+        .body(body)
+        .unwrap())
+}
+
+/// Poll until `path` exists with a non-zero size and stays unchanged across
+/// consecutive polls.
+///
+/// ffmpeg creates HLS init/segment files *before* flushing their content, so
+/// checking existence alone can serve a 0-byte init segment to the player —
+/// the browser's MSE/AVFoundation decoder can't initialize from an empty init
+/// and playback fails hard until the user re-enters (by which time the file is
+/// complete). Returns true once the file is ready (or already was).
+async fn wait_for_file_ready(
+    path: &std::path::Path,
+    timeout: std::time::Duration,
+) -> bool {
+    let deadline = tokio::time::Instant::now() + timeout;
+    let mut last_size: Option<u64> = None;
+    let mut stable = 0u32;
+    while tokio::time::Instant::now() < deadline {
+        match tokio::fs::metadata(path).await {
+            Ok(meta) if meta.len() > 0 => {
+                if Some(meta.len()) == last_size {
+                    stable += 1;
+                    if stable >= 2 {
+                        return true;
+                    }
+                } else {
+                    stable = 0;
+                }
+                last_size = Some(meta.len());
+            }
+            _ => {
+                last_size = None;
+                stable = 0;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+    // Last chance: file exists and is non-empty right now.
+    matches!(tokio::fs::metadata(path).await, Ok(m) if m.len() > 0)
+}
+
 async fn hls_segment_inner(
     state: AppState,
     segment_id: String,
     q: api::HlsVideoQuery,
+    headers: HeaderMap,
 ) -> Result<impl IntoResponse> {
     let play_session_id = q
         .play_session_id
@@ -950,35 +987,25 @@ async fn hls_segment_inner(
                 .segment_path(&play_session_id, "init.mp4")
                 .with_extension("mp4"),
         };
-        // Wait briefly for ffmpeg to write the init segment.
+        // Wait for ffmpeg to write the init segment. Merely checking existence
+        // is not enough: ffmpeg creates init.mp4 before buffering its content
+        // out, so serving it in that window yields an empty init segment that
+        // breaks the browser's decoder. Wait until the file is non-empty and
+        // stable.
         if session.is_some() {
-            let mut attempts = 0;
-            while !init_path.exists() && attempts < 40 {
-                tokio::time::sleep(std::time::Duration::from_millis(250)).await;
-                attempts += 1;
+            if !wait_for_file_ready(&init_path, std::time::Duration::from_secs(10))
+                .await
+            {
+                None::<()>.context_not_found("fMP4 init segment not ready")?;
             }
-        }
-        if !init_path.exists() {
+        } else if !init_path.exists() {
             None::<()>.context_not_found("fMP4 init segment not ready")?;
         }
         state
             .ctx
             .sessions
             .ping(&play_session_id);
-        let raw = tokio::fs::read(&init_path).await?;
-        // Strip `edts` boxes (which contain the empty-edit that shifts the
-        // presentation start to ~83 ms).  With the edit list present the MSE
-        // SourceBuffer's buffered range begins at 83 ms, so Jellyfin Web's
-        // video.currentTime = 0 falls before buffered.start and the browser
-        // reports a stall/error on the very first segment.  Without it the
-        // buffered range starts at 0 and currentTime = 0 works correctly.
-        let body = strip_edts_from_init(raw);
-        return Ok(Response::builder()
-            .status(StatusCode::OK)
-            .header("Content-Type", "video/mp4")
-            .header("Cache-Control", "public, max-age=86400")
-            .body(Body::from(body))
-            .unwrap());
+        return serve_file_with_range(&init_path, &headers, "video/mp4").await;
     }
 
     // Derive the segment path — either from the live session or from the base
@@ -1246,14 +1273,13 @@ async fn hls_segment_inner(
         }
     }
 
-    // Wait up to 60s for ffmpeg to produce the segment.
+    // Wait up to 60s for ffmpeg to produce the segment (also waiting until it
+    // is non-empty — same create-before-write race as the init segment).
     // If there's no live session (e.g. after server restart), only serve from disk.
-    if session.is_some() {
-        let mut attempts = 0;
-        while !segment_path.exists() && attempts < 120 {
-            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-            attempts += 1;
-        }
+    if session.is_some()
+        && !wait_for_file_ready(&segment_path, std::time::Duration::from_secs(60)).await
+    {
+        // fall through to the not-found error below
     }
 
     if !segment_path.exists() {
@@ -1275,10 +1301,6 @@ async fn hls_segment_inner(
         .sessions
         .ping(&play_session_id);
 
-    let file = tokio::fs::File::open(&segment_path).await?;
-    let stream = ReaderStream::new(file);
-    let body = Body::from_stream(stream);
-
     // fMP4 segments (.m4s) use video/mp4; MPEG-TS segments use video/mp2t.
     let content_type = if segment_path
         .extension()
@@ -1290,12 +1312,7 @@ async fn hls_segment_inner(
         "video/mp2t"
     };
 
-    Ok(Response::builder()
-        .status(StatusCode::OK)
-        .header("Content-Type", content_type)
-        .header("Cache-Control", "public, max-age=86400")
-        .body(body)
-        .unwrap())
+    serve_file_with_range(&segment_path, &headers, content_type).await
 }
 
 #[cfg(test)]

--- a/crates/remux-server/src/playback/engine.rs
+++ b/crates/remux-server/src/playback/engine.rs
@@ -738,6 +738,15 @@ pub(crate) fn build_hls_args(params: &TranscodeParams) -> Vec<String> {
         ]);
     }
 
+    // fMP4 (baseMediaDecodeTime) uses unsigned integers; negative DTS from HEVC
+    // B-frames wraps to a huge value and breaks all browsers. Shift timestamps
+    // to make DTS >= 0 for fMP4 sessions. TS segments handle negative DTS fine
+    // via the 33-bit PCR, so keep the existing "disabled" behaviour there.
+    let avoid_negative_ts = if is_hevc_copy {
+        "make_non_negative"
+    } else {
+        "disabled"
+    };
     args.extend([
         "-copyts".into(),
         "-i".into(),
@@ -745,7 +754,7 @@ pub(crate) fn build_hls_args(params: &TranscodeParams) -> Vec<String> {
             .input_url
             .clone(),
         "-avoid_negative_ts".into(),
-        "disabled".into(),
+        avoid_negative_ts.into(),
         "-max_muxing_queue_size".into(),
         "2048".into(),
     ]);
@@ -1977,7 +1986,12 @@ pub fn generate_variant_playlist(
     buf.push_str(&format!("#EXT-X-VERSION:{}\n", version));
     buf.push_str(&format!("#EXT-X-TARGETDURATION:{}\n", target_duration));
     buf.push_str("#EXT-X-MEDIA-SEQUENCE:0\n");
-    if start_time_secs > 0 {
+    // EXT-X-START is only useful for TS segments: for fMP4 the synthetic playlist
+    // always starts at segment_00000 (no -start_number offset) and the Jellyfin
+    // Web client drives seeking via video.currentTime. Emitting EXT-X-START for
+    // fMP4 causes hls.js to attempt an in-buffer MSE seek on the very first
+    // segment, which triggers a decode error in browsers playing HEVC 10-bit.
+    if start_time_secs > 0 && !use_fmp4 {
         buf.push_str(&format!(
             "#EXT-X-START:TIME-OFFSET={:.6},PRECISE=YES\n",
             start_time_secs as f64
@@ -2395,6 +2409,11 @@ mod tests {
             Some("init.mp4")
         );
         assert_eq!(arg_after(&args, "-tag:v"), Some("hvc1"));
+        // fMP4 uses unsigned baseMediaDecodeTime; negative DTS must be shifted.
+        assert_eq!(
+            arg_after(&args, "-avoid_negative_ts"),
+            Some("make_non_negative")
+        );
         // No DoVi range type → dovi_rpu must NOT be injected (would crash on non-HEVC/AV1)
         assert!(
             !args

--- a/crates/remux-server/src/playback/engine.rs
+++ b/crates/remux-server/src/playback/engine.rs
@@ -738,15 +738,6 @@ pub(crate) fn build_hls_args(params: &TranscodeParams) -> Vec<String> {
         ]);
     }
 
-    // fMP4 (baseMediaDecodeTime) uses unsigned integers; negative DTS from HEVC
-    // B-frames wraps to a huge value and breaks all browsers. Shift timestamps
-    // to make DTS >= 0 for fMP4 sessions. TS segments handle negative DTS fine
-    // via the 33-bit PCR, so keep the existing "disabled" behaviour there.
-    let avoid_negative_ts = if is_hevc_copy {
-        "make_non_negative"
-    } else {
-        "disabled"
-    };
     args.extend([
         "-copyts".into(),
         "-i".into(),
@@ -754,7 +745,7 @@ pub(crate) fn build_hls_args(params: &TranscodeParams) -> Vec<String> {
             .input_url
             .clone(),
         "-avoid_negative_ts".into(),
-        avoid_negative_ts.into(),
+        "disabled".into(),
         "-max_muxing_queue_size".into(),
         "2048".into(),
     ]);
@@ -1080,11 +1071,18 @@ pub(crate) fn build_hls_args(params: &TranscodeParams) -> Vec<String> {
     if is_hevc_copy {
         // Apple HLS spec: HEVC must be delivered in fMP4/CMAF segments, not MPEG-TS.
         // Use just the filename for init; ffmpeg places it alongside the segments.
+        //
+        // -start_at_zero: shifts all timestamps so the first DTS = 0.
+        // movflags=+frag_discont: writes each fragment's actual decode time into
+        // MOOF::TRAF::TFDT so A/V sync is correct across discontinuities.
         args.extend([
             "-hls_segment_type".into(),
             "fmp4".into(),
             "-hls_fmp4_init_filename".into(),
             "init.mp4".into(),
+            "-start_at_zero".into(),
+            "-hls_segment_options".into(),
+            "movflags=+frag_discont".into(),
         ]);
     }
 
@@ -2409,10 +2407,11 @@ mod tests {
             Some("init.mp4")
         );
         assert_eq!(arg_after(&args, "-tag:v"), Some("hvc1"));
-        // fMP4 uses unsigned baseMediaDecodeTime; negative DTS must be shifted.
+        assert_eq!(arg_after(&args, "-avoid_negative_ts"), Some("disabled"));
+        assert!(args_contains(&args, "-start_at_zero"));
         assert_eq!(
-            arg_after(&args, "-avoid_negative_ts"),
-            Some("make_non_negative")
+            arg_after(&args, "-hls_segment_options"),
+            Some("movflags=+frag_discont")
         );
         // No DoVi range type → dovi_rpu must NOT be injected (would crash on non-HEVC/AV1)
         assert!(

--- a/crates/remux-server/src/playback/probe.rs
+++ b/crates/remux-server/src/playback/probe.rs
@@ -278,10 +278,24 @@ struct FfprobeStream {
     channels: Option<i64>,
     channel_layout: Option<String>,
     sample_rate: Option<String>,
+    pix_fmt: Option<String>,
+    bits_per_raw_sample: Option<String>,
     #[serde(default)]
     tags: HashMap<String, String>,
     #[serde(default)]
     disposition: FfprobeDisposition,
+}
+
+/// Derive bit depth from a pixel format string (e.g. "yuv420p10le" → 10, "yuv420p" → 8).
+fn bit_depth_from_pix_fmt(pix_fmt: &str) -> Option<i64> {
+    // Check for explicit bit-depth suffixes: 9, 10, 12, 14, 16
+    for depth in [16u8, 14, 12, 10, 9] {
+        if pix_fmt.contains(&depth.to_string()) {
+            return Some(depth as i64);
+        }
+    }
+    // Standard 8-bit formats have no numeric suffix
+    if !pix_fmt.is_empty() { Some(8) } else { None }
 }
 
 #[derive(Deserialize)]
@@ -614,6 +628,19 @@ pub fn probe_media(url: &str) -> Result<(api::MediaSourceInfo, MediaSegments)> {
                     title: title.as_deref(),
                 };
 
+                let bit_depth = s
+                    .bits_per_raw_sample
+                    .as_deref()
+                    .and_then(|b| {
+                        b.parse::<i64>()
+                            .ok()
+                    })
+                    .filter(|&b| b > 0)
+                    .or_else(|| {
+                        s.pix_fmt
+                            .as_deref()
+                            .and_then(bit_depth_from_pix_fmt)
+                    });
                 streams.push(api::MediaStream {
                     type_: Some(api::MediaStreamType::Video),
                     index: s.index,
@@ -628,6 +655,7 @@ pub fn probe_media(url: &str) -> Result<(api::MediaSourceInfo, MediaSegments)> {
                     width: meta.width,
                     height: meta.height,
                     bit_rate: bitrate,
+                    bit_depth,
                     average_frame_rate: fps
                         .map(|f| f as f32)
                         .and_then(nonzero),
@@ -1126,6 +1154,16 @@ where
 #[cfg(test)]
 mod probe_tests {
     use super::*;
+
+    #[test]
+    fn bit_depth_from_pix_fmt_known_formats() {
+        assert_eq!(bit_depth_from_pix_fmt("yuv420p10le"), Some(10));
+        assert_eq!(bit_depth_from_pix_fmt("yuv420p12le"), Some(12));
+        assert_eq!(bit_depth_from_pix_fmt("yuv444p16le"), Some(16));
+        assert_eq!(bit_depth_from_pix_fmt("yuv420p"), Some(8));
+        assert_eq!(bit_depth_from_pix_fmt("yuvj420p"), Some(8));
+        assert_eq!(bit_depth_from_pix_fmt(""), None);
+    }
     use crate::stream::{StreamDescriptor, StreamInfo};
     use remux_sdks::remux::{MediaSegments, MediaStream, MediaStreamType};
     use std::{


### PR DESCRIPTION
fix #218