### PR TITLE
refactor(tracking): build the delivery target at delivery

### DIFF
--- a/crates/remux-server/src/addons/tracking.rs
+++ b/crates/remux-server/src/addons/tracking.rs
@@ -188,34 +188,39 @@ pub struct TrackingTarget {
     pub kind: db::MediaKind,
     pub title: String,
     pub year: Option<i32>,
-    pub ids: TrackingIds,
+    pub ids: db::ExternalIds,
     /// Set for episodes: the parent series' title, year and ids.
     pub series: Option<Box<TrackingTarget>>,
     pub season: Option<i64>,
     pub episode: Option<i64>,
 }
 
-/// The ids tracking services key on — narrower than `db::ExternalIds`, which
-/// also carries Deezer/Kitsu/IPTV/Stremio ids none of them understand.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct TrackingIds {
-    pub imdb: Option<String>,
-    pub tmdb: Option<i64>,
-    pub tvdb: Option<i64>,
+/// Whether any id here is one a tracking service could key on. `ExternalIds`
+/// also carries Deezer, IPTV and Stremio ids, which identify nothing to them.
+fn has_tracking_ids(ids: &db::ExternalIds) -> bool {
+    ids.imdb
+        .is_some()
+        || ids
+            .tmdb
+            .is_some()
+        || ids
+            .tvdb
+            .is_some()
+        || ids
+            .kitsu
+            .is_some()
 }
 
-impl TrackingIds {
-    /// Nothing to match on. Core drops the action rather than queueing
-    /// something no provider can act on.
-    pub fn is_empty(&self) -> bool {
-        self.imdb
-            .is_none()
-            && self
-                .tmdb
-                .is_none()
-            && self
-                .tvdb
-                .is_none()
+impl TrackingTarget {
+    /// Whether a provider could find this item at all. An episode counts when
+    /// its series does, since every service can key on the show plus season
+    /// and episode numbers.
+    pub fn is_matchable(&self) -> bool {
+        has_tracking_ids(&self.ids)
+            || self
+                .series
+                .as_ref()
+                .is_some_and(|s| has_tracking_ids(&s.ids))
     }
 }
 
@@ -429,7 +434,7 @@ pub trait TrackingAddon: AddonKind + Send + Sync {
         &self,
         _creds: &TrackingCredentials,
         _ctx: &TrackingCtx,
-    ) -> TrackingResult<Vec<TrackingIds>> {
+    ) -> TrackingResult<Vec<db::ExternalIds>> {
         Err(TrackingError::unsupported("watchlist sync"))
     }
 
@@ -448,7 +453,7 @@ pub trait TrackingAddon: AddonKind + Send + Sync {
 /// `pull_changes`.
 #[derive(Debug, Clone)]
 pub struct RemoteWatch {
-    pub ids: TrackingIds,
+    pub ids: db::ExternalIds,
     pub season: Option<i64>,
     pub episode: Option<i64>,
     pub watched: bool,
@@ -600,29 +605,75 @@ mod tests {
         );
     }
 
+    fn target(kind: db::MediaKind, ids: db::ExternalIds) -> TrackingTarget {
+        TrackingTarget {
+            kind,
+            title: "Heat".into(),
+            year: None,
+            ids,
+            series: None,
+            season: None,
+            episode: None,
+        }
+    }
+
     #[test]
-    fn ids_are_empty_only_when_nothing_is_matchable() {
-        assert!(TrackingIds::default().is_empty());
+    fn an_item_is_matchable_on_any_id_a_service_reads() {
         assert!(
-            !TrackingIds {
-                imdb: Some("tt123".into()),
-                ..Default::default()
-            }
-            .is_empty()
+            !target(db::MediaKind::Movie, db::ExternalIds::default()).is_matchable()
         );
-        assert!(
-            !TrackingIds {
+        for ids in [
+            db::ExternalIds {
+                imdb: db::NonEmptyString::try_new("tt123".to_string()).ok(),
+                ..Default::default()
+            },
+            db::ExternalIds {
                 tmdb: Some(603),
                 ..Default::default()
-            }
-            .is_empty()
-        );
-        assert!(
-            !TrackingIds {
+            },
+            db::ExternalIds {
                 tvdb: Some(1),
                 ..Default::default()
-            }
-            .is_empty()
+            },
+            db::ExternalIds {
+                kitsu: Some(1),
+                ..Default::default()
+            },
+        ] {
+            assert!(target(db::MediaKind::Movie, ids).is_matchable());
+        }
+    }
+
+    /// Yamtrack wants the episode's own ids and Trakt wants the show's, so an
+    /// episode carrying neither of its own is still worth delivering.
+    #[test]
+    fn an_episode_is_matchable_through_its_series() {
+        let mut episode = target(db::MediaKind::Episode, db::ExternalIds::default());
+        assert!(!episode.is_matchable());
+
+        episode.series = Some(Box::new(target(
+            db::MediaKind::Series,
+            db::ExternalIds {
+                tvdb: Some(79126),
+                ..Default::default()
+            },
+        )));
+        assert!(episode.is_matchable());
+    }
+
+    /// A music id identifies nothing to a tracking service, so it must not
+    /// stand in for one.
+    #[test]
+    fn a_non_tracking_id_does_not_make_an_item_matchable() {
+        assert!(
+            !target(
+                db::MediaKind::Movie,
+                db::ExternalIds {
+                    deezer_album: Some(1),
+                    ..Default::default()
+                }
+            )
+            .is_matchable()
         );
     }
 
@@ -656,7 +707,7 @@ mod tests {
     #[test]
     fn remote_user_data_can_carry_a_favourite_on_its_own() {
         let watch = RemoteWatch {
-            ids: TrackingIds {
+            ids: db::ExternalIds {
                 tmdb: Some(603),
                 ..Default::default()
             },
@@ -677,7 +728,7 @@ mod tests {
     #[test]
     fn remote_user_data_can_carry_a_rating_on_its_own() {
         let watch = RemoteWatch {
-            ids: TrackingIds {
+            ids: db::ExternalIds {
                 tmdb: Some(603),
                 ..Default::default()
             },

--- a/crates/remux-server/src/api/models.rs
+++ b/crates/remux-server/src/api/models.rs
@@ -965,14 +965,17 @@ pub fn db_media_to_item(media: db::Media, hide_sources: bool) -> BaseItemDto {
             db::ImageKind::Backdrop,
         )
         .map(|b| vec![b]);
-        
+
         // Backdrop: prefer episode backdrop when it exists;
         // fall back to series backdrop for strict clients (Infuse) so the field is never empty.
-        if match &item.backdrop_image_tags {
-            Some(tags) => tags.is_empty(),
-            None => true,
-        } {
-            item.backdrop_image_tags = item.parent_backdrop_image_tags.clone();
+        if item
+            .backdrop_image_tags
+            .is_empty()
+        {
+            item.backdrop_image_tags = item
+                .parent_backdrop_image_tags
+                .clone()
+                .unwrap_or_default();
         }
 
         // Thumb: prefer season (direct parent) when it has a thumb image;

--- a/crates/remux-server/src/db/delivery_queue.rs
+++ b/crates/remux-server/src/db/delivery_queue.rs
@@ -5,7 +5,7 @@ use sqlx::{FromRow, Row, SqlitePool, sqlite::SqliteRow};
 use std::time::Duration;
 use uuid::Uuid;
 
-use crate::addons::tracking::{TrackingError, TrackingEvent, TrackingTarget};
+use crate::addons::tracking::{TrackingError, TrackingEvent};
 
 /// Attempts before a row is parked as `failed_retryable` and stops being
 /// retried. Roughly a day of backoff, so a provider outage is ridden out but a
@@ -62,12 +62,17 @@ pub enum DeliveryKind {
     Tracker,
 }
 
-/// What one tracking delivery carries: the event, plus the item it was about
-/// resolved at enqueue time so delivery never has to look anything up.
+/// What one tracking delivery carries: the event, and the item it was about by
+/// reference.
+///
+/// The item is a reference rather than a snapshot so that the target is built
+/// in one place, at delivery, where its external ids can still be completed.
+/// Rebuilding it costs a row read; a provider that cannot identify the item is
+/// worth more than saving one.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TrackerPayload {
+    pub media_id: Uuid,
     pub event: TrackingEvent,
-    pub target: TrackingTarget,
 }
 
 /// A queued delivery and everything its deliverer needs to make it.
@@ -385,8 +390,7 @@ mod tests {
     // --- state machine, against a real database ---
 
     use crate::{
-        addons::tracking::{TrackingEventKind, TrackingIds},
-        integration_test::new_test_server,
+        addons::tracking::TrackingEventKind, integration_test::new_test_server,
     };
     use sqlx::SqlitePool;
 
@@ -428,21 +432,10 @@ mod tests {
 
     pub(crate) fn tracker_payload() -> TrackerPayload {
         TrackerPayload {
+            media_id: crate::common::get_uuid(),
             event: TrackingEvent::PlaybackStop {
                 position_ticks: 42,
                 played: true,
-            },
-            target: TrackingTarget {
-                kind: crate::db::MediaKind::Movie,
-                title: "Arrival".into(),
-                year: Some(2016),
-                ids: TrackingIds {
-                    tmdb: Some(329865),
-                    ..Default::default()
-                },
-                series: None,
-                season: None,
-                episode: None,
             },
         }
     }
@@ -475,13 +468,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(
-            got.kind,
-            QueueKind::Tracker {
-                user_media_tracker_id: conn,
-                payload: tracker_payload(),
-            }
-        );
+        assert_eq!(got.kind, row.kind);
         assert_eq!(
             got.kind
                 .kind(),

--- a/crates/remux-server/src/db/media.rs
+++ b/crates/remux-server/src/db/media.rs
@@ -870,7 +870,7 @@ impl ExternalRatings {
 pub use remux_utils::NonEmptyString;
 
 #[skip_serializing_none]
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExternalIds {
     pub imdb: Option<NonEmptyString>,
     pub tmdb: Option<i64>,

--- a/crates/remux-server/src/db/user_media_tracker.rs
+++ b/crates/remux-server/src/db/user_media_tracker.rs
@@ -253,13 +253,13 @@ impl UserMediaTracker {
         err: &TrackingError,
     ) -> Result<()> {
         let kind = MediaTrackerErrorKind::from(err);
-        let status = match kind {
-            MediaTrackerErrorKind::Retryable => None,
-            MediaTrackerErrorKind::Permanent if err.requires_reauth() => {
-                Some(MediaTrackerStatus::AuthExpired)
-            }
-            MediaTrackerErrorKind::Permanent => Some(MediaTrackerStatus::Error),
-        };
+        // `status` is about the connection, `last_error` is about the last
+        // delivery. Only a rejected credential is the connection's fault, and
+        // a status change stops every later event, so one item a provider
+        // could not match must not cost the user the whole connection.
+        let status = err
+            .requires_reauth()
+            .then_some(MediaTrackerStatus::AuthExpired);
         let now = Utc::now().naive_utc();
         sqlx::query(
             "UPDATE user_media_trackers \
@@ -580,13 +580,19 @@ mod tests {
                 .status,
             MediaTrackerStatus::AuthExpired
         );
+        let other = UserMediaTracker::get(db, other.id)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(
-            UserMediaTracker::get(db, other.id)
-                .await
-                .unwrap()
-                .unwrap()
-                .status,
-            MediaTrackerStatus::Error
+            other.status,
+            MediaTrackerStatus::Connected,
+            "one undeliverable item is not a broken connection"
+        );
+        assert_eq!(
+            other.last_error,
+            Some("400".to_string()),
+            "it is still the last thing that went wrong"
         );
     }
 

--- a/crates/remux-server/src/services/media_tracker.rs
+++ b/crates/remux-server/src/services/media_tracker.rs
@@ -1,4 +1,4 @@
-//! Turning a stored media row into what a tracking provider needs to see.
+//! Turning a stored media row into what a media tracker needs to see.
 //!
 //! A queued delivery names the item rather than describing it, so this runs
 //! once per delivery instead of once per request. That is what keeps the walk

--- a/crates/remux-server/src/services/mod.rs
+++ b/crates/remux-server/src/services/mod.rs
@@ -1,8 +1,8 @@
 pub mod image;
+pub mod media_tracker;
 pub(crate) mod resolve;
 pub(crate) mod stream_service;
 pub mod stremio;
-pub mod tracking;
 
 pub use resolve::MediaResolveService;
 pub(crate) use resolve::ResolvedItem;

--- a/crates/remux-server/src/services/mod.rs
+++ b/crates/remux-server/src/services/mod.rs
@@ -2,6 +2,7 @@ pub mod image;
 pub(crate) mod resolve;
 pub(crate) mod stream_service;
 pub mod stremio;
+pub mod tracking;
 
 pub use resolve::MediaResolveService;
 pub(crate) use resolve::ResolvedItem;

--- a/crates/remux-server/src/services/tracking.rs
+++ b/crates/remux-server/src/services/tracking.rs
@@ -1,0 +1,57 @@
+//! Turning a stored media row into what a tracking provider needs to see.
+//!
+//! A queued delivery names the item rather than describing it, so this runs
+//! once per delivery instead of once per request. That is what keeps the walk
+//! to the series, and any future completion of the item's external ids, off
+//! the playback path.
+
+use anyhow::Result;
+use chrono::Datelike;
+use sqlx::SqlitePool;
+
+use crate::{addons::tracking::TrackingTarget, db};
+
+fn describe(media: &db::Media, series: Option<&db::Media>) -> TrackingTarget {
+    TrackingTarget {
+        kind: media
+            .kind
+            .clone(),
+        title: media
+            .title
+            .clone(),
+        year: media
+            .released_at
+            .map(|d| d.year()),
+        ids: media
+            .external_ids
+            .clone(),
+        series: series.map(|s| Box::new(describe(s, None))),
+        season: media.parent_idx,
+        episode: media.idx,
+    }
+}
+
+/// The item as a provider needs to see it, or `None` when nothing about it
+/// carries an id one could match on.
+///
+/// Episodes carry their series as well as their own ids, because which of the
+/// two identifies an episode is the provider's choice: Yamtrack reads the
+/// episode's ids, Trakt reads the show's plus season and episode numbers.
+pub async fn resolve_target(
+    db: &SqlitePool,
+    media: &db::Media,
+) -> Result<Option<TrackingTarget>> {
+    let series = if media.kind == db::MediaKind::Episode {
+        db::Media::get_ancestors(db, &media.id)
+            .await?
+            .into_iter()
+            .find(|m| m.kind == db::MediaKind::Series)
+    } else {
+        None
+    };
+
+    let target = describe(media, series.as_ref());
+    Ok(target
+        .is_matchable()
+        .then_some(target))
+}

--- a/crates/remux-server/src/tasks/delivery_queue_sync.rs
+++ b/crates/remux-server/src/tasks/delivery_queue_sync.rs
@@ -662,7 +662,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn an_unmatchable_item_fails_the_row_rather_than_retrying_forever() {
+    async fn an_unmatchable_item_fails_the_row_and_leaves_the_connection_alone() {
         let (_s, guard) = new_test_server()
             .await
             .unwrap();
@@ -690,6 +690,15 @@ mod tests {
                 .status,
             DeliveryStatus::FailedPermanent,
             "no amount of retrying gives the item an id"
+        );
+        assert_eq!(
+            UserMediaTracker::get(&ctx.db, conn)
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            MediaTrackerStatus::Connected,
+            "one item nobody can match must not cost the user the connection"
         );
     }
 

--- a/crates/remux-server/src/tasks/delivery_queue_sync.rs
+++ b/crates/remux-server/src/tasks/delivery_queue_sync.rs
@@ -172,6 +172,20 @@ async fn deliver_tracker(
             TrackingError::permanent("tracking addon is not enabled")
         })?;
 
+    let media = db::Media::get_by_id(&ctx.db, &payload.media_id)
+        .await
+        .map_err(|e| TrackingError::retryable(format!("loading item: {e}")))?
+        .ok_or_else(|| TrackingError::permanent("item no longer exists"))?;
+
+    // Built here rather than at enqueue so every provider sees the item
+    // described the same way, from whatever ids the row carries by now.
+    let target = crate::services::tracking::resolve_target(&ctx.db, &media)
+        .await
+        .map_err(|e| TrackingError::retryable(format!("describing item: {e}")))?
+        .ok_or_else(|| {
+            TrackingError::permanent("no external id a tracking service could match")
+        })?;
+
     let tctx = TrackingCtx {
         config: Arc::new(
             ctx.config
@@ -179,7 +193,7 @@ async fn deliver_tracker(
         ),
     };
     addon
-        .on_event(&payload.event, &payload.target, &conn.credentials, &tctx)
+        .on_event(&payload.event, &target, &conn.credentials, &tctx)
         .await
 }
 
@@ -191,7 +205,7 @@ mod tests {
             AddonCapabilities, AddonKind, AddonPresetRef, AddonRuntime,
             tracking::{
                 TrackingAddon, TrackingCapabilities, TrackingCredentials,
-                TrackingEvent, TrackingEventKind, TrackingIds, TrackingTarget,
+                TrackingEvent, TrackingEventKind, TrackingTarget,
             },
         },
         db::{
@@ -214,6 +228,7 @@ mod tests {
     struct ScriptedAddon {
         script: Mutex<VecDeque<TrackingResult<()>>>,
         seen: Mutex<Vec<(TrackingEventKind, String)>>,
+        targets: Mutex<Vec<TrackingTarget>>,
     }
 
     impl ScriptedAddon {
@@ -222,11 +237,21 @@ mod tests {
             Arc::new(Self {
                 script: Mutex::new(script.into()),
                 seen: Mutex::new(Vec::new()),
+                targets: Mutex::new(Vec::new()),
             })
         }
 
         fn seen(&self) -> Vec<(TrackingEventKind, String)> {
             self.seen
+                .lock()
+                .unwrap()
+                .clone()
+        }
+
+        /// The items as they reached the provider, for asserting on what the
+        /// delivery path built rather than only on what it was told to send.
+        fn targets(&self) -> Vec<TrackingTarget> {
+            self.targets
                 .lock()
                 .unwrap()
                 .clone()
@@ -261,6 +286,10 @@ mod tests {
                         .title
                         .clone(),
                 ));
+            self.targets
+                .lock()
+                .unwrap()
+                .push(target.clone());
             self.script
                 .lock()
                 .unwrap()
@@ -337,31 +366,47 @@ mod tests {
         (conn.id, row)
     }
 
-    fn payload(title: &str) -> TrackerPayload {
-        TrackerPayload {
-            event: TrackingEvent::PlaybackStop {
-                position_ticks: 42,
-                played: true,
-            },
-            target: TrackingTarget {
+    /// The delivery names an item, so one has to exist for a target to be
+    /// built from. `imdb` is what makes it matchable, and its id is derived
+    /// from that.
+    async fn movie(db: &SqlitePool, title: &str, imdb: &str) -> Uuid {
+        let external_ids = crate::db::ExternalIds {
+            imdb: crate::db::NonEmptyString::try_new(imdb.to_string()).ok(),
+            ..Default::default()
+        };
+        let mut media = crate::db::Media {
+            id: Uuid::from(&crate::db::MediaIdRaw {
                 kind: crate::db::MediaKind::Movie,
-                title: title.into(),
-                year: Some(1999),
-                ids: TrackingIds {
-                    imdb: Some("tt0133093".into()),
-                    ..Default::default()
-                },
-                series: None,
+                external_ids: external_ids.clone(),
                 season: None,
                 episode: None,
-            },
-        }
+            }),
+            title: title.into(),
+            kind: crate::db::MediaKind::Movie,
+            external_ids,
+            ..Default::default()
+        };
+        media
+            .save(db)
+            .await
+            .unwrap();
+        media.id
     }
 
     async fn queue(db: &SqlitePool, conn: Uuid, title: &str) -> Uuid {
+        queue_item(db, conn, movie(db, title, "tt0133093").await).await
+    }
+
+    async fn queue_item(db: &SqlitePool, conn: Uuid, media_id: Uuid) -> Uuid {
         let row = DeliveryQueue::new(QueueKind::Tracker {
             user_media_tracker_id: conn,
-            payload: payload(title),
+            payload: TrackerPayload {
+                media_id,
+                event: TrackingEvent::PlaybackStop {
+                    position_ticks: 42,
+                    played: true,
+                },
+            },
         });
         row.insert(db)
             .await
@@ -534,6 +579,117 @@ mod tests {
             got.status,
             DeliveryStatus::FailedPermanent,
             "retrying cannot re-enable an addon, so this must not sit pending forever"
+        );
+    }
+
+    /// Yamtrack matches an episode on its own ids and Trakt on the show's plus
+    /// season and episode, so the delivery path owes both to every provider.
+    #[tokio::test]
+    async fn an_episode_reaches_the_provider_with_its_series_attached() {
+        let (_s, guard) = new_test_server()
+            .await
+            .unwrap();
+        let ctx = &guard.0;
+        let addon = ScriptedAddon::new(vec![]);
+        let (conn, _) = connect(ctx, "hana", addon.clone()).await;
+
+        let series_ids = crate::db::ExternalIds {
+            imdb: crate::db::NonEmptyString::try_new("tt0306414".to_string()).ok(),
+            tvdb: Some(79126),
+            ..Default::default()
+        };
+        let mut series = crate::db::Media {
+            id: Uuid::from(&crate::db::MediaIdRaw {
+                kind: crate::db::MediaKind::Series,
+                external_ids: series_ids.clone(),
+                season: None,
+                episode: None,
+            }),
+            title: "The Wire".into(),
+            kind: crate::db::MediaKind::Series,
+            external_ids: series_ids,
+            ..Default::default()
+        };
+        series
+            .save(&ctx.db)
+            .await
+            .unwrap();
+        let mut season = crate::db::Media {
+            title: "Season 1".into(),
+            kind: crate::db::MediaKind::Season,
+            parent_id: Some(series.id),
+            grandparent_id: Some(series.id),
+            idx: Some(1),
+            ..Default::default()
+        };
+        season
+            .save(&ctx.db)
+            .await
+            .unwrap();
+        let mut episode = crate::db::Media {
+            title: "The Target".into(),
+            kind: crate::db::MediaKind::Episode,
+            parent_id: Some(season.id),
+            grandparent_id: Some(series.id),
+            idx: Some(1),
+            parent_idx: Some(1),
+            ..Default::default()
+        };
+        episode
+            .save(&ctx.db)
+            .await
+            .unwrap();
+
+        queue_item(&ctx.db, conn, episode.id).await;
+        drain(ctx, &reporter())
+            .await
+            .unwrap();
+
+        let targets = addon.targets();
+        assert_eq!(targets.len(), 1);
+        let target = &targets[0];
+        assert_eq!(target.season, Some(1));
+        assert_eq!(target.episode, Some(1));
+        assert_eq!(
+            target
+                .series
+                .as_ref()
+                .expect("an episode alone identifies nothing")
+                .ids
+                .tvdb,
+            Some(79126)
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unmatchable_item_fails_the_row_rather_than_retrying_forever() {
+        let (_s, guard) = new_test_server()
+            .await
+            .unwrap();
+        let ctx = &guard.0;
+        let addon = ScriptedAddon::new(vec![]);
+        let (conn, _) = connect(ctx, "gina", addon.clone()).await;
+        let media = crate::integration_test::insert_test_source(ctx).await;
+        let queued = queue_item(&ctx.db, conn, media.id).await;
+
+        drain(ctx, &reporter())
+            .await
+            .unwrap();
+
+        assert!(
+            addon
+                .seen()
+                .is_empty(),
+            "there is no id to hand a provider"
+        );
+        assert_eq!(
+            DeliveryQueue::get(&ctx.db, queued)
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            DeliveryStatus::FailedPermanent,
+            "no amount of retrying gives the item an id"
         );
     }
 

--- a/crates/remux-server/src/tasks/delivery_queue_sync.rs
+++ b/crates/remux-server/src/tasks/delivery_queue_sync.rs
@@ -179,7 +179,7 @@ async fn deliver_tracker(
 
     // Built here rather than at enqueue so every provider sees the item
     // described the same way, from whatever ids the row carries by now.
-    let target = crate::services::tracking::resolve_target(&ctx.db, &media)
+    let target = crate::services::media_tracker::resolve_target(&ctx.db, &media)
         .await
         .map_err(|e| TrackingError::retryable(format!("describing item: {e}")))?
         .ok_or_else(|| {


### PR DESCRIPTION
Part of #207, follow-up to #242.

The target was built when an event was queued. It needs to be built when the event is delivered, because filling in an episode's missing ids means a network call, and that can't happen in a request handler.

Second commit fixes a bug where one undeliverable item marked the whole tracker broken.
