### PR TITLE
fix(addons): import Stremio catalogs whose type is the wildcard `all`

### DIFF
--- a/crates/remux-server/src/addons/deezer.rs
+++ b/crates/remux-server/src/addons/deezer.rs
@@ -11,8 +11,8 @@ use uuid::Uuid;
 
 use super::{
     AddonCapabilities, AddonKind, AddonMetadata, AddonOption, AddonOptionType,
-    AddonPreset, AddonPresetRegistration, CatalogAddon, CatalogInfo, MediaKind,
-    MetaAddon, ResourceType, SearchAddon, TreeAddon,
+    AddonPreset, AddonPresetRegistration, CatalogAddon, CatalogInfo, CatalogKind,
+    MediaKind, MetaAddon, ResourceType, SearchAddon, TreeAddon,
 };
 use crate::{
     AppContext, common, db,
@@ -1047,7 +1047,7 @@ impl CatalogAddon for DeezerAddon {
                     _ => default_playlist_name(&id),
                 };
                 CatalogInfo {
-                    media_kind: Some(db::MediaKind::Playlist),
+                    media_kind: CatalogKind::Single(db::MediaKind::Playlist),
                     ..CatalogInfo::new(id, name)
                 }
             }

--- a/crates/remux-server/src/addons/iptv.rs
+++ b/crates/remux-server/src/addons/iptv.rs
@@ -8,8 +8,8 @@ use uuid::Uuid;
 
 use super::{
     AddonCapabilities, AddonKind, AddonMetadata, AddonOption, AddonOptionType,
-    AddonPreset, AddonPresetRegistration, CatalogAddon, CatalogInfo, MediaKind,
-    ProgressReporter, ResourceType, StreamAddon,
+    AddonPreset, AddonPresetRegistration, CatalogAddon, CatalogInfo, CatalogKind,
+    MediaKind, ProgressReporter, ResourceType, StreamAddon,
 };
 use crate::{AppContext, db, iptv};
 
@@ -335,7 +335,7 @@ impl CatalogAddon for IptvAddon {
             default_enabled: true,
             default_max_items: Some(999999999),
             collection_media_kind: None,
-            media_kind: Some(db::MediaKind::TvChannel),
+            media_kind: CatalogKind::Single(db::MediaKind::TvChannel),
         }])
     }
 

--- a/crates/remux-server/src/addons/mod.rs
+++ b/crates/remux-server/src/addons/mod.rs
@@ -51,6 +51,33 @@ pub use remux_sdks::{
     stremio::ResourceType,
 };
 
+#[derive(Debug, Clone, Default, PartialEq)]
+pub enum CatalogKind {
+    Single(db::MediaKind),
+    /// Heterogeneous catalog: each item's own type decides its kind at import.
+    ItemDefined,
+    #[default]
+    Unspecified,
+}
+
+/// Wildcard catalogs are heterogeneous, so exactly one refresh task may own
+/// them, or both would import the same movies and series.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WildcardCatalogs {
+    Include,
+    Exclude,
+}
+
+impl CatalogKind {
+    fn admitted(&self, kinds: &[db::MediaKind], wildcards: WildcardCatalogs) -> bool {
+        match self {
+            Self::Single(k) => kinds.contains(k),
+            Self::ItemDefined => wildcards == WildcardCatalogs::Include,
+            Self::Unspecified => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct CatalogInfo {
     pub provider_catalog_id: String,
@@ -61,8 +88,7 @@ pub struct CatalogInfo {
     pub default_max_items: Option<i64>,
     /// Media kind for auto-created collections backed by this catalog.
     pub collection_media_kind: Option<db::CollectionMediaKind>,
-    /// The MediaKind of items this specific catalog yields.
-    pub media_kind: Option<db::MediaKind>,
+    pub media_kind: CatalogKind,
 }
 
 impl CatalogInfo {
@@ -76,7 +102,7 @@ impl CatalogInfo {
             default_enabled: false,
             default_max_items: None,
             collection_media_kind: None,
-            media_kind: None,
+            media_kind: CatalogKind::default(),
         }
     }
 }
@@ -93,7 +119,7 @@ pub struct ResolvedCatalog {
     /// Deterministic collection id for this catalog's `media_relations` membership.
     pub collection_id: Uuid,
     pub name: String,
-    pub media_kind: Option<db::MediaKind>,
+    pub media_kind: CatalogKind,
     pub collection_media_kind: Option<db::CollectionMediaKind>,
     pub enabled: bool,
     pub max_items: Option<i64>,
@@ -1628,6 +1654,7 @@ impl AddonService {
         &self,
         ctx: &AppContext,
         kinds: &[db::MediaKind],
+        wildcards: WildcardCatalogs,
     ) -> Vec<(AddonRuntime, Vec<ResolvedCatalog>)> {
         let mut out = Vec::new();
         for runtime in self
@@ -1655,9 +1682,19 @@ impl AddonService {
             let resolved: Vec<_> = resolved
                 .into_iter()
                 .filter(|c| {
-                    c.media_kind
-                        .as_ref()
-                        .map_or(false, |k| kinds.contains(k))
+                    let admitted = c
+                        .media_kind
+                        .admitted(kinds, wildcards);
+                    // A kind mismatch is the normal case and stays quiet; an
+                    // unmappable type is a dead end the operator can't see.
+                    if !admitted && c.enabled && c.media_kind == CatalogKind::Unspecified {
+                        warn!(
+                            addon = %addon_id,
+                            catalog = %c.provider_catalog_id,
+                            "enabled catalog skipped: addon declares a media type remux cannot map"
+                        );
+                    }
+                    admitted
                 })
                 .collect();
             if resolved.is_empty() {
@@ -3508,6 +3545,121 @@ mod tests {
                 "episode".to_string()
             )),
             Some(sdks::remux::MediaKind::Episode)
+        );
+    }
+
+    const LIBRARY_KINDS: &[db::MediaKind] =
+        &[db::MediaKind::Movie, db::MediaKind::Series];
+
+    #[test]
+    fn single_kind_catalog_admitted_only_for_its_own_kind() {
+        let cat = CatalogKind::Single(db::MediaKind::Movie);
+        assert!(cat.admitted(LIBRARY_KINDS, WildcardCatalogs::Include));
+        assert!(cat.admitted(LIBRARY_KINDS, WildcardCatalogs::Exclude));
+        assert!(
+            !cat.admitted(&[db::MediaKind::TvChannel], WildcardCatalogs::Include),
+            "a movie catalog must never be imported by the IPTV refresh"
+        );
+    }
+
+    #[test]
+    fn wildcard_catalog_admitted_only_when_caller_claims_wildcards() {
+        assert!(
+            CatalogKind::ItemDefined.admitted(LIBRARY_KINDS, WildcardCatalogs::Include),
+            "RefreshLibrary claims wildcard catalogs"
+        );
+        assert!(
+            !CatalogKind::ItemDefined
+                .admitted(&[db::MediaKind::TvChannel], WildcardCatalogs::Exclude),
+            "RefreshIptv must not double-import a wildcard catalog's movies"
+        );
+    }
+
+    #[test]
+    fn unspecified_catalog_never_admitted() {
+        for wildcards in [WildcardCatalogs::Include, WildcardCatalogs::Exclude] {
+            assert!(
+                !CatalogKind::Unspecified.admitted(LIBRARY_KINDS, wildcards),
+                "a catalog with no usable declared type stays out ({wildcards:?})"
+            );
+        }
+    }
+
+    fn runtime_with_manifest_types(raw: &[&str]) -> AddonRuntime {
+        // Mirrors the live-manifest upgrade in `load_runtimes`.
+        let supported_types: Vec<sdks::remux::MediaKind> = raw
+            .iter()
+            .map(|t| {
+                serde_json::from_value::<sdks::stremio::MediaType>(
+                    serde_json::Value::String((*t).to_string()),
+                )
+                .unwrap_or_else(|_| sdks::stremio::MediaType::Unknown((*t).to_string()))
+            })
+            .filter_map(recognized_manifest_media_kind)
+            .collect();
+        let now = chrono::Utc::now().naive_utc();
+        AddonRuntime {
+            row: Addon {
+                id: Uuid::nil(),
+                name: "test".to_string(),
+                preset: AddonPresetRef {
+                    kind: "stremio".to_string(),
+                    ..Default::default()
+                },
+                resources: vec![ResourceType::Catalog],
+                // Empty = every type enabled.
+                types: vec![],
+                enabled: true,
+                priority: 0,
+                created_at: now,
+                updated_at: now,
+                system: false,
+                is_default: true,
+                http_redirect_stream: false,
+                service_filter: vec![],
+            },
+            caps: AddonCapabilities {
+                metadata: sdks::remux::AddonMetadata {
+                    supported_types,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        }
+    }
+
+    // Guards the upstream precondition: if the addon-level pre-filter rejected
+    // such an addon, no catalog of it would ever be looked at.
+    #[test]
+    fn addon_declaring_only_wildcard_type_is_not_pre_filtered_out() {
+        let runtime = runtime_with_manifest_types(&["all"]);
+        assert!(
+            runtime
+                .caps
+                .metadata
+                .supported_types
+                .is_empty(),
+            "`all` has no MediaKind equivalent, so the list filters down to nothing"
+        );
+        for kind in LIBRARY_KINDS {
+            assert!(
+                runtime.supports_type(kind),
+                "an empty supported_types list must stay permissive for {kind:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn addon_declaring_recognized_types_still_gates_on_them() {
+        let runtime = runtime_with_manifest_types(&["all", "series"]);
+        assert!(runtime.supports_type(&db::MediaKind::Series));
+        assert!(
+            runtime.supports_type(&db::MediaKind::Episode),
+            "Series in a type list covers Episode (Stremio model)"
+        );
+        assert!(
+            !runtime.supports_type(&db::MediaKind::Album),
+            "a recognized type in the manifest is still an upper bound"
         );
     }
 }

--- a/crates/remux-server/src/addons/opendal.rs
+++ b/crates/remux-server/src/addons/opendal.rs
@@ -14,8 +14,8 @@ use tracing::{debug, info, warn};
 use super::{
     AddonCapabilities, AddonKind, AddonMetadata, AddonOption, AddonOptionType,
     AddonPreset, AddonPresetRegistration, AddonSelectOption, CatalogAddon, CatalogInfo,
-    IndexAddon, MediaKind, ProgressReporter, ResourceType, StreamAddon, SubtitleAddon,
-    SubtitleInfo, TreeAddon,
+    CatalogKind, IndexAddon, MediaKind, ProgressReporter, ResourceType, StreamAddon,
+    SubtitleAddon, SubtitleInfo, TreeAddon,
 };
 use crate::{AppContext, addons::Addon, common, db, sdks, sdks::CachedEndpoint};
 
@@ -386,10 +386,11 @@ impl CatalogAddon for OpendalAddon {
                 .as_str()
             {
                 // episode files are grouped into Series catalog items
-                "episode" => Some(db::MediaKind::Series),
+                "episode" => CatalogKind::Single(db::MediaKind::Series),
                 other => other
                     .parse()
-                    .ok(),
+                    .map(CatalogKind::Single)
+                    .unwrap_or_default(),
             },
         }])
     }
@@ -2448,7 +2449,11 @@ mod tests {
         {
             let admitted = ctx
                 .addons
-                .catalogs_for_kinds(ctx, &[requested.clone()])
+                .catalogs_for_kinds(
+                    ctx,
+                    &[requested.clone()],
+                    crate::addons::WildcardCatalogs::Exclude,
+                )
                 .await
                 .into_iter()
                 .find(|(rt, _)| {

--- a/crates/remux-server/src/addons/stremio.rs
+++ b/crates/remux-server/src/addons/stremio.rs
@@ -16,9 +16,9 @@ use uuid::Uuid;
 
 use super::{
     AddonCapabilities, AddonKind, AddonMetadata, AddonOption, AddonOptionType,
-    AddonPreset, AddonPresetRegistration, CatalogAddon, CatalogInfo, MediaKind,
-    MetaAddon, ResourceType, SearchAddon, StreamAddon, SubtitleAddon, SubtitleInfo,
-    TreeAddon, addon,
+    AddonPreset, AddonPresetRegistration, CatalogAddon, CatalogInfo, CatalogKind,
+    MediaKind, MetaAddon, ResourceType, SearchAddon, StreamAddon, SubtitleAddon,
+    SubtitleInfo, TreeAddon, addon,
 };
 use crate::{
     AppContext, common, db, sdks,
@@ -229,6 +229,25 @@ impl AddonKind for StremioAddon {
     }
 }
 
+const WILDCARD_CATALOG_TYPE: &str = "all";
+
+/// Only `all` fans out: its items carry real types. Any other unmapped type
+/// (`collection`, `anime`, …) is also the type of its own items, which
+/// `TryFrom<stremio::Meta>` would then collapse to `Movie`.
+fn catalog_kind(raw: &str, parsed: remux_sdks::stremio::MediaType) -> CatalogKind {
+    match db::MediaKind::try_from(parsed) {
+        Ok(k) => CatalogKind::Single(k),
+        Err(_)
+            if raw
+                .trim()
+                .eq_ignore_ascii_case(WILDCARD_CATALOG_TYPE) =>
+        {
+            CatalogKind::ItemDefined
+        }
+        Err(_) => CatalogKind::Unspecified,
+    }
+}
+
 #[async_trait]
 impl CatalogAddon for StremioAddon {
     async fn catalog_list(&self, _ctx: &AppContext) -> Result<Vec<CatalogInfo>> {
@@ -283,7 +302,7 @@ impl CatalogAddon for StremioAddon {
                             .as_str()
                             .into()
                     }),
-                    media_kind: db::MediaKind::try_from(stremio_kind).ok(),
+                    media_kind: catalog_kind(&c.kind, stremio_kind),
                     ..CatalogInfo::new(
                         format!("{}:{}", c.kind, c.id),
                         format!(
@@ -1846,5 +1865,44 @@ mod tests {
             Vec::<TrackerUrl>::new()
         );
         assert_eq!(extract_trackers(&[]), Vec::<TrackerUrl>::new());
+    }
+
+    /// Classifies a raw manifest type string the way `catalog_list` does.
+    fn classify(raw: &str) -> CatalogKind {
+        let parsed: remux_sdks::stremio::MediaType =
+            serde_json::from_value(serde_json::Value::String(raw.to_string()))
+                .unwrap_or_else(|_| {
+                    remux_sdks::stremio::MediaType::Unknown(raw.to_string())
+                });
+        catalog_kind(raw, parsed)
+    }
+
+    #[test]
+    fn known_catalog_type_maps_to_a_single_kind() {
+        assert_eq!(classify("movie"), CatalogKind::Single(db::MediaKind::Movie));
+        assert_eq!(
+            classify("series"),
+            CatalogKind::Single(db::MediaKind::Series)
+        );
+        assert_eq!(
+            classify("tv"),
+            CatalogKind::Single(db::MediaKind::TvChannel)
+        );
+    }
+
+    #[test]
+    fn wildcard_catalog_type_fans_out_to_item_kinds() {
+        assert_eq!(classify("all"), CatalogKind::ItemDefined);
+        assert_eq!(
+            classify(" ALL "),
+            CatalogKind::ItemDefined,
+            "manifest strings are not normalized, so match loosely"
+        );
+    }
+
+    #[test]
+    fn other_unmappable_catalog_types_stay_unspecified() {
+        assert_eq!(classify("anime"), CatalogKind::Unspecified);
+        assert_eq!(classify("collection"), CatalogKind::Unspecified);
     }
 }

--- a/crates/remux-server/src/addons/tmdb.rs
+++ b/crates/remux-server/src/addons/tmdb.rs
@@ -8,8 +8,8 @@ use uuid::Uuid;
 
 use super::{
     AddonCapabilities, AddonKind, AddonMetadata, AddonPreset, AddonPresetRegistration,
-    CatalogAddon, CatalogInfo, MediaKind, MetaAddon, MetricSnapshot, MetricValue,
-    MetricsAddon, MetricsCtx, ResourceType, SearchAddon, TreeAddon,
+    CatalogAddon, CatalogInfo, CatalogKind, MediaKind, MetaAddon, MetricSnapshot,
+    MetricValue, MetricsAddon, MetricsCtx, ResourceType, SearchAddon, TreeAddon,
 };
 use crate::{
     AppContext, api, common, db, sdks,
@@ -271,7 +271,7 @@ impl CatalogAddon for TmdbAddon {
         Ok(TMDB_CATALOGS
             .iter()
             .map(|c| CatalogInfo {
-                media_kind: Some(
+                media_kind: CatalogKind::Single(
                     c.kind
                         .clone(),
                 ),

--- a/crates/remux-server/src/db/media.rs
+++ b/crates/remux-server/src/db/media.rs
@@ -235,11 +235,11 @@ impl TryFrom<sdks::stremio::MediaType> for MediaKind {
 /// Extracts the addon's raw Stremio type string when it's a non-standard type
 /// (e.g. "anime") that `MediaKind` cannot represent and would otherwise collapse
 /// to a generic `Movie`/`Series`. Structural keywords (`episode`/`season`/`person`)
-/// are not content types and are excluded.
+/// are not content types and are excluded, as is the wildcard `all`.
 fn custom_stremio_type(media_type: &sdks::stremio::MediaType) -> Option<String> {
     match media_type {
         sdks::stremio::MediaType::Unknown(s)
-            if !matches!(s.as_str(), "episode" | "season" | "person") =>
+            if !matches!(s.as_str(), "episode" | "season" | "person" | "all") =>
         {
             Some(s.clone())
         }
@@ -7095,6 +7095,11 @@ mod tests {
                 "episode".to_string()
             )),
             None
+        );
+        assert_eq!(
+            custom_stremio_type(&sdks::stremio::MediaType::Unknown("all".to_string())),
+            None,
+            "the wildcard type names no content type, so it cannot stand in for one"
         );
     }
 

--- a/crates/remux-server/src/tasks/catalog_import_shared.rs
+++ b/crates/remux-server/src/tasks/catalog_import_shared.rs
@@ -6,14 +6,18 @@ use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use super::ProgressReporter;
-use crate::{AppContext, addons::ResolvedCatalog, db};
+use crate::{
+    AppContext,
+    addons::{CatalogKind, ResolvedCatalog},
+    db,
+};
 
 /// Consume `stream`, fetching metadata + full tree for new items and upserting everything.
 ///
 /// Returns a map of `kind -> count` for top-level items imported.
 pub async fn import_catalog_items<S>(
     ctx: &AppContext,
-    _catalog: &ResolvedCatalog,
+    catalog: &ResolvedCatalog,
     media_id: &str,
     max: usize,
     stream: S,
@@ -32,6 +36,10 @@ where
     let mut total = 0usize;
     let mut catalog_position = 0i64;
     let membership = catalog_membership(media_id);
+    // Channels are RefreshIptv's, and its `prune_stale_iptv_channels` deletes any
+    // `tv_channel` older than its own run whatever the source — a channel taken
+    // from a wildcard catalog would flap in and out on every pair of refreshes.
+    let allow_tv_channels = catalog.media_kind != CatalogKind::ItemDefined;
 
     let collection_id: Uuid = match membership {
         Some((addon_str, local_id)) => Uuid::parse_str(addon_str)
@@ -66,11 +74,10 @@ where
                 db::MediaKind::Movie
                     | db::MediaKind::Series
                     | db::MediaKind::Artist
-                    | db::MediaKind::TvChannel
                     | db::MediaKind::Album
                     | db::MediaKind::Track
                     | db::MediaKind::Playlist
-            )
+            ) || (allow_tv_channels && m.kind == db::MediaKind::TvChannel)
         });
 
         // A playlist carries its tracks in `relations`, which take(max) above

--- a/crates/remux-server/src/tasks/refresh_iptv.rs
+++ b/crates/remux-server/src/tasks/refresh_iptv.rs
@@ -12,7 +12,7 @@ use super::{
         remove_stale_catalog_memberships,
     },
 };
-use crate::{AppContext, db};
+use crate::{AppContext, addons, db};
 
 pub struct RefreshIptvTask;
 
@@ -42,7 +42,11 @@ impl Task for RefreshIptvTask {
     ) -> Result<()> {
         let iptv_runtimes = ctx
             .addons
-            .catalogs_for_kinds(&ctx, &[db::MediaKind::TvChannel])
+            .catalogs_for_kinds(
+                &ctx,
+                &[db::MediaKind::TvChannel],
+                addons::WildcardCatalogs::Exclude,
+            )
             .await;
 
         let global_max = db::Settings::get_config_or_default(&ctx.db)

--- a/crates/remux-server/src/tasks/refresh_library.rs
+++ b/crates/remux-server/src/tasks/refresh_library.rs
@@ -11,7 +11,7 @@ use super::{
         remove_stale_catalog_memberships,
     },
 };
-use crate::{AppContext, db};
+use crate::{AppContext, addons, db};
 use remux_sdks::stremio::ResourceType;
 
 pub struct RefreshLibraryTask;
@@ -62,7 +62,7 @@ impl Task for RefreshLibraryTask {
         ];
         let addons = ctx
             .addons
-            .catalogs_for_kinds(&ctx, LIBRARY_KINDS)
+            .catalogs_for_kinds(&ctx, LIBRARY_KINDS, addons::WildcardCatalogs::Include)
             .await;
         let total_work = addons
             .len()


### PR DESCRIPTION
Fixes https://github.com/lostb1t/remux/issues/267

Catalogs whose Stremio `type` is `all` were dropped by `Refresh Library` without a log line. They stay enabled in the dashboard and just never import, so any collection built on one renders as a permanently empty row with nothing pointing back to the cause.

This is the `#267` case: AIOMetadata publishes every Trakt list as `type: "all"`.

## Why it happened

`MediaKind::try_from(MediaType::Unknown("all"))` returns `Err`, `.ok()` collapsed that into `media_kind: None`, and the filter in `catalogs_for_kinds` used `map_or(false, ...)` so the catalog was removed before any request was made, silently.

The item path was never the problem: every meta in an `all` catalog response carries its own `type`, and `TryFrom<stremio::Meta> for Media` already uses it. So the fix lives entirely at the catalog-admission layer.

## What changed

- `Option<MediaKind>` on `CatalogInfo`/`ResolvedCatalog` becomes a `CatalogKind` enum, so a provider can say *wildcard* (`ItemDefined`) as opposed to *nothing declared* (`Unspecified`). No new `MediaKind` variant that enum is the DB text encoding.
- `catalogs_for_kinds` takes an explicit `WildcardCatalogs::{Include,Exclude}`. `RefreshLibrary` claims wildcard catalogs; `RefreshIptv` asks for `TvChannel` alone and must not double-import the movies and series such a catalog also yields.
- A wildcard catalog's own channels are skipped at import. `prune_stale_iptv_channels` deletes any `tv_channel` older than its run regardless of source, so such a row would otherwise flap in and out of the library on every pair of refreshes. This puts the previously unused `_catalog` param of `import_catalog_items` to work.
- Other unmappable types (`collection`, `anime`, …) deliberately stay out: their items carry that same unmapped type and `TryFrom<stremio::Meta>` falls back to `Movie`, so fanning them out would import junk rows as films. They now log a warning when the catalog is enabled which is what was missing all along. That's option 2 from the issue, for the cases option 1 can't safely cover.

## Compatibility

`media_kind` is never persisted (`CatalogState` only stores enabled/max_items/tags) and `provider_catalog_id` keeps its `all:{id}` format, so catalogs users already enabled stay enabled. No migration.