### PR TITLE
fix(users): honour the target user on favourite endpoints

### DIFF
--- a/crates/remux-server/src/api/users.rs
+++ b/crates/remux-server/src/api/users.rs
@@ -431,8 +431,9 @@ pub async fn users_me(
 #[post("/users/{user_id}/favoriteitems/{id}")]
 pub async fn mark_favorite(
     State(state): State<AppState>,
-    session: auth::AuthSession,
-    Path((user_id, id)): Path<(Uuid, Uuid)>,
+    _session: auth::AuthSession,
+    auth::TargetUser(user): auth::TargetUser,
+    Path((_, id)): Path<(Uuid, Uuid)>,
 ) -> Result<impl IntoResponse> {
     let media = MediaResolveService::resolve_item(id, &state.ctx)
         .await?
@@ -442,7 +443,7 @@ pub async fn mark_favorite(
             &state
                 .ctx
                 .db,
-            &session.user,
+            &user,
         )
         .await?;
     Ok(Json(api::db_state_to_dto(ms, &media)).into_response())
@@ -451,8 +452,9 @@ pub async fn mark_favorite(
 #[delete("/users/{user_id}/favoriteitems/{id}")]
 pub async fn unmark_favorite(
     State(state): State<AppState>,
-    session: auth::AuthSession,
-    Path((user_id, id)): Path<(Uuid, Uuid)>,
+    _session: auth::AuthSession,
+    auth::TargetUser(user): auth::TargetUser,
+    Path((_, id)): Path<(Uuid, Uuid)>,
 ) -> Result<impl IntoResponse> {
     let media = MediaResolveService::resolve_item(id, &state.ctx)
         .await?
@@ -462,7 +464,7 @@ pub async fn unmark_favorite(
             &state
                 .ctx
                 .db,
-            &session.user,
+            &user,
         )
         .await?;
     Ok(Json(api::db_state_to_dto(ms, &media)).into_response())
@@ -471,7 +473,8 @@ pub async fn unmark_favorite(
 #[post("/userfavoriteitems/{id}")]
 pub async fn mark_favorite_modern(
     State(state): State<AppState>,
-    session: auth::AuthSession,
+    _session: auth::AuthSession,
+    auth::TargetUser(user): auth::TargetUser,
     Path(id): Path<Uuid>,
 ) -> Result<impl IntoResponse> {
     let media = MediaResolveService::resolve_item(id, &state.ctx)
@@ -482,7 +485,7 @@ pub async fn mark_favorite_modern(
             &state
                 .ctx
                 .db,
-            &session.user,
+            &user,
         )
         .await?;
     Ok(Json(api::db_state_to_dto(s, &media)).into_response())
@@ -491,7 +494,8 @@ pub async fn mark_favorite_modern(
 #[delete("/userfavoriteitems/{id}")]
 pub async fn unmark_favorite_modern(
     State(state): State<AppState>,
-    session: auth::AuthSession,
+    _session: auth::AuthSession,
+    auth::TargetUser(user): auth::TargetUser,
     Path(id): Path<Uuid>,
 ) -> Result<impl IntoResponse> {
     let media = MediaResolveService::resolve_item(id, &state.ctx)
@@ -502,7 +506,7 @@ pub async fn unmark_favorite_modern(
             &state
                 .ctx
                 .db,
-            &session.user,
+            &user,
         )
         .await?;
     Ok(Json(api::db_state_to_dto(s, &media)).into_response())
@@ -3311,5 +3315,119 @@ mod e2e_tests {
                 "rating={value} derived the wrong Likes"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn favoriting_for_another_user_does_not_silently_hit_your_own() {
+        // The path user_id used to be ignored: an admin favouriting on behalf
+        // of someone else marked it for themselves instead, and the target was
+        // left untouched. Nothing failed, so it went unnoticed.
+        let (server, ctx, token) = authenticated_server().await;
+        let item = insert_test_source(&ctx.0).await;
+        let auth = || {
+            (
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth_header_with_token(&token)).unwrap(),
+            )
+        };
+
+        let other = server
+            .post("/users/new")
+            .add_header(auth().0, auth().1)
+            .json(&json!({ "Name": "other", "Password": "pw" }))
+            .await;
+        let other_id = other.json::<serde_json::Value>()["Id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        server
+            .post(&format!("/users/{other_id}/favoriteitems/{}", item.id))
+            .add_header(auth().0, auth().1)
+            .await;
+
+        // The admin who issued the call must not have been marked.
+        let mine = server
+            .get(&format!("/items/{}", item.id))
+            .add_header(auth().0, auth().1)
+            .await;
+        assert_eq!(
+            mine.json::<serde_json::Value>()["UserData"]["IsFavorite"],
+            false,
+            "the caller was marked instead of the target"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_non_admin_cannot_favorite_for_someone_else() {
+        let (server, ctx, token) = authenticated_server().await;
+        let item = insert_test_source(&ctx.0).await;
+        let admin_auth = || {
+            (
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth_header_with_token(&token)).unwrap(),
+            )
+        };
+
+        server
+            .post("/users/new")
+            .add_header(admin_auth().0, admin_auth().1)
+            .json(&json!({ "Name": "regular", "Password": "pw" }))
+            .await;
+        let login = server
+            .post("/users/authenticatebyname")
+            .add_header(
+                http::header::AUTHORIZATION,
+                HeaderValue::from_static(AUTH_HEADER),
+            )
+            .json(&json!({ "Username": "regular", "Pw": "pw" }))
+            .await;
+        let user_token = login.json::<serde_json::Value>()["AccessToken"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        // The admin's own id, not the caller's: targeting yourself is allowed.
+        let admin = server
+            .get("/users/me")
+            .add_header(admin_auth().0, admin_auth().1)
+            .await;
+        let target = admin.json::<serde_json::Value>()["Id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let resp = server
+            .post(&format!("/users/{target}/favoriteitems/{}", item.id))
+            .add_header(
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth_header_with_token(&user_token)).unwrap(),
+            )
+            .expect_failure()
+            .await;
+        assert_eq!(resp.status_code(), http::StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn favoriting_yourself_still_works_on_both_routes() {
+        let (server, ctx, token) = authenticated_server().await;
+        let item = insert_test_source(&ctx.0).await;
+        let auth = || {
+            (
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth_header_with_token(&token)).unwrap(),
+            )
+        };
+
+        let resp = server
+            .post(&format!("/userfavoriteitems/{}", item.id))
+            .add_header(auth().0, auth().1)
+            .await;
+        assert_eq!(resp.json::<serde_json::Value>()["IsFavorite"], true);
+
+        let resp = server
+            .delete(&format!("/userfavoriteitems/{}", item.id))
+            .add_header(auth().0, auth().1)
+            .await;
+        assert_eq!(resp.json::<serde_json::Value>()["IsFavorite"], false);
     }
 }


### PR DESCRIPTION
The four favourite handlers bind the path `{user_id}` and never use it, operating on `session.user` instead. Favouriting on behalf of another user marks it for the caller and leaves the target untouched. Nothing errors, so it goes unnoticed.

Uses `TargetUser`, as `mark_played` and `unmark_played` just below already do. That honours the path user and rejects a non-admin targeting someone else.

The unscoped `/userfavoriteitems` routes get the same extractor: with no path user it falls back to the caller, and picks up `?userId=` for parity with Jellyfin.