### PR TITLE
fix(jellyfin): align server routes and playback requests

### DIFF
--- a/crates/remux-server/src/api/playback.rs
+++ b/crates/remux-server/src/api/playback.rs
@@ -54,9 +54,21 @@ pub async fn items_playbackinfo(
     State(state): State<AppState>,
     session: auth::AuthSession,
     Path(id): Path<Uuid>,
+    Query(query): Query<api::PlaybackInfoQuery>,
     Json(payload): Json<api::PlaybackInfoQuery>,
 ) -> Result<impl IntoResponse> {
-    items_playbackinfo_inner(state, session, id, payload).await
+    // Jellyfin web sends MediaSourceId as query param even for POST; merge query and body
+    let mut q = payload;
+    q.media_source_id = q
+        .media_source_id
+        .or(query.media_source_id);
+    q.user_id = q
+        .user_id
+        .or(query.user_id);
+    q.device_profile = q
+        .device_profile
+        .or(query.device_profile);
+    items_playbackinfo_inner(state, session, id, q).await
 }
 
 #[get("/items/{id}/playbackinfo")]

--- a/crates/remux-server/src/api/system.rs
+++ b/crates/remux-server/src/api/system.rs
@@ -4,7 +4,7 @@ use axum::{
     http::header,
     response::{IntoResponse, Response},
 };
-use http::StatusCode;
+use http::{HeaderMap, StatusCode};
 use remux_macros::{get, post, query, route};
 use serde::Deserialize;
 use serde_json::json;
@@ -24,9 +24,53 @@ use remux_sdks::remux::IntroOptions;
 
 use super::mock_items;
 
+fn request_local_address(headers: &HeaderMap, fallback_port: u16) -> String {
+    let scheme = headers
+        .get("x-forwarded-proto")
+        .and_then(|value| {
+            value
+                .to_str()
+                .ok()
+        })
+        .and_then(|value| {
+            value
+                .split(',')
+                .next()
+        })
+        .map(str::trim)
+        .filter(|value| matches!(*value, "http" | "https"))
+        .unwrap_or("http");
+
+    let authority = [headers.get("x-forwarded-host"), headers.get(header::HOST)]
+        .into_iter()
+        .flatten()
+        .filter_map(|value| {
+            value
+                .to_str()
+                .ok()
+        })
+        .filter_map(|value| {
+            value
+                .split(',')
+                .next()
+        })
+        .map(str::trim)
+        .find_map(|value| {
+            value
+                .parse::<http::uri::Authority>()
+                .ok()
+        });
+
+    authority.map_or_else(
+        || format!("http://127.0.0.1:{fallback_port}"),
+        |authority| format!("{scheme}://{authority}"),
+    )
+}
+
 #[get("/system/info/public")]
 pub async fn system_info_public(
     State(state): State<AppState>,
+    headers: HeaderMap,
 ) -> Result<impl IntoResponse> {
     let config = crate::db::Settings::get_config(
         &state
@@ -35,8 +79,16 @@ pub async fn system_info_public(
     )
     .await?;
     Ok(Json(api::PublicSystemInfo {
-        // todo
-        local_address: String::new(),
+        // Jellyfin clients persist LocalAddress as part of the server identity.
+        // Report the request authority so saved authentication state remains
+        // associated with the endpoint the client actually reached.
+        local_address: request_local_address(
+            &headers,
+            state
+                .ctx
+                .config
+                .port,
+        ),
         server_name: config
             .server_name
             .unwrap_or_default(),
@@ -869,12 +921,13 @@ mod test {
 
         let resp = server
             .get("/system/info/public")
+            .add_header(header::HOST, HeaderValue::from_static("192.168.1.2:3000"))
             .await;
 
         resp.assert_status_ok();
         resp.assert_json_contains(&json!({
             "Id": expect_json::uuid(),
-            "LocalAddress": "",
+            "LocalAddress": "http://192.168.1.2:3000",
             "ServerName": "Remux",
             "ProductName": "Jellyfin Server",
             "Version": crate::default_jellyfin_version(),

--- a/crates/remux-server/src/web_client.rs
+++ b/crates/remux-server/src/web_client.rs
@@ -14,7 +14,7 @@ use tower_http::services::ServeDir;
 use crate::embedded_static::EmbeddedDir;
 use crate::web_transform::TransformLayer;
 
-const JELLYFIN_ALIAS_PREFIX: &str = "/jellyfin";
+const JELLYFIN_ALIAS_PREFIXES: [&str; 2] = ["/jellyfin", "/web"];
 
 const UNREGISTER_SW_SCRIPT: &str = r#"self.addEventListener('install', () => self.skipWaiting());
 self.addEventListener('activate', (event) => {
@@ -52,6 +52,12 @@ fn strip_prefixed_path(path: &str, prefix: &str) -> Option<String> {
     }
 
     None
+}
+
+fn strip_client_alias(path: &str) -> Option<String> {
+    JELLYFIN_ALIAS_PREFIXES
+        .iter()
+        .find_map(|prefix| strip_prefixed_path(path, prefix))
 }
 
 fn normalize_spa_inner_path(path: &str) -> String {
@@ -168,7 +174,7 @@ impl Service<Request<Body>> for WebClientService {
             .map(str::to_owned);
 
         let is_service_worker_path = path.eq_ignore_ascii_case("/serviceworker.js");
-        let jellyfin_inner = strip_prefixed_path(&path, JELLYFIN_ALIAS_PREFIX);
+        let jellyfin_inner = strip_client_alias(&path);
         let mut jellyfin = self
             .jellyfin
             .clone();
@@ -186,5 +192,28 @@ impl Service<Request<Body>> for WebClientService {
                 .call(req)
                 .await
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_jellyfin_and_web_aliases() {
+        assert_eq!(
+            strip_client_alias("/jellyfin/index.html"),
+            Some("/index.html".to_string())
+        );
+        assert_eq!(
+            strip_client_alias("/web/index.html"),
+            Some("/index.html".to_string())
+        );
+        assert_eq!(
+            strip_client_alias("/WEB/assets/app.js"),
+            Some("/assets/app.js".to_string())
+        );
+        assert_eq!(strip_client_alias("/web"), Some("/".to_string()));
+        assert_eq!(strip_client_alias("/websocket"), None);
     }
 }


### PR DESCRIPTION
## Summary

- report `LocalAddress` from the request authority, including reverse-proxy headers
- serve the Jellyfin web client through both `/jellyfin` and the standard `/web` alias
- merge POST `PlaybackInfo` query parameters with the JSON body

These match request patterns used by Jellyfin web and WebOS clients and keep saved server identity/authentication associated with the endpoint the client actually reached.

## Testing

- `cargo fmt --all --check`
- `cargo check -p remux-server --lib`
- added coverage for the `/web` alias and request-derived `LocalAddress`