### PR TITLE
[Enhancement] Remove `SxxExx` prefix from episode metadata to prevent redundant UI display in Jellyfin clients

### DIFF
--- a/crates/remux-server/src/addons/mod.rs
+++ b/crates/remux-server/src/addons/mod.rs
@@ -462,7 +462,7 @@ pub(crate) fn apply_title_format(media: &mut db::Media) {
     if media.kind == db::MediaKind::Episode {
         if let Some(ep) = media.idx {
             let prefix = match media.parent_idx {
-                Some(s) => format!("S{}E{} - ", s, ep),
+                Some(_) => String::new(),
                 None => format!("E{} - ", ep),
             };
             if !media

--- a/crates/remux-server/src/addons/stremio.rs
+++ b/crates/remux-server/src/addons/stremio.rs
@@ -476,7 +476,7 @@ impl TreeAddon for StremioAddon {
                 for ep in &mut episodes {
                     if let Some(ep_num) = ep.idx {
                         if let Some(s_num) = ep.parent_idx {
-                            ep.title = format!("S{}E{} - {}", s_num, ep_num, ep.title);
+                            
                         } else {
                             ep.title = format!("E{} - {}", ep_num, ep.title);
                         }

--- a/crates/remux-server/src/addons/tmdb.rs
+++ b/crates/remux-server/src/addons/tmdb.rs
@@ -690,7 +690,7 @@ impl From<&sdks::tmdb::Episode> for db::Media {
         };
         let mut media = db::Media {
             kind: db::MediaKind::Episode,
-            title: format!("S{}E{} - {}", ep.season_number, ep.episode_number, ep.name),
+            title: ep.name.clone(),
             description: ep
                 .overview
                 .clone()

--- a/crates/remux-server/src/db/media.rs
+++ b/crates/remux-server/src/db/media.rs
@@ -1821,11 +1821,11 @@ impl Media {
                     .unwrap_or_default();
                 match (show.is_empty(), self.parent_idx, self.idx) {
                     (false, Some(s), Some(e)) => {
-                        format!("{} S{:02}E{:02} - {}", show, s, e, self.title)
+                        format!("{} - {}", show, self.title)
                     }
                     (false, _, _) => format!("{} - {}", show, self.title),
                     (true, Some(s), Some(e)) => {
-                        format!("S{:02}E{:02} - {}", s, e, self.title)
+                        self.title.clone()
                     }
                     _ => self
                         .title


### PR DESCRIPTION
### Description

Currently, `remux` hardcode prefixes the season and episode number directly into the episode title metadata. This conflicts with how Jellyfin clients render TV show episode titles.

Because `remux` forces the `SxxExx - ` prefix into the title string itself, it results in redundant UI displays across standard clients. For example:
* **Infuse:** `S1 • E1 -  S1E1 - Pilot`
* **Remux Jellyfin Web:** `S1:E1 - S1E1 - Pilot`

Jellyfin's API separates metadata into distinct fields (`Name`, `IndexNumber` (episode), and `ParentIndexNumber` (season). The server is expected to provide a clean title (e.g., "Pilot"), so the client UI can cleanly show it.

Source: https://typescript-sdk.jellyfin.org/interfaces/generated-client.BaseItemDto.html