### PR TITLE
fix: redact secrets from Debug output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6740,6 +6740,8 @@ dependencies = [
  "moka",
  "nutype",
  "serde",
+ "serde_json",
+ "sqlx",
  "uuid",
 ]
 

--- a/crates/remux-dashboard/src/pages/addons.rs
+++ b/crates/remux-dashboard/src/pages/addons.rs
@@ -442,7 +442,7 @@ pub fn AddonsPage(app_state: AppState) -> Element {
                                         let c = client.clone();
                                         spawn(async move {
                                             let payload = CreateAddonRequest {
-                                                preset: AddonPresetRef { kind, config },
+                                                preset: AddonPresetRef { kind, config: config.into() },
                                                 name,
                                                 resources: Vec::new(),
                                                 types: Vec::new(),

--- a/crates/remux-sdks/src/remux/mod.rs
+++ b/crates/remux-sdks/src/remux/mod.rs
@@ -145,8 +145,9 @@ pub struct AddonSelectOption {
 #[serde(rename_all = "camelCase")]
 pub struct AddonPresetRef {
     pub kind: String,
+    /// Holds every `Password`-kind option value.
     #[serde(default)]
-    pub config: serde_json::Value,
+    pub config: remux_utils::Secret<serde_json::Value>,
 }
 
 /// Static metadata describing one kind of addon. Returned by `GET /addon-kinds`

--- a/crates/remux-server/Cargo.toml
+++ b/crates/remux-server/Cargo.toml
@@ -79,7 +79,7 @@ flate2 = "1.1.1"
 tar = "0.4.44"
 #reqwest-middleware = { version = "0.4", default-features = false, features = ["rustls-tls"] }
 remux-sdks = { path = "../remux-sdks", features = ["native"] }
-remux-utils = { path = "../remux-utils" }
+remux-utils = { path = "../remux-utils", features = ["sqlx"] }
 isolang = { version = "2.4.0", features = ["list_languages"] }
 timed = "0.2.1"
 async-trait = "0.1.88"

--- a/crates/remux-server/src/addons/addon.rs
+++ b/crates/remux-server/src/addons/addon.rs
@@ -123,14 +123,21 @@ impl Addon {
     pub fn catalog_states(&self) -> HashMap<String, CatalogState> {
         self.preset
             .config
+            .expose()
             .get("catalogs")
             .and_then(|v| serde_json::from_value(v.clone()).ok())
             .unwrap_or_default()
     }
 
     pub fn set_catalog_states(&mut self, states: HashMap<String, CatalogState>) {
+        let mut cfg = self
+            .preset
+            .config
+            .expose()
+            .clone();
+        cfg["catalogs"] = serde_json::to_value(states).unwrap_or_default();
         self.preset
-            .config["catalogs"] = serde_json::to_value(states).unwrap_or_default();
+            .config = cfg.into();
         self.updated_at = Utc::now().naive_utc();
     }
 }

--- a/crates/remux-server/src/addons/mod.rs
+++ b/crates/remux-server/src/addons/mod.rs
@@ -1313,9 +1313,10 @@ impl AddonService {
             };
             match preset.from_cfg(
                 addon.id,
-                &addon
+                addon
                     .preset
-                    .config,
+                    .config
+                    .expose(),
                 config,
             ) {
                 Ok(mut caps) => {

--- a/crates/remux-server/src/addons/opendal.rs
+++ b/crates/remux-server/src/addons/opendal.rs
@@ -1832,7 +1832,8 @@ mod tests {
                 config: serde_json::json!({
                     "media_kind": media_kind,
                     "paths": [root],
-                }),
+                })
+                .into(),
             },
             resources: vec![ResourceType::Stream, ResourceType::Catalog],
             types: vec![],

--- a/crates/remux-server/src/addons/opendal.rs
+++ b/crates/remux-server/src/addons/opendal.rs
@@ -1064,9 +1064,10 @@ async fn scan_addon(
     tmdb: &Option<sdks::RestClient<sdks::BearerAuth>>,
     addon: &Addon,
 ) -> Result<()> {
-    let cfg = &addon
+    let cfg = addon
         .preset
-        .config;
+        .config
+        .expose();
     let media_kind = cfg["media_kind"]
         .as_str()
         .unwrap_or("movie")

--- a/crates/remux-server/src/addons/tracking.rs
+++ b/crates/remux-server/src/addons/tracking.rs
@@ -220,22 +220,7 @@ impl TrackingIds {
 }
 
 /// Opaque to core: a static webhook token and an OAuth triple look the same.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct TrackingCredentials(pub serde_json::Value);
-
-impl TrackingCredentials {
-    pub fn new(value: serde_json::Value) -> Self {
-        Self(value)
-    }
-
-    pub fn get_str(&self, key: &str) -> Option<&str> {
-        self.0
-            .get(key)
-            .and_then(|v| v.as_str())
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-    }
-}
+pub type TrackingCredentials = remux_utils::Secret<serde_json::Value>;
 
 /// Drives which connect UI the dashboard renders, without it knowing the
 /// provider.

--- a/crates/remux-server/src/api/addons.rs
+++ b/crates/remux-server/src/api/addons.rs
@@ -47,9 +47,10 @@ async fn addon_to_dto(addon: Addon, config: &crate::Config) -> AddonDto {
             .clone();
         match p.from_cfg(
             addon.id,
-            &addon
+            addon
                 .preset
-                .config,
+                .config
+                .expose(),
             config,
         ) {
             Ok(caps) => {
@@ -114,7 +115,8 @@ async fn addon_to_dto(addon: Addon, config: &crate::Config) -> AddonDto {
         name: addon.name,
         config: addon
             .preset
-            .config,
+            .config
+            .into_inner(),
         resources: addon.resources,
         types: addon
             .types
@@ -237,7 +239,8 @@ pub async fn create_addon(
         .normalize_cfg(
             payload
                 .preset
-                .config,
+                .config
+                .into_inner(),
             &state
                 .ctx
                 .config,
@@ -245,13 +248,14 @@ pub async fn create_addon(
         .context_bad_request("Invalid addon configuration")?;
     payload
         .preset
-        .config = normalized_config;
+        .config = normalized_config.into();
     let caps = preset
         .from_cfg(
             addon_id,
-            &payload
+            payload
                 .preset
-                .config,
+                .config
+                .expose(),
             &state
                 .ctx
                 .config,
@@ -459,7 +463,8 @@ pub async fn update_addon(
                     .ctx
                     .config,
             )
-            .context_bad_request("Invalid addon configuration")?;
+            .context_bad_request("Invalid addon configuration")?
+            .into();
     }
     preset
         .from_cfg(

--- a/crates/remux-server/src/api/addons.rs
+++ b/crates/remux-server/src/api/addons.rs
@@ -469,9 +469,10 @@ pub async fn update_addon(
     preset
         .from_cfg(
             addon.id,
-            &addon
+            addon
                 .preset
-                .config,
+                .config
+                .expose(),
             &state
                 .ctx
                 .config,

--- a/crates/remux-server/src/api/api_keys.rs
+++ b/crates/remux-server/src/api/api_keys.rs
@@ -32,7 +32,10 @@ pub async fn get_api_keys(
     let items: Vec<api::AuthenticationInfo> = keys
         .into_iter()
         .map(|k| api::AuthenticationInfo {
-            access_token: Some(k.access_token),
+            access_token: Some(
+                k.access_token
+                    .into_inner(),
+            ),
             app_name: Some(k.app_name),
             date_created: Some(k.created_at),
             is_active: Some(true),
@@ -62,7 +65,10 @@ pub async fn create_api_key(
     )
     .await?;
     let info = api::AuthenticationInfo {
-        access_token: Some(key.access_token),
+        access_token: Some(
+            key.access_token
+                .into_inner(),
+        ),
         app_name: Some(key.app_name),
         date_created: Some(key.created_at),
         is_active: Some(true),

--- a/crates/remux-server/src/api/devices.rs
+++ b/crates/remux-server/src/api/devices.rs
@@ -92,9 +92,10 @@ pub async fn delete_device(
                     .db,
                 &user_id,
                 Some(
-                    &session
+                    session
                         .device
-                        .access_token,
+                        .access_token
+                        .expose(),
                 ),
             )
             .await?;
@@ -206,6 +207,7 @@ pub async fn get_devices(
     let caller_token = session
         .device
         .access_token
+        .expose()
         .as_str();
     let device_infos: Vec<api::DeviceInfo> = devices
         .iter()

--- a/crates/remux-server/src/api/items.rs
+++ b/crates/remux-server/src/api/items.rs
@@ -3349,7 +3349,10 @@ mod tests {
     use crate::{
         db,
         db::{ExternalIds, MediaIdRaw, NonEmptyString},
-        integration_test::{auth_header_with_token, authenticated_server},
+        integration_test::{
+            assert_api_keys_are_real, auth_header_with_token, authenticated_server,
+            insert_test_source_of_kind,
+        },
     };
 
     async fn get_user_id(server: &axum_test::TestServer, auth: &str) -> String {
@@ -4384,5 +4387,26 @@ mod tests {
             !names.contains(&"Comedy Movies"),
             "untagged collection must not appear in smart group; got: {names:?}"
         );
+    }
+
+    /// Tracks are wrapped as HLS sources here rather than in the playback layer,
+    /// so this URL is built in its own place and needs its own check: it carries
+    /// the session token the client must play with.
+    #[tokio::test]
+    async fn track_media_source_url_carries_the_real_token() {
+        let (server, guard, token) = authenticated_server().await;
+        let auth = auth_header_with_token(&token);
+        let media = insert_test_source_of_kind(&guard.0, db::MediaKind::Track).await;
+
+        let resp = server
+            .get(&format!("/items/{}", media.id))
+            .add_header(
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth).unwrap(),
+            )
+            .await;
+
+        resp.assert_status_ok();
+        assert_api_keys_are_real(&resp.json::<serde_json::Value>(), &token);
     }
 }

--- a/crates/remux-server/src/api/items.rs
+++ b/crates/remux-server/src/api/items.rs
@@ -1780,6 +1780,7 @@ async fn item_for_user(
             session
                 .device
                 .access_token
+                .expose()
         );
         let sources = media
             .sources

--- a/crates/remux-server/src/api/models.rs
+++ b/crates/remux-server/src/api/models.rs
@@ -105,7 +105,12 @@ pub fn device_info_from(
                 .remote_ip
                 .clone(),
             user_id: Some(device.user_id),
-            is_current_session: Some(device.access_token == caller_token),
+            is_current_session: Some(
+                device
+                    .access_token
+                    .expose()
+                    == caller_token,
+            ),
         }),
     }
 }

--- a/crates/remux-server/src/api/playback.rs
+++ b/crates/remux-server/src/api/playback.rs
@@ -1130,7 +1130,8 @@ mod tests {
                 kind: "stremio".to_string(),
                 config: serde_json::json!({
                     "manifest_url": "https://example.com/addon/manifest.json"
-                }),
+                })
+                .into(),
             },
             resources: vec![ResourceType::Stream],
             types: vec![],

--- a/crates/remux-server/src/api/playback.rs
+++ b/crates/remux-server/src/api/playback.rs
@@ -1107,7 +1107,8 @@ mod tests {
     use serde_json::json;
 
     use crate::integration_test::{
-        AUTH_HEADER, auth_header_with_token, authenticated_server, insert_test_source,
+        AUTH_HEADER, assert_api_keys_are_real, auth_header_with_token,
+        authenticated_server, insert_test_source, insert_test_source_of_kind,
         new_test_server,
     };
 
@@ -1845,6 +1846,59 @@ mod tests {
             url.contains(&format!("ApiKey={}", token)),
             "TranscodingUrl should carry the session token: {}",
             url
+        );
+        // Subtitle delivery URLs and any other URL in the body carry it too.
+        assert_api_keys_are_real(&body, &token);
+    }
+
+    /// Live TV takes its own branch and builds its own URL.
+    #[tokio::test]
+    async fn test_playbackinfo_live_url_carries_the_real_token() {
+        let (server, guard, token) = authenticated_server().await;
+        let auth = auth_header_with_token(&token);
+        let media =
+            insert_test_source_of_kind(&guard.0, crate::db::MediaKind::TvChannel).await;
+
+        let resp = server
+            .post(&format!("/items/{}/playbackinfo", media.id))
+            .add_header(
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth).unwrap(),
+            )
+            .json(&json!({ "MaxStreamingBitrate": 1_000_000 }))
+            .await;
+
+        resp.assert_status_ok();
+        assert_api_keys_are_real(&resp.json::<serde_json::Value>(), &token);
+    }
+
+    /// The audio redirect hands the client a URL it must fetch with the token
+    /// already in it, so a redacted one 401s on the very next request.
+    #[tokio::test]
+    async fn test_audio_universal_redirect_carries_the_real_token() {
+        let (server, guard, token) = authenticated_server().await;
+        let auth = auth_header_with_token(&token);
+        let media =
+            insert_test_source_of_kind(&guard.0, crate::db::MediaKind::Track).await;
+
+        let resp = server
+            .get(&format!("/audio/{}/universal", media.id))
+            .add_header(
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth).unwrap(),
+            )
+            .expect_failure()
+            .await;
+
+        resp.assert_status(StatusCode::TEMPORARY_REDIRECT);
+        let location = resp
+            .header("location")
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert!(
+            location.contains(&format!("ApiKey={}", token)),
+            "redirect should carry the session token: {location}"
         );
     }
 

--- a/crates/remux-server/src/api/playback.rs
+++ b/crates/remux-server/src/api/playback.rs
@@ -427,9 +427,10 @@ async fn items_playbackinfo_inner(
         apply_subtitle_delivery(
             &mut source,
             id,
-            &session
+            session
                 .device
-                .access_token,
+                .access_token
+                .expose(),
             &cfg.device_profile,
             cfg.subtitle_mode,
         );
@@ -457,9 +458,10 @@ async fn items_playbackinfo_inner(
             sub_media,
             &mut media_sources,
             id,
-            &session
+            session
                 .device
-                .access_token,
+                .access_token
+                .expose(),
             sub_langs,
             Some(
                 session
@@ -527,7 +529,8 @@ async fn items_playbackinfo_inner(
                     source.id,
                     session
                         .device
-                        .access_token,
+                        .access_token
+                        .expose(),
                 ));
             }
         }
@@ -1069,6 +1072,7 @@ pub async fn audio_universal(
         session
             .device
             .access_token
+            .expose()
     );
 
     Ok(axum::response::Redirect::temporary(&transcoding_url).into_response())
@@ -1810,6 +1814,36 @@ mod tests {
         assert!(
             url.contains(&format!("MaxStreamingBitrate={}", max_bitrate)),
             "TranscodingUrl should contain MaxStreamingBitrate: {}",
+            url
+        );
+    }
+
+    /// The session token is carried in the URL the client is told to fetch, so
+    /// it has to be the real one. It is wrapped in a `Secret`, which only ever
+    /// prints as `<redacted>`.
+    #[tokio::test]
+    async fn test_playbackinfo_transcoding_url_carries_the_real_token() {
+        let (server, guard, token) = authenticated_server().await;
+        let auth = auth_header_with_token(&token);
+        let media = insert_test_source(&guard.0).await;
+
+        let resp = server
+            .post(&format!("/items/{}/playbackinfo", media.id))
+            .add_header(
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth).unwrap(),
+            )
+            .json(&json!({ "MaxStreamingBitrate": 1_000_000 }))
+            .await;
+
+        resp.assert_status_ok();
+        let body: serde_json::Value = resp.json();
+        let url = body["MediaSources"][0]["TranscodingUrl"]
+            .as_str()
+            .expect("TranscodingUrl should be present");
+        assert!(
+            url.contains(&format!("ApiKey={}", token)),
+            "TranscodingUrl should carry the session token: {}",
             url
         );
     }

--- a/crates/remux-server/src/api/playback.rs
+++ b/crates/remux-server/src/api/playback.rs
@@ -1109,7 +1109,7 @@ mod tests {
     use crate::integration_test::{
         AUTH_HEADER, assert_api_keys_are_real, auth_header_with_token,
         authenticated_server, insert_test_source, insert_test_source_of_kind,
-        new_test_server,
+        insert_test_source_with_external_subtitle, new_test_server,
     };
 
     #[tokio::test]
@@ -1848,6 +1848,38 @@ mod tests {
             url
         );
         // Subtitle delivery URLs and any other URL in the body carry it too.
+        assert_api_keys_are_real(&body, &token);
+    }
+
+    /// An external subtitle is delivered by URL, and that URL is built apart
+    /// from the transcode one.
+    #[tokio::test]
+    async fn test_playbackinfo_subtitle_delivery_url_carries_the_real_token() {
+        let (server, guard, token) = authenticated_server().await;
+        let auth = auth_header_with_token(&token);
+        let media = insert_test_source_with_external_subtitle(&guard.0).await;
+
+        let resp = server
+            .post(&format!("/items/{}/playbackinfo", media.id))
+            .add_header(
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth).unwrap(),
+            )
+            .json(&json!({ "MaxStreamingBitrate": 1_000_000 }))
+            .await;
+
+        resp.assert_status_ok();
+        let body: serde_json::Value = resp.json();
+        let delivery = body["MediaSources"][0]["MediaStreams"]
+            .as_array()
+            .expect("media streams")
+            .iter()
+            .find_map(|s| s["DeliveryUrl"].as_str())
+            .expect("an external subtitle is delivered by URL");
+        assert!(
+            delivery.contains(&format!("ApiKey={}", token)),
+            "subtitle delivery URL should carry the session token: {delivery}"
+        );
         assert_api_keys_are_real(&body, &token);
     }
 

--- a/crates/remux-server/src/api/remux.rs
+++ b/crates/remux-server/src/api/remux.rs
@@ -632,6 +632,7 @@ pub async fn remux_meta(
             .find_map(|a| {
                 a.preset
                     .config
+                    .expose()
                     .get("manifest_url")
                     .and_then(|v| {
                         v.as_str()

--- a/crates/remux-server/src/api/session.rs
+++ b/crates/remux-server/src/api/session.rs
@@ -33,9 +33,10 @@ pub async fn sessions_logout(
         &state
             .ctx
             .db,
-        &session
+        session
             .device
-            .access_token,
+            .access_token
+            .expose(),
     )
     .await?;
     Ok(StatusCode::NO_CONTENT)

--- a/crates/remux-server/src/api/shows.rs
+++ b/crates/remux-server/src/api/shows.rs
@@ -690,7 +690,9 @@ mod test {
     async fn insert_user(db: &SqlitePool, username: &str) -> db::User {
         let mut user = db::User {
             username: username.to_string(),
-            password_hash: "test".to_string(),
+            password_hash: "test"
+                .to_string()
+                .into(),
             ..Default::default()
         };
         user.save(db)

--- a/crates/remux-server/src/api/users.rs
+++ b/crates/remux-server/src/api/users.rs
@@ -257,7 +257,11 @@ fn build_auth_response(
     user_dto.last_activity_date = Some(now);
 
     Json(api::AuthenticationResult {
-        access_token: Some(device.access_token),
+        access_token: Some(
+            device
+                .access_token
+                .into_inner(),
+        ),
         server_id: server_id(),
         session_info: Some(session_info),
         user: Some(user_dto),
@@ -346,7 +350,9 @@ pub async fn authenticate_with_quickconnect(
             .version
             .unwrap_or_else(|| "1.0".to_string()),
         user_id: user.id,
-        access_token: get_uuid().to_string(),
+        access_token: get_uuid()
+            .to_string()
+            .into(),
         last_activity_at: None,
         capabilities: None,
         remote_ip: None,

--- a/crates/remux-server/src/api/users.rs
+++ b/crates/remux-server/src/api/users.rs
@@ -815,9 +815,10 @@ pub async fn change_password(
             .db,
         &user_id,
         Some(
-            &session
+            session
                 .device
-                .access_token,
+                .access_token
+                .expose(),
         ),
     )
     .await?;

--- a/crates/remux-server/src/db/api_key.rs
+++ b/crates/remux-server/src/db/api_key.rs
@@ -5,7 +5,7 @@ use sqlx::SqlitePool;
 
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
 pub struct ApiKey {
-    pub access_token: String,
+    pub access_token: remux_utils::Secret<String>,
     pub app_name: String,
     pub created_at: DateTime<Utc>,
 }

--- a/crates/remux-server/src/db/auth.rs
+++ b/crates/remux-server/src/db/auth.rs
@@ -42,7 +42,7 @@ use crate::{AppState, common::get_uuid, db};
 #[serde(rename_all = "PascalCase")]
 pub struct Device {
     pub id: String,
-    pub access_token: String,
+    pub access_token: remux_utils::Secret<String>,
     pub user_id: Uuid,
     pub name: String,
     pub app_name: String,
@@ -101,7 +101,9 @@ impl Device {
             user_id: user
                 .id
                 .clone(),
-            access_token: get_uuid().to_string(),
+            access_token: get_uuid()
+                .to_string()
+                .into(),
             ..Default::default()
         })
     }
@@ -753,7 +755,9 @@ mod tests {
     async fn insert_device(db: &SqlitePool, user_id: Uuid, token: &str) {
         Device {
             id: Uuid::new_v4().to_string(),
-            access_token: token.to_string(),
+            access_token: token
+                .to_string()
+                .into(),
             user_id,
             name: "Test Device".to_string(),
             app_name: "Test".to_string(),

--- a/crates/remux-server/src/db/auth.rs
+++ b/crates/remux-server/src/db/auth.rs
@@ -774,6 +774,62 @@ mod tests {
         .unwrap();
     }
 
+    /// An API key authenticates without a row in `devices`, so its session gets
+    /// a device built here, with an id derived from the token. The id has to
+    /// carry the real token: two keys that derive the same id share one playback
+    /// session, and each overwrites the other's progress.
+    #[tokio::test]
+    async fn each_api_key_gets_its_own_synthetic_device_id() {
+        use crate::integration_test::{auth_header_with_token, authenticated_server};
+        use http::header::{AUTHORIZATION, HeaderValue};
+
+        let (server, guard, admin_token) = authenticated_server().await;
+        let admin_auth = auth_header_with_token(&admin_token);
+
+        let mut keys = Vec::new();
+        for app in ["first", "second"] {
+            let resp = server
+                .post(&format!("/auth/keys?app={app}"))
+                .add_header(AUTHORIZATION, HeaderValue::from_str(&admin_auth).unwrap())
+                .await;
+            resp.assert_status_ok();
+            let info: crate::api::AuthenticationInfo = resp.json();
+            keys.push(
+                info.access_token
+                    .expect("a new key returns its token"),
+            );
+        }
+
+        for (i, key) in keys
+            .iter()
+            .enumerate()
+        {
+            server
+                .post("/sessions/playing")
+                .add_header("X-Emby-Token", HeaderValue::from_str(key).unwrap())
+                .json(&serde_json::json!({
+                    "ItemId": Uuid::new_v4().simple().to_string(),
+                    "PlaySessionId": format!("api-key-session-{i}"),
+                }))
+                .await
+                .assert_status(http::StatusCode::NO_CONTENT);
+        }
+
+        let device_ids: std::collections::HashSet<String> = guard
+            .0
+            .sessions
+            .get_all()
+            .into_iter()
+            .map(|s| s.device_id)
+            .collect();
+        for key in &keys {
+            assert!(
+                device_ids.contains(&format!("apikey-{key}")),
+                "each key should own a session under its own device id: {device_ids:?}"
+            );
+        }
+    }
+
     #[tokio::test]
     async fn delete_all_removes_every_device_for_user() {
         let db = test_db().await;

--- a/crates/remux-server/src/db/auth.rs
+++ b/crates/remux-server/src/db/auth.rs
@@ -484,7 +484,12 @@ impl FromRequestParts<AppState> for AuthSession {
         .context_unauthorized("forbidden")?;
 
         let synthetic_device = Device {
-            id: format!("apikey-{}", api_key.access_token),
+            id: format!(
+                "apikey-{}",
+                api_key
+                    .access_token
+                    .expose()
+            ),
             access_token: api_key.access_token,
             user_id: user.id,
             name: api_key

--- a/crates/remux-server/src/db/user.rs
+++ b/crates/remux-server/src/db/user.rs
@@ -266,8 +266,11 @@ impl User {
     }
 
     pub fn verify_password(&self, password: &str) -> Result<bool> {
-        let parsed = PasswordHash::new(&self.password_hash)
-            .map_err(|e| anyhow!("invalid stored password hash: {e}"))?;
+        let parsed = PasswordHash::new(
+            self.password_hash
+                .expose(),
+        )
+        .map_err(|e| anyhow!("invalid stored password hash: {e}"))?;
 
         Ok(Argon2::default()
             .verify_password(password.as_bytes(), &parsed)

--- a/crates/remux-server/src/db/user.rs
+++ b/crates/remux-server/src/db/user.rs
@@ -52,9 +52,9 @@ pub struct User {
     pub id: Uuid,
     pub username: String,
     #[serde(skip_serializing)]
-    pub password_hash: String,
+    pub password_hash: remux_utils::Secret<String>,
     #[serde(skip_serializing)]
-    pub aio_url: Option<String>,
+    pub aio_url: Option<remux_utils::Secret<String>>,
     pub configuration: Option<sqlx::types::Json<crate::api::UserConfiguration>>,
     pub is_admin: bool,
     pub policy: Option<sqlx::types::Json<crate::api::UserPolicy>>,
@@ -202,8 +202,8 @@ impl User {
         Ok(Self {
             id: get_uuid(),
             username,
-            password_hash,
-            aio_url,
+            password_hash: password_hash.into(),
+            aio_url: aio_url.map(Into::into),
             ..Default::default()
         })
     }
@@ -261,7 +261,7 @@ impl User {
     }
 
     pub fn set_password(&mut self, password: &str) -> Result<()> {
-        self.password_hash = Self::hash_password(password)?;
+        self.password_hash = Self::hash_password(password)?.into();
         Ok(())
     }
 

--- a/crates/remux-server/src/integration_test.rs
+++ b/crates/remux-server/src/integration_test.rs
@@ -103,6 +103,15 @@ pub async fn authenticated_server() -> (TestServer, TestGuard, String) {
 /// fields are set directly so playbackinfo tests behave identically in CI and
 /// locally.
 pub async fn insert_test_source(ctx: &AppContext) -> db::Media {
+    insert_test_source_of_kind(ctx, db::MediaKind::Stream).await
+}
+
+/// [`insert_test_source`] for a specific kind. Playbackinfo branches on it:
+/// `TvChannel` is live, `Track` goes down the HLS-only path.
+pub async fn insert_test_source_of_kind(
+    ctx: &AppContext,
+    kind: db::MediaKind,
+) -> db::Media {
     let now = Utc::now().naive_utc();
 
     // Build minimal probe_data so playbackinfo can make transcode decisions
@@ -131,9 +140,20 @@ pub async fn insert_test_source(ctx: &AppContext) -> db::Media {
         ..Default::default()
     };
 
+    // Tracks are rejected without a music provider id.
+    let external_ids = if kind == db::MediaKind::Track {
+        db::ExternalIds {
+            deezer_track: Some(1),
+            ..Default::default()
+        }
+    } else {
+        db::ExternalIds::default()
+    };
+
     let mut media = db::Media {
         title: "Test Source".to_string(),
-        kind: db::MediaKind::Stream,
+        kind,
+        external_ids,
         stream_info: Some(crate::stream::StreamInfo {
             descriptor: crate::stream::StreamDescriptor::Local(
                 "test-fixture.mp4".into(),
@@ -150,4 +170,46 @@ pub async fn insert_test_source(ctx: &AppContext) -> db::Media {
         .await
         .expect("insert_test_source failed");
     media
+}
+
+/// Every `ApiKey=` a response hands back must carry the caller's real token.
+/// The token is a `Secret`, so one formatting slip redacts it for every client
+/// at once; that is worth checking over the whole body rather than the one
+/// field a test happens to know about.
+pub fn assert_api_keys_are_real(value: &serde_json::Value, token: &str) {
+    fn walk(v: &serde_json::Value, token: &str, seen: &mut usize) {
+        match v {
+            serde_json::Value::String(s) => {
+                for tail in s
+                    .split("ApiKey=")
+                    .skip(1)
+                {
+                    *seen += 1;
+                    let got = tail
+                        .split('&')
+                        .next()
+                        .unwrap_or_default();
+                    assert_eq!(got, token, "ApiKey should be the caller's token: {s}");
+                }
+            }
+            serde_json::Value::Array(items) => {
+                for v in items {
+                    walk(v, token, seen);
+                }
+            }
+            serde_json::Value::Object(fields) => {
+                for v in fields.values() {
+                    walk(v, token, seen);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut seen = 0;
+    walk(value, token, &mut seen);
+    assert!(
+        seen > 0,
+        "expected the response to carry an ApiKey: {value}"
+    );
 }

--- a/crates/remux-server/src/integration_test.rs
+++ b/crates/remux-server/src/integration_test.rs
@@ -106,11 +106,37 @@ pub async fn insert_test_source(ctx: &AppContext) -> db::Media {
     insert_test_source_of_kind(ctx, db::MediaKind::Stream).await
 }
 
+/// [`insert_test_source`] with an external subtitle stream, which is delivered
+/// by URL rather than embedded.
+pub async fn insert_test_source_with_external_subtitle(ctx: &AppContext) -> db::Media {
+    insert_source(
+        ctx,
+        db::MediaKind::Stream,
+        vec![MediaStream {
+            codec: Some("subrip".to_string()),
+            type_: Some(MediaStreamType::Subtitle),
+            index: 2,
+            is_external: true,
+            language: Some("eng".to_string()),
+            ..Default::default()
+        }],
+    )
+    .await
+}
+
 /// [`insert_test_source`] for a specific kind. Playbackinfo branches on it:
 /// `TvChannel` is live, `Track` goes down the HLS-only path.
 pub async fn insert_test_source_of_kind(
     ctx: &AppContext,
     kind: db::MediaKind,
+) -> db::Media {
+    insert_source(ctx, kind, vec![]).await
+}
+
+async fn insert_source(
+    ctx: &AppContext,
+    kind: db::MediaKind,
+    extra_streams: Vec<MediaStream>,
 ) -> db::Media {
     let now = Utc::now().naive_utc();
 
@@ -136,7 +162,10 @@ pub async fn insert_test_source_of_kind(
                 index: 1,
                 ..Default::default()
             },
-        ],
+        ]
+        .into_iter()
+        .chain(extra_streams)
+        .collect(),
         ..Default::default()
     };
 

--- a/crates/remux-server/src/playback/decision.rs
+++ b/crates/remux-server/src/playback/decision.rs
@@ -424,3 +424,67 @@ pub(crate) fn apply_subtitle_delivery(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A source with no video stream routes to its own transcode branch, which
+    /// builds its own URL. That URL is what the client fetches next, so it has
+    /// to carry the real session token rather than the `Secret`'s redaction.
+    #[test]
+    fn audio_only_transcode_url_carries_the_real_token() {
+        let session = db::auth::AuthSession {
+            device: db::auth::Device {
+                access_token: "real-token"
+                    .to_string()
+                    .into(),
+                ..Default::default()
+            },
+            user: db::User::default(),
+        };
+        let source = api::MediaSourceInfo {
+            id: Uuid::new_v4(),
+            media_streams: vec![api::MediaStream {
+                codec: Some("flac".to_string()),
+                type_: Some(api::MediaStreamType::Audio),
+                index: 0,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let cfg = PlaybackConfig {
+            encoding_cfg: EncodingOptions::default(),
+            device_profile: None,
+            max_bitrate: None,
+            play_session_id: "play-session".to_string(),
+            item_id: Uuid::new_v4(),
+            subtitle_mode: EmbeddedSubtitleHandling::default(),
+        };
+        // Direct play off is what forces the decision down a transcode branch.
+        let q = api::PlaybackInfoQuery {
+            enable_direct_play: Some(false),
+            ..Default::default()
+        };
+
+        let decision = build_transcode_decision(
+            &source,
+            &api::TranscodeReasons::default(),
+            None,
+            &q,
+            &session,
+            &cfg,
+        );
+
+        let TranscodeDecision::Transcode(outcome) = decision else {
+            panic!("a source with no video stream should transcode");
+        };
+        assert!(
+            outcome
+                .url
+                .contains("ApiKey=real-token"),
+            "audio transcode URL should carry the session token: {}",
+            outcome.url
+        );
+    }
+}

--- a/crates/remux-server/src/playback/decision.rs
+++ b/crates/remux-server/src/playback/decision.rs
@@ -121,7 +121,8 @@ fn build_audio_transcode(
             start_time,
             session
                 .device
-                .access_token,
+                .access_token
+                .expose(),
         ),
         container,
         sub_protocol: "http".to_string(),
@@ -235,7 +236,8 @@ fn build_video_transcode(
             start_time,
             session
                 .device
-                .access_token,
+                .access_token
+                .expose(),
         )
     } else {
         format!(
@@ -254,7 +256,8 @@ fn build_video_transcode(
             start_time,
             session
                 .device
-                .access_token,
+                .access_token
+                .expose(),
         )
     };
 

--- a/crates/remux-server/src/tasks/refresh_iptv.rs
+++ b/crates/remux-server/src/tasks/refresh_iptv.rs
@@ -164,10 +164,11 @@ impl Task for RefreshIptvTask {
                 .row
                 .preset
                 .kind;
-            let config = &runtime
+            let config = runtime
                 .row
                 .preset
-                .config;
+                .config
+                .expose();
 
             let epg_url = if kind == "iptv-xtream" {
                 let server_url = config["server_url"]

--- a/crates/remux-utils/Cargo.toml
+++ b/crates/remux-utils/Cargo.toml
@@ -8,3 +8,12 @@ uuid = { version = "1", features = ["v4", "v5", "serde"] }
 moka = { version = "0.12.12", features = ["sync"] }
 nutype = { version = "0.6", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sqlx = { version = "0.8", default-features = false, optional = true }
+
+[features]
+# Lets a Secret be a database column. Enabled by remux-server; a standalone
+# build of remux-sdks or remux-dashboard leaves it off. Note a workspace build
+# unifies features, so those crates do link sqlx there. Redaction never depends
+# on this: Debug and Display sit outside the gate.
+sqlx = ["dep:sqlx"]

--- a/crates/remux-utils/src/lib.rs
+++ b/crates/remux-utils/src/lib.rs
@@ -140,3 +140,5 @@ pub fn normalize_container(raw: &str) -> String {
         other => other.to_string(),
     }
 }
+pub mod secret;
+pub use secret::Secret;

--- a/crates/remux-utils/src/secret.rs
+++ b/crates/remux-utils/src/secret.rs
@@ -1,0 +1,166 @@
+//! Values that must never reach logs. Redaction lives on the value, so
+//! anything holding one can still `#[derive(Debug)]`.
+//!
+//! This is about logs only. The sqlx impls pass the value straight through, so
+//! it is stored unencrypted exactly as before. Encryption at rest is a separate
+//! problem: it needs a key, a migration, and an answer for what happens when
+//! the key is lost.
+
+use serde::{Deserialize, Serialize};
+use std::{fmt, ops::Deref};
+
+/// Prints as `<redacted>` however it is formatted.
+#[derive(Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Secret<T>(T);
+
+impl<T> Secret<T> {
+    pub fn new(value: T) -> Self {
+        Self(value)
+    }
+
+    /// Named so every read of a secret is greppable.
+    pub fn expose(&self) -> &T {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl Secret<serde_json::Value> {
+    /// A trimmed, non-empty string field from a secret JSON blob.
+    pub fn get_str(&self, key: &str) -> Option<&str> {
+        self.0
+            .get(key)
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+    }
+}
+
+impl<T> fmt::Debug for Secret<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("<redacted>")
+    }
+}
+
+/// Also redacted: `{}` reaches logs as readily as `{:?}`.
+impl<T> fmt::Display for Secret<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("<redacted>")
+    }
+}
+
+impl<T> Deref for Secret<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> From<T> for Secret<T> {
+    fn from(value: T) -> Self {
+        Self(value)
+    }
+}
+
+// sqlx passthrough: a wrapped column behaves like the bare type.
+#[cfg(feature = "sqlx")]
+mod sqlx_impls {
+    use super::Secret;
+
+    impl<T, DB> sqlx::Type<DB> for Secret<T>
+    where
+        DB: sqlx::Database,
+        T: sqlx::Type<DB>,
+    {
+        fn type_info() -> DB::TypeInfo {
+            T::type_info()
+        }
+        fn compatible(ty: &DB::TypeInfo) -> bool {
+            T::compatible(ty)
+        }
+    }
+
+    impl<'r, DB, T> sqlx::Decode<'r, DB> for Secret<T>
+    where
+        DB: sqlx::Database,
+        T: sqlx::Decode<'r, DB>,
+    {
+        fn decode(
+            value: <DB as sqlx::Database>::ValueRef<'r>,
+        ) -> Result<Self, sqlx::error::BoxDynError> {
+            T::decode(value).map(Secret)
+        }
+    }
+
+    impl<'q, DB, T> sqlx::Encode<'q, DB> for Secret<T>
+    where
+        DB: sqlx::Database,
+        T: sqlx::Encode<'q, DB>,
+    {
+        fn encode_by_ref(
+            &self,
+            buf: &mut <DB as sqlx::Database>::ArgumentBuffer<'q>,
+        ) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
+            self.0
+                .encode_by_ref(buf)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Redaction must not depend on the `sqlx` feature, so this holds in every
+    /// build configuration.
+    #[test]
+    fn both_debug_and_display_are_redacted() {
+        let s = Secret::new("hunter2".to_string());
+        assert_eq!(format!("{s:?}"), "<redacted>");
+        assert_eq!(format!("{s}"), "<redacted>");
+        assert_eq!(s.expose(), "hunter2");
+    }
+
+    /// The point of the wrapper: holders can still derive Debug.
+    #[test]
+    fn a_deriving_struct_inherits_the_redaction() {
+        #[derive(Debug)]
+        struct Holder {
+            name: String,
+            token: Secret<String>,
+        }
+        let shown = format!(
+            "{:?}",
+            Holder {
+                name: "alice".into(),
+                token: Secret::new("super-secret".into()),
+            }
+        );
+        assert!(!shown.contains("super-secret"), "leaked: {shown}");
+        assert!(shown.contains("alice"), "non-secrets should still print");
+    }
+
+    #[test]
+    fn get_str_reads_a_field_without_exposing_the_blob() {
+        let creds = Secret::new(serde_json::json!({
+            "token": "  abc  ",
+            "blank": "",
+        }));
+        assert_eq!(creds.get_str("token"), Some("abc"));
+        assert_eq!(creds.get_str("blank"), None);
+        assert_eq!(creds.get_str("missing"), None);
+        assert!(!format!("{creds:?}").contains("abc"));
+    }
+
+    #[test]
+    fn serde_is_transparent_so_storage_is_unchanged() {
+        let s: Secret<String> = Secret::new("v".into());
+        assert_eq!(serde_json::to_string(&s).unwrap(), "\"v\"");
+        let back: Secret<String> = serde_json::from_str("\"v\"").unwrap();
+        assert_eq!(back.expose(), "v");
+    }
+}

--- a/crates/remux-utils/src/secret.rs
+++ b/crates/remux-utils/src/secret.rs
@@ -1,15 +1,20 @@
 //! Values that must never reach logs. Redaction lives on the value, so
 //! anything holding one can still `#[derive(Debug)]`.
 //!
+//! Deliberately no `Display` and no `Deref`: with either one, `{}` and `&secret`
+//! keep compiling everywhere they used to, and the value silently turns into
+//! `<redacted>` or slips out unmarked. Without them the compiler points at every
+//! site, and each one has to say `expose()` or `into_inner()` out loud.
+//!
 //! This is about logs only. The sqlx impls pass the value straight through, so
 //! it is stored unencrypted exactly as before. Encryption at rest is a separate
 //! problem: it needs a key, a migration, and an answer for what happens when
 //! the key is lost.
 
 use serde::{Deserialize, Serialize};
-use std::{fmt, ops::Deref};
+use std::fmt;
 
-/// Prints as `<redacted>` however it is formatted.
+/// Debug-prints as `<redacted>`; there is no other way to format it.
 #[derive(Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Secret<T>(T);
@@ -43,20 +48,6 @@ impl Secret<serde_json::Value> {
 impl<T> fmt::Debug for Secret<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("<redacted>")
-    }
-}
-
-/// Also redacted: `{}` reaches logs as readily as `{:?}`.
-impl<T> fmt::Display for Secret<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("<redacted>")
-    }
-}
-
-impl<T> Deref for Secret<T> {
-    type Target = T;
-    fn deref(&self) -> &T {
-        &self.0
     }
 }
 
@@ -118,10 +109,9 @@ mod tests {
     /// Redaction must not depend on the `sqlx` feature, so this holds in every
     /// build configuration.
     #[test]
-    fn both_debug_and_display_are_redacted() {
+    fn debug_is_redacted_but_the_value_is_still_readable() {
         let s = Secret::new("hunter2".to_string());
         assert_eq!(format!("{s:?}"), "<redacted>");
-        assert_eq!(format!("{s}"), "<redacted>");
         assert_eq!(s.expose(), "hunter2");
     }
 


### PR DESCRIPTION
Taken from finding [lostb1t/remux#222 (comment)](https://github.com/lostb1t/remux/pull/222#discussion_r3791473499)

Fixing it properly.

Part of #207.
