### PR TITLE
fix(items): restore episode backdrop fallback

### DIFF
--- a/crates/remux-server/src/api/models.rs
+++ b/crates/remux-server/src/api/models.rs
@@ -965,14 +965,17 @@ pub fn db_media_to_item(media: db::Media, hide_sources: bool) -> BaseItemDto {
             db::ImageKind::Backdrop,
         )
         .map(|b| vec![b]);
-        
+
         // Backdrop: prefer episode backdrop when it exists;
         // fall back to series backdrop for strict clients (Infuse) so the field is never empty.
-        if match &item.backdrop_image_tags {
-            Some(tags) => tags.is_empty(),
-            None => true,
-        } {
-            item.backdrop_image_tags = item.parent_backdrop_image_tags.clone();
+        if item
+            .backdrop_image_tags
+            .is_empty()
+        {
+            item.backdrop_image_tags = item
+                .parent_backdrop_image_tags
+                .clone()
+                .unwrap_or_default();
         }
 
         // Thumb: prefer season (direct parent) when it has a thumb image;


### PR DESCRIPTION
## Summary

- treat `BackdropImageTags` as the non-optional vector defined by the API model
- fall back to optional parent backdrop tags without changing the intended Infuse behavior
- restore formatting and compilation after #262

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p remux-server --lib -- --test-threads=1` (440 passed)