### PR TITLE
refactor(music): keep episode titles clean; centralize S/E formatting

### DIFF
--- a/crates/remux-server/src/addons/mod.rs
+++ b/crates/remux-server/src/addons/mod.rs
@@ -460,19 +460,53 @@ pub(crate) fn apply_title_format(media: &mut db::Media) {
         );
     }
     if media.kind == db::MediaKind::Episode {
-        if let Some(ep) = media.idx {
-            let prefix = match media.parent_idx {
-                Some(s) => format!("S{}E{} - ", s, ep),
-                None => format!("E{} - ", ep),
-            };
-            if !media
-                .title
-                .starts_with(&prefix)
-            {
-                media.title = format!("{}{}", prefix, media.title);
-            }
+        // Stored episode titles are kept clean: Jellyfin clients render the
+        // season/episode from IndexNumber/ParentIndexNumber, so embedding a
+        // "SxxExx - " prefix here double-prints it. Any prefix that slipped in
+        // from a raw source is stripped so this stays the single invariant for
+        // episode titles.
+        if let Some(stripped) = strip_episode_title_prefix(&media.title) {
+            media.title = stripped;
         }
     }
+}
+
+/// Remove a leading `S<season>E<episode> - ` / `E<episode> - ` prefix (optionally
+/// space-separated, e.g. `S01 E07`) from an episode title. Returns `None` when
+/// there's nothing to strip.
+fn strip_episode_title_prefix(title: &str) -> Option<String> {
+    let t = title.trim_start();
+    let mut after = t;
+
+    if after.starts_with('S') {
+        after = take_digits(&after[1..]);
+        after = after.trim_start();
+        if !after.starts_with('E') {
+            return None;
+        }
+    } else if !after.starts_with('E') {
+        return None;
+    }
+    after = take_digits(&after[1..]);
+    after = after.trim_start();
+
+    match after.strip_prefix('-') {
+        Some(rest) => {
+            let rest = rest.trim_start();
+            (!rest.is_empty()).then(|| rest.to_string())
+        }
+        None => None,
+    }
+}
+
+/// The leading run of ASCII digits.
+fn take_digits(s: &str) -> &str {
+    let n = s
+        .as_bytes()
+        .iter()
+        .take_while(|b| b.is_ascii_digit())
+        .count();
+    &s[n..]
 }
 
 fn series_is_active(status: &Option<db::MediaStatus>) -> bool {
@@ -3371,7 +3405,7 @@ mod tests {
     // --- apply_title_format idempotency ---
 
     #[test]
-    fn apply_title_format_does_not_double_prefix_episode() {
+    fn apply_title_format_strips_episode_prefix() {
         let mut media = db::Media {
             kind: db::MediaKind::Episode,
             title: "S3E4 - Tumbleton".into(),
@@ -3380,11 +3414,11 @@ mod tests {
             ..Default::default()
         };
         apply_title_format(&mut media);
-        assert_eq!(media.title, "S3E4 - Tumbleton");
+        assert_eq!(media.title, "Tumbleton");
     }
 
     #[test]
-    fn apply_title_format_adds_prefix_to_raw_episode_title() {
+    fn apply_title_format_keeps_clean_episode_title() {
         let mut media = db::Media {
             kind: db::MediaKind::Episode,
             title: "Tumbleton".into(),
@@ -3393,7 +3427,7 @@ mod tests {
             ..Default::default()
         };
         apply_title_format(&mut media);
-        assert_eq!(media.title, "S3E4 - Tumbleton");
+        assert_eq!(media.title, "Tumbleton");
     }
 
     #[test]

--- a/crates/remux-server/src/addons/stremio.rs
+++ b/crates/remux-server/src/addons/stremio.rs
@@ -474,13 +474,6 @@ impl TreeAddon for StremioAddon {
                 )?;
                 let now = chrono::Utc::now().naive_utc();
                 for ep in &mut episodes {
-                    if let Some(ep_num) = ep.idx {
-                        if let Some(s_num) = ep.parent_idx {
-                            ep.title = format!("S{}E{} - {}", s_num, ep_num, ep.title);
-                        } else {
-                            ep.title = format!("E{} - {}", ep_num, ep.title);
-                        }
-                    }
                     // Mark refreshed so TMDB isn't called per-episode during tree sync.
                     ep.refreshed_at = Some(now);
                 }

--- a/crates/remux-server/src/addons/tmdb.rs
+++ b/crates/remux-server/src/addons/tmdb.rs
@@ -690,7 +690,9 @@ impl From<&sdks::tmdb::Episode> for db::Media {
         };
         let mut media = db::Media {
             kind: db::MediaKind::Episode,
-            title: format!("S{}E{} - {}", ep.season_number, ep.episode_number, ep.name),
+            title: ep
+                .name
+                .clone(),
             description: ep
                 .overview
                 .clone()


### PR DESCRIPTION
Episodes now store the bare title (e.g. "Pilot"); the `SxxExx - ` prefix was embedded by every importer (`apply_title_format`, the Stremio tree builder, the TMDB `From` impl) and had to be removed in 4 places — see #256, which only half-removed it (dead branch in stremio, leftover `E{num}` prefix elsewhere).

Jellyfin clients render the season/episode from `IndexNumber`/`ParentIndexNumber`, so a prefixed title double-prints (Infuse: `S1 • E1 - S1E1 - Pilot`).

Centralized:
- `apply_title_format` is now the single invariant: it strips any leading `SxxExx`/`Exx` prefix, so stored episode titles are always clean.
- The Stremio tree builder no longer mutates the title (removes the dead branch #256 left behind).
- The TMDB `From<Episode>` impl stores the clean name.
- `full_title()` (`db/media.rs`) remains the single place that composes the `Show S01E01 - Name` display string.

Note: main's lib test suite currently fails to compile (unrelated pre-existing breakage in `tasks/delivery_queue_sync.rs` tests after `TrackingCredentials` became a type alias). I validated this branch against a locally-patched version of that test file: **433 tests pass**. This PR does not include that unrelated fix.