### PR TITLE
fix: regenerate collection/library image when you remove it

### DIFF
--- a/crates/remux-dashboard/src/pages/collections.rs
+++ b/crates/remux-dashboard/src/pages/collections.rs
@@ -448,13 +448,19 @@ pub fn CollectionForm(
         .server
         .manual_address
         .clone();
-    let current_image_url = existing_item_id
+    let existing_uuid = existing
+        .as_ref()
+        .map(|f| f.id);
+    let initial_image_url = existing_item_id
         .as_ref()
         .zip(existing_image_tag.as_ref())
         .map(|(id, tag)| format!("{server_base}/Items/{id}/Images/Primary?tag={tag}"));
+    let mut current_image_url: Signal<Option<String>> =
+        use_signal(|| initial_image_url.clone());
     let mut pending_image_bytes: Signal<Option<Vec<u8>>> = use_signal(|| None);
     let mut pending_image_preview: Signal<Option<String>> = use_signal(|| None);
     let mut has_image = use_signal(|| existing_image_tag.is_some());
+    let server_base_delete = server_base.clone();
     let client_for_delete = app_state.clone();
     let app_state_delete = app_state.clone();
     let delete_name = existing
@@ -711,7 +717,7 @@ pub fn CollectionForm(
                                 src: "{preview}",
                                 style: "width:100%;max-height:180px;object-fit:cover;border-radius:6px;border:1px solid var(--border)",
                             }
-                        } else if let Some(url) = &current_image_url {
+                        } else if let Some(url) = current_image_url.read().as_ref() {
                             if *has_image.read() {
                                 img {
                                     src: "{url}",
@@ -757,20 +763,47 @@ pub fn CollectionForm(
                                     style: "height:30px;font-size:.68rem;padding:0 10px;color:var(--error);border-color:var(--error)",
                                     onclick: {
                                         let item_id = existing_item_id.clone();
+                                        let uuid = existing_uuid;
                                         let client = client_for_delete.clone();
+                                        let base = server_base_delete.clone();
                                         move |_| {
                                             let item_id = item_id.clone();
                                             let client = client.clone();
+                                            let base = base.clone();
                                             spawn(async move {
-                                                if let Some(id) = item_id {
-                                                    let _ = client.execute(remux_sdks::remux::DeleteItemImage {
-                                                        item_id: id,
-                                                        image_type: "Primary".to_string(),
-                                                    }).await;
-                                                }
+                                                let Some(id) = item_id else { return };
+                                                let _ = client.execute(remux_sdks::remux::DeleteItemImage {
+                                                    item_id: id.clone(),
+                                                    image_type: "Primary".to_string(),
+                                                }).await;
                                                 pending_image_bytes.set(None);
                                                 pending_image_preview.set(None);
-                                                has_image.set(false);
+                                                // The delete regenerates the placeholder server-side
+                                                // under a new tag; reusing the old one would hit the
+                                                // browser cache and show what we just removed.
+                                                let refreshed = client
+                                                    .execute(GetItems(GetItemsQuery {
+                                                        ids: uuid.map(|u| vec![u]),
+                                                        include_childless: Some(true),
+                                                        ..Default::default()
+                                                    }))
+                                                    .await
+                                                    .ok()
+                                                    .and_then(|r| r.items.into_iter().next())
+                                                    .and_then(|i| i.image_tags)
+                                                    .and_then(|t| t.primary);
+                                                match refreshed {
+                                                    Some(tag) => {
+                                                        current_image_url.set(Some(format!(
+                                                            "{base}/Items/{id}/Images/Primary?tag={tag}"
+                                                        )));
+                                                        has_image.set(true);
+                                                    }
+                                                    None => {
+                                                        current_image_url.set(None);
+                                                        has_image.set(false);
+                                                    }
+                                                }
                                             });
                                         }
                                     },

--- a/crates/remux-server/src/api/images.rs
+++ b/crates/remux-server/src/api/images.rs
@@ -395,6 +395,23 @@ async fn delete_item_image_inner(
     )
     .await
     .context_internal("failed to delete image")?;
+
+    // Rebuild now rather than on the next GET, so the item DTO carries a fresh
+    // ImageTag immediately — clients cache images by tag for a day.
+    if kind == ImageKind::Primary {
+        let _ = ImageService::regenerate_library_image(
+            &state
+                .ctx
+                .config
+                .data_dir,
+            id,
+            &state
+                .ctx
+                .db,
+        )
+        .await;
+    }
+
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/crates/remux-server/src/api/items.rs
+++ b/crates/remux-server/src/api/items.rs
@@ -2249,14 +2249,13 @@ pub async fn update_virtual_folder(
     .execute(&state.ctx.db)
     .await?;
 
-    // Library name is baked into the generated placeholder — clear it so it regenerates.
-    let _ = ImageService::delete_image(
+    // Library name is baked into the generated placeholder — rebuild it.
+    let _ = ImageService::regenerate_library_image(
         &state
             .ctx
             .config
             .data_dir,
         payload.id,
-        db::ImageKind::Primary,
         &state
             .ctx
             .db,
@@ -3209,13 +3208,13 @@ pub async fn patch_item(
         .name
         .is_some()
     {
-        let _ = ImageService::delete_image(
+        // Title is baked into the generated placeholder — rebuild it.
+        let _ = ImageService::regenerate_library_image(
             &state
                 .ctx
                 .config
                 .data_dir,
             id,
-            db::ImageKind::Primary,
             &state
                 .ctx
                 .db,

--- a/crates/remux-server/src/services/image.rs
+++ b/crates/remux-server/src/services/image.rs
@@ -154,8 +154,11 @@ impl ImageService {
         ))
     }
 
-    /// Generate the library placeholder image, write it to disk, save the path
-    /// to `media_images` in the DB, and return the JPEG bytes.
+    /// Return the generated library placeholder for `id`, creating it if needed.
+    ///
+    /// A `media_images` row is guaranteed to exist on return: its UUID is the
+    /// client-facing image tag, and without one the item DTO falls back to a
+    /// constant synthetic tag that clients can never bust their cache on.
     pub async fn library_image(
         data_dir: &std::path::Path,
         id: Uuid,
@@ -164,12 +167,14 @@ impl ImageService {
     ) -> anyhow::Result<Vec<u8>> {
         let path = Self::image_path(data_dir, id, "primary", "jpg");
 
-        if path.exists() {
-            return Ok(tokio::fs::read(&path).await?);
-        }
+        let bytes = if path.exists() {
+            tokio::fs::read(&path).await?
+        } else {
+            let bytes = Self::generate(id, name, db).await?;
+            Self::write_image_to_disk(&path, &bytes).await?;
+            bytes
+        };
 
-        let bytes = Self::generate(id, name, db).await?;
-        Self::write_image_to_disk(&path, &bytes).await?;
         // INSERT OR IGNORE — don't replace if already exists (stable UUID for cache)
         sqlx::query(
             "INSERT OR IGNORE INTO media_images (id, media_id, image_type, image_index, path, width, height) VALUES (?, ?, 'primary', 0, ?, ?, ?)"
@@ -183,6 +188,35 @@ impl ImageService {
         .await?;
 
         Ok(bytes)
+    }
+
+    /// Rebuild the generated placeholder for a Collection/Folder, returning
+    /// `false` for any other media kind.
+    ///
+    /// Deleting the current Primary first is what mints a **new** row UUID —
+    /// that UUID is the `ImageTags.Primary` clients cache on, and reusing it
+    /// leaves browsers on the old picture for the full `max-age=86400`.
+    ///
+    /// May fetch a child backdrop over HTTP (15 s timeout), so this is reserved
+    /// for admin-triggered writes. Callers should discard errors: a failed
+    /// regeneration must not fail the surrounding request.
+    pub async fn regenerate_library_image(
+        data_dir: &std::path::Path,
+        id: Uuid,
+        db: &sqlx::SqlitePool,
+    ) -> anyhow::Result<bool> {
+        let Some(media) = db::Media::get_by_id(db, &id).await? else {
+            return Ok(false);
+        };
+        if !matches!(
+            media.kind,
+            db::MediaKind::Collection | db::MediaKind::Folder
+        ) {
+            return Ok(false);
+        }
+        Self::delete_image(data_dir, id, ImageKind::Primary, db).await?;
+        Self::library_image(data_dir, id, &media.title, db).await?;
+        Ok(true)
     }
 
     /// Save an uploaded image for `id`/`image_type`, write to disk, update DB.
@@ -214,9 +248,14 @@ impl ImageService {
         Ok(())
     }
 
+    /// Every extension `save_image`/`library_image` may have written for a kind.
+    /// Uploading a PNG over a generated JPEG leaves the JPEG orphaned on disk;
+    /// `library_image`'s existence check would then serve the stale file forever.
+    const IMAGE_EXTS: [&'static str; 4] = ["jpg", "png", "gif", "webp"];
+
     /// Delete the local image for `id`/`kind` and remove from media_images.
     pub async fn delete_image(
-        _data_dir: &std::path::Path,
+        data_dir: &std::path::Path,
         id: Uuid,
         kind: ImageKind,
         db: &sqlx::SqlitePool,
@@ -234,6 +273,12 @@ impl ImageService {
                         tokio::fs::remove_file(&path).await?;
                     }
                 }
+            }
+        }
+        for ext in Self::IMAGE_EXTS {
+            let path = Self::image_path(data_dir, id, &kind.to_string(), ext);
+            if path.exists() {
+                tokio::fs::remove_file(&path).await?;
             }
         }
         db::MediaImage::delete_for_type(db, id, kind)
@@ -634,4 +679,192 @@ fn apply_sizing(img: DynamicImage, opts: &ImageProcessOptions) -> DynamicImage {
     }
 
     img
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::SqlitePool;
+
+    use super::*;
+
+    async fn test_db() -> SqlitePool {
+        let db = crate::db::connect("sqlite::memory:", 10_000)
+            .await
+            .unwrap();
+        crate::db::migrate(&db)
+            .await
+            .unwrap();
+        db
+    }
+
+    async fn insert_collection(db: &SqlitePool, title: &str) -> Uuid {
+        let mut media = db::Media {
+            id: Uuid::new_v4(),
+            title: title.to_string(),
+            kind: db::MediaKind::Collection,
+            ..Default::default()
+        };
+        media
+            .save(db)
+            .await
+            .unwrap();
+        media.id
+    }
+
+    fn scratch_dir() -> PathBuf {
+        std::env::temp_dir().join(format!("remux-img-test-{}", Uuid::new_v4()))
+    }
+
+    #[tokio::test]
+    async fn delete_image_removes_orphaned_extension_variants() {
+        let db = test_db().await;
+        let data_dir = scratch_dir();
+        let id = insert_collection(&db, "Movies").await;
+
+        // A generated primary.jpg later shadowed by a PNG upload: only the PNG
+        // is recorded in the DB, so the JPEG is unreachable from the row alone.
+        let jpg = ImageService::image_path(&data_dir, id, "primary", "jpg");
+        let png = ImageService::image_path(&data_dir, id, "primary", "png");
+        ImageService::write_image_to_disk(&jpg, b"stale-generated")
+            .await
+            .unwrap();
+        ImageService::write_image_to_disk(&png, b"user-upload")
+            .await
+            .unwrap();
+        db::MediaImage::save(
+            &db,
+            id,
+            ImageKind::Primary,
+            png.to_string_lossy()
+                .as_ref(),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        ImageService::delete_image(&data_dir, id, ImageKind::Primary, &db)
+            .await
+            .unwrap();
+
+        assert!(!png.exists(), "recorded upload must be deleted");
+        assert!(!jpg.exists(), "orphaned generated file must be deleted too");
+        let images = db::MediaImage::get_for_media(&db, &id)
+            .await
+            .unwrap();
+        assert!(
+            images
+                .get(ImageKind::Primary)
+                .is_none()
+        );
+
+        let _ = std::fs::remove_dir_all(&data_dir);
+    }
+
+    #[tokio::test]
+    async fn library_image_inserts_row_even_when_file_already_exists() {
+        let db = test_db().await;
+        let data_dir = scratch_dir();
+        let id = insert_collection(&db, "Movies").await;
+
+        // File on disk with no DB row — the state older builds left behind.
+        let jpg = ImageService::image_path(&data_dir, id, "primary", "jpg");
+        ImageService::write_image_to_disk(&jpg, b"already-generated")
+            .await
+            .unwrap();
+
+        let bytes = ImageService::library_image(&data_dir, id, "Movies", &db)
+            .await
+            .unwrap();
+        assert_eq!(bytes, b"already-generated");
+
+        let images = db::MediaImage::get_for_media(&db, &id)
+            .await
+            .unwrap();
+        let row = images
+            .get(ImageKind::Primary)
+            .expect("primary row must exist after library_image");
+        assert_eq!(
+            row.path,
+            jpg.to_string_lossy()
+                .to_string()
+        );
+
+        let _ = std::fs::remove_dir_all(&data_dir);
+    }
+
+    #[tokio::test]
+    async fn regenerate_library_image_rebuilds_with_a_fresh_tag() {
+        let db = test_db().await;
+        let data_dir = scratch_dir();
+        let id = insert_collection(&db, "Movies").await;
+
+        ImageService::library_image(&data_dir, id, "Movies", &db)
+            .await
+            .unwrap();
+        let tag_before = db::MediaImage::get_for_media(&db, &id)
+            .await
+            .unwrap()
+            .get(ImageKind::Primary)
+            .unwrap()
+            .id;
+
+        let regenerated = ImageService::regenerate_library_image(&data_dir, id, &db)
+            .await
+            .unwrap();
+        assert!(regenerated);
+
+        let after = db::MediaImage::get_for_media(&db, &id)
+            .await
+            .unwrap();
+        let row = after
+            .get(ImageKind::Primary)
+            .expect("placeholder row must be rebuilt");
+        assert_ne!(row.id, tag_before, "tag must change so clients refetch");
+        assert!(ImageService::image_path(&data_dir, id, "primary", "jpg").exists());
+
+        let _ = std::fs::remove_dir_all(&data_dir);
+    }
+
+    #[tokio::test]
+    async fn regenerate_library_image_ignores_non_container_media() {
+        let db = test_db().await;
+        let data_dir = scratch_dir();
+        let external_ids = db::ExternalIds {
+            imdb: db::NonEmptyString::try_new("tt0000001".to_string()).ok(),
+            ..Default::default()
+        };
+        let mut movie = db::Media {
+            id: Uuid::from(&db::MediaIdRaw {
+                kind: db::MediaKind::Movie,
+                external_ids: external_ids.clone(),
+                season: None,
+                episode: None,
+            }),
+            title: "A Movie".to_string(),
+            kind: db::MediaKind::Movie,
+            external_ids,
+            ..Default::default()
+        };
+        movie
+            .save(&db)
+            .await
+            .unwrap();
+        let id = movie.id;
+
+        let regenerated = ImageService::regenerate_library_image(&data_dir, id, &db)
+            .await
+            .unwrap();
+        assert!(!regenerated);
+        let images = db::MediaImage::get_for_media(&db, &id)
+            .await
+            .unwrap();
+        assert!(
+            images
+                .get(ImageKind::Primary)
+                .is_none()
+        );
+
+        let _ = std::fs::remove_dir_all(&data_dir);
+    }
 }


### PR DESCRIPTION
Fixes #209

Removing a collection or library image doesn't give you the generated placeholder back, you just keep seeing the old picture. You mentioned it refreshes in the clients but not in the dashboard, that's true but it's not really a dashboard problem, the dashboard just happens to be where you notice it first. Three bugs stacked on top of each other.

**The image tag is a constant when there's no image row.** In `db_to_dto`, a collection or folder with no `media_images` row falls back to a synthetic `ImageTags.Primary` equal to `media.id`. That never changes. Images go out with `Cache-Control: max-age=86400` and no ETag, so same tag, same URL, and the browser happily replays the picture you just deleted for the next 24 hours. Timeline is: new collection → tag is `media.id` → browser caches the generated placeholder under that URL → you upload a poster (new row, new tag, fine) → you remove it → the row is gone so we're back to `media.id` → cache hit on the very first URL. It only looks like the dashboard because that's the client that shows you the edit form right after.

**Orphaned placeholder files.** `save_image` writes `{kind}.{ext}` following the upload format, but the generated placeholder is always `primary.jpg`. Upload a PNG over a generated placeholder and the JPEG stays behind, and `delete_image` only unlinked whatever path was in the DB row. So the orphan survives, and `library_image`'s `if path.exists()` check serves it forever. You get "a" generated image back, just the wrong one, possibly with the old library name baked in.

**`library_image` only recorded its row on one branch.** The `INSERT OR IGNORE` runs when it generates, not when it returns the existing file. So you can end up with a placeholder on disk and no row, which puts the DTO back on the synthetic tag permanently, and `process_image` keys its disk cache on the constant `placeholder:{id}` too.

## Changes

`delete_image` now sweeps every local `{kind}.{ext}` variant on top of the DB path, so nothing can shadow a later regeneration. `library_image` got restructured so both branches upsert, a row always exists when it returns. And a new `regenerate_library_image` deletes the current Primary then regenerates, which is what actually mints a new row UUID, and that UUID is the tag clients cache on. It's a no-op for anything that isn't a Collection or Folder.

It runs in three places: after a Primary delete in `delete_item_image_inner`, and at the two rename sites in `items.rs` that were already doing a bare `delete_image` for the same reason (the name is drawn into the image). Both of those already run after the title is committed, so the rebuilt placeholder picks up the new name.

Dashboard side, the Remove button now refetches the item to get the new tag and shows you the regenerated placeholder, instead of setting `has_image = false` and hiding the whole thing. `current_image_url` had to become a signal since it was computed once at page load and never recomputed.

Nothing changes on the public API, `DELETE /items/{id}/images/{type}` still returns 204 with no body, no new fields anywhere.

## The trade-off

Regeneration is synchronous, and `generate()` can go fetch a child backdrop over HTTP with a 15s timeout. The dashboard always sends `name` on save, so renaming a collection can now block for that long in the worst case with a dead backdrop URL. Before, the rename path was just a delete and the cost was pushed to the next image GET.

I did it inline on purpose, because that's the whole point, the fresh tag has to exist by the time the response comes back or the client has nothing new to request. Spawning it would make saves fast again but you'd be back to a stale tag for a moment. Happy to flip it if you'd rather have the latency, just say so.

Upload still works by the way, the dashboard does `PatchItem` then `UploadItemImage`, so the placeholder the rename regenerates gets immediately replaced by the actual upload under its own fresh UUID.