### PR TITLE
feat(torrent): pass addon-provided trackers through to the magnet

### DIFF
--- a/crates/remux-server/src/addons/stremio.rs
+++ b/crates/remux-server/src/addons/stremio.rs
@@ -1316,6 +1316,29 @@ async fn stremio_subtitles(
 /// Rewrite a URL whose host is `aiostreams` to use the stremio addon's origin.
 /// AIO running in Docker uses this internal hostname; we remap it at descriptor
 /// construction time so callers never see the unresolvable internal address.
+/// Extract tracker URLs from a Stremio stream's `sources` array.
+///
+/// Tracker entries are conventionally `"tracker:udp://…/announce"`, but some
+/// addons (notably private-tracker addons) emit the bare URL without the
+/// `tracker:` prefix. Accept both and run each through [`TrackerUrl`]
+/// validation so unrelated `sources` entries are dropped; de-duplicate.
+fn extract_trackers(sources: &[String]) -> Vec<crate::stream::TrackerUrl> {
+    let mut seen = std::collections::HashSet::new();
+    let mut trackers = Vec::new();
+    for src in sources {
+        let url = src
+            .strip_prefix("tracker:")
+            .unwrap_or(src.as_str())
+            .trim();
+        if let Ok(url) = crate::stream::TrackerUrl::try_new(url.to_string()) {
+            if seen.insert(url.clone()) {
+                trackers.push(url);
+            }
+        }
+    }
+    trackers
+}
+
 fn rewrite_aio_url(url: &str, manifest_url: &StremioManifestUrl) -> String {
     let Ok(mut parsed) = url::Url::parse(url) else {
         return url.to_string();
@@ -1392,6 +1415,16 @@ async fn stremio_streams(
         .filter(|s| s.is_valid())
         .filter_map(|s| {
             let descriptor = if s.is_torrent() {
+                let trackers = extract_trackers(
+                    s.sources
+                        .as_deref()
+                        .unwrap_or_default(),
+                );
+                debug!(
+                    info_hash = ?s.info_hash(),
+                    ?trackers,
+                    "torrent stream trackers"
+                );
                 crate::stream::StreamDescriptor::Torrent {
                     info_hash: s
                         .info_hash()?
@@ -1402,14 +1435,7 @@ async fn stremio_streams(
                     file_idx: s
                         .file_idx
                         .map(|i| i as usize),
-                    trackers: s
-                        .sources
-                        .as_deref()
-                        .unwrap_or_default()
-                        .iter()
-                        .filter_map(|src| src.strip_prefix("tracker:"))
-                        .map(String::from)
-                        .collect(),
+                    trackers,
                 }
             } else {
                 let url = s
@@ -1780,5 +1806,45 @@ mod tests {
 
         assert_eq!(streams.len(), 1);
         reconstructed.assert();
+    }
+
+    #[test]
+    fn extract_trackers_accepts_prefixed_bare_and_dedupes() {
+        use crate::stream::TrackerUrl;
+        let sources = vec![
+            "tracker:udp://tracker.opentrackr.org:1337/announce".to_string(),
+            "https://private-tracker.example/announce".to_string(),
+            "tracker:https://private-tracker.example/announce".to_string(),
+            "not-a-tracker".to_string(),
+            "udp://open.demonii.com:1337/announce".to_string(),
+        ];
+        let trackers = extract_trackers(&sources);
+        let inner = |t: &TrackerUrl| {
+            t.as_ref()
+                .to_string()
+        };
+        assert_eq!(
+            trackers
+                .iter()
+                .map(inner)
+                .collect::<Vec<_>>(),
+            vec![
+                "udp://tracker.opentrackr.org:1337/announce",
+                "https://private-tracker.example/announce",
+                "udp://open.demonii.com:1337/announce",
+            ]
+        );
+    }
+
+    #[test]
+    fn extract_trackers_ignores_non_urls() {
+        use crate::stream::TrackerUrl;
+        let empty: Vec<TrackerUrl> = Vec::new();
+        assert_eq!(extract_trackers(&["foo".to_string()]), empty);
+        assert_eq!(
+            extract_trackers(&["https://tracker.example".to_string()]),
+            Vec::<TrackerUrl>::new()
+        );
+        assert_eq!(extract_trackers(&[]), Vec::<TrackerUrl>::new());
     }
 }

--- a/crates/remux-server/src/addons/torznab.rs
+++ b/crates/remux-server/src/addons/torznab.rs
@@ -867,7 +867,7 @@ fn magnet_to_descriptor(
     let trackers = parsed
         .query_pairs()
         .filter(|(k, _)| k == "tr")
-        .map(|(_, v)| v.into_owned())
+        .filter_map(|(_, v)| crate::stream::TrackerUrl::try_new(v.into_owned()).ok())
         .collect();
     Some(crate::stream::StreamDescriptor::Torrent {
         info_hash,

--- a/crates/remux-server/src/db/media.rs
+++ b/crates/remux-server/src/db/media.rs
@@ -5816,7 +5816,9 @@ impl From<sdks::stremio::Stream> for Media {
                     .unwrap_or_default()
                     .iter()
                     .filter_map(|src| src.strip_prefix("tracker:"))
-                    .map(String::from)
+                    .filter_map(|url| {
+                        crate::stream::TrackerUrl::try_new(url.to_string()).ok()
+                    })
                     .collect(),
             }
         } else if let Some(url) = source

--- a/crates/remux-server/src/stream.rs
+++ b/crates/remux-server/src/stream.rs
@@ -3,12 +3,34 @@ use async_trait::async_trait;
 use axum::{body::Body, http::HeaderMap, response::Response};
 use axum_anyhow::ApiResult as Result;
 use futures_util::TryStreamExt;
+use nutype::nutype;
 use std::{io, path::PathBuf};
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use tokio_util::io::ReaderStream;
 use uuid::Uuid;
 
 use crate::AppState;
+
+/// A BitTorrent tracker announce URL: an absolute `udp://`/`http(s)://` URI with
+/// a path. Rejects bare hosts and non-URL `sources` entries, so random addon
+/// metadata is never mistaken for a tracker.
+#[nutype(
+    validate(predicate = is_tracker_url),
+    derive(Clone, Debug, PartialEq, Eq, Hash, AsRef, Serialize, Deserialize)
+)]
+pub struct TrackerUrl(String);
+
+/// Whether `s` looks like a tracker announce URL (absolute http/https/udp + path).
+pub fn is_tracker_url(s: &str) -> bool {
+    let lower = s
+        .trim()
+        .to_ascii_lowercase();
+    let rest = lower
+        .strip_prefix("udp://")
+        .or_else(|| lower.strip_prefix("http://"))
+        .or_else(|| lower.strip_prefix("https://"));
+    matches!(rest, Some(rest) if rest.contains('/'))
+}
 
 /// Typed representation of how a stream is accessed (transport mechanism).
 ///
@@ -37,7 +59,7 @@ pub enum StreamDescriptor {
         file_idx: Option<usize>,
         /// Tracker announce URLs (populated from the stream's `sources`).
         #[serde(default)]
-        trackers: Vec<String>,
+        trackers: Vec<TrackerUrl>,
     },
     Opendal {
         addon_id: Uuid,
@@ -269,19 +291,20 @@ pub struct TorrentSource {
     pub info_hash: String,
     pub file_hint: Option<String>,
     pub file_idx: Option<usize>,
-    pub trackers: Vec<String>,
+    pub trackers: Vec<TrackerUrl>,
 }
 
 impl TorrentSource {
     fn to_magnet(&self) -> String {
         let mut m = format!("magnet:?xt=urn:btih:{}", self.info_hash);
-        let trackers: &[String] = &self.trackers;
+        let trackers = &self.trackers;
         if trackers.is_empty() {
             for t in DEFAULT_TRACKERS {
                 m.push_str(&format!("&tr={}", urlencoding::encode(t)));
             }
         } else {
             for t in trackers {
+                let t: &str = t.as_ref();
                 m.push_str(&format!("&tr={}", urlencoding::encode(t)));
             }
         }
@@ -495,7 +518,27 @@ fn extract_query_param(url: &str, param: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::STREAM_PROXY_CLIENT;
+    use super::{STREAM_PROXY_CLIENT, TrackerUrl, is_tracker_url};
+
+    #[test]
+    fn tracker_url_validates_absolute_urls() {
+        assert!(is_tracker_url("udp://tracker.opentrackr.org:1337/announce"));
+        assert!(is_tracker_url("https://private.example/announce"));
+        assert!(is_tracker_url("http://tracker.example:8080/announce"));
+
+        // bare host, relative path, and non-URLs are rejected
+        assert!(!is_tracker_url("https://tracker.example"));
+        assert!(!is_tracker_url("/announce"));
+        assert!(!is_tracker_url("tracker:udp://x/announce"));
+        assert!(!is_tracker_url("not-a-tracker"));
+        assert!(
+            TrackerUrl::try_new(
+                "udp://tracker.opentrackr.org:1337/announce".to_string()
+            )
+            .is_ok()
+        );
+        assert!(TrackerUrl::try_new("not-a-tracker".to_string()).is_err());
+    }
 
     #[test]
     fn stream_proxy_client_builds_without_panic() {


### PR DESCRIPTION
Private-tracker torrents failed to resolve: the magnet only contained remux's fallback public trackers, so with DHT/PEX disabled (private flag) there was no way to find peers. The addon's stream `sources` entries were either missing the `tracker:` prefix or otherwise not picked up.

Changes:
- **`extract_trackers` (stremio addon)**: accept `tracker:`-prefixed **and bare** tracker URLs from `sources`, validate + dedupe, and `debug!`-log the extracted trackers per torrent stream (makes the next report instantly diagnosable).
- **`TrackerUrl` nutype** (stream.rs): validated tracker URL (absolute `udp://`/`http(s)://` + path), used in the Torrent descriptor, `TorrentSource` and `to_magnet` so invalid entries can never reach the magnet.
- torznab + debrid descriptor builds route trackers through `TrackerUrl`.
- Tests for validation and extraction.

Verified: 441 lib tests pass. Note: the still-open question is whether the failing addon actually *sends* the tracker in `sources` — the new debug log will show exactly what remux receives.