### PR TITLE
fix(jellyfin): preserve session message protocol shapes

### DIFF
--- a/crates/remux-server/src/api/session.rs
+++ b/crates/remux-server/src/api/session.rs
@@ -831,6 +831,22 @@ struct RemotePlaystateQuery {
     controlling_user_id: Option<String>,
 }
 
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, strum_macros::Display, strum_macros::EnumString,
+)]
+#[strum(serialize_all = "PascalCase", ascii_case_insensitive)]
+enum PlaystateCommand {
+    Stop,
+    Pause,
+    Unpause,
+    NextTrack,
+    PreviousTrack,
+    Seek,
+    Rewind,
+    FastForward,
+    PlayPause,
+}
+
 #[query]
 #[derive(Default)]
 struct RemoteViewingQuery {
@@ -938,8 +954,11 @@ pub async fn remote_playstate_command(
         return Err(anyhow::anyhow!("Forbidden")
             .context_forbidden("cannot control other users' sessions"));
     }
+    let command = command
+        .parse::<PlaystateCommand>()
+        .context_bad_request("invalid playstate command")?;
     let data = serde_json::json!({
-        "Command": command,
+        "Command": command.to_string(),
         "SeekPositionTicks": q.seek_position_ticks,
         "ControllingUserId": q.controlling_user_id,
     });
@@ -1207,4 +1226,35 @@ pub async fn delete_transcoding(
             .send(crate::ws::WsEvent::SessionsChanged);
     }
     Ok(StatusCode::NO_CONTENT.into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PlaystateCommand;
+
+    #[test]
+    fn playstate_commands_keep_jellyfin_enum_casing() {
+        for (request_path, protocol_value) in [
+            ("stop", "Stop"),
+            ("PAUSE", "Pause"),
+            ("unpause", "Unpause"),
+            ("nexttrack", "NextTrack"),
+            ("previoustrack", "PreviousTrack"),
+            ("seek", "Seek"),
+            ("rewind", "Rewind"),
+            ("fastforward", "FastForward"),
+            ("playpause", "PlayPause"),
+        ] {
+            let command = request_path
+                .parse::<PlaystateCommand>()
+                .unwrap();
+            assert_eq!(command.to_string(), protocol_value);
+        }
+
+        assert!(
+            "invalid"
+                .parse::<PlaystateCommand>()
+                .is_err()
+        );
+    }
 }

--- a/crates/remux-server/src/ws.rs
+++ b/crates/remux-server/src/ws.rs
@@ -42,6 +42,18 @@ struct OutboundMessage<T: Serialize> {
     data: Option<T>,
 }
 
+#[derive(Debug, Default, Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct LibraryUpdateInfo {
+    folders_added_to: Vec<String>,
+    folders_removed_from: Vec<String>,
+    items_added: Vec<String>,
+    items_removed: Vec<String>,
+    items_updated: Vec<String>,
+    collection_folders: Vec<String>,
+    is_empty: bool,
+}
+
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
 struct InboundMessage {
@@ -154,7 +166,14 @@ async fn handle_socket(mut socket: WebSocket, state: AppState, session: AuthSess
                         }
                     }
                     Ok(WsEvent::LibraryChanged) => {
-                        if !send_msg::<()>(&mut socket, SessionMessageType::LibraryChanged, None).await {
+                        if !send_msg(
+                            &mut socket,
+                            SessionMessageType::LibraryChanged,
+                            Some(LibraryUpdateInfo {
+                                is_empty: true,
+                                ..Default::default()
+                            }),
+                        ).await {
                             return;
                         }
                     }
@@ -243,4 +262,26 @@ async fn build_sessions(state: &AppState) -> Vec<api::SessionInfoDto> {
     build_session_list(state, Some(Duration::from_secs(120)), None)
         .await
         .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn library_update_info_uses_jellyfin_message_shape() {
+        let value = serde_json::to_value(LibraryUpdateInfo {
+            is_empty: true,
+            ..Default::default()
+        })
+        .unwrap();
+
+        assert_eq!(value["ItemsAdded"], serde_json::json!([]));
+        assert_eq!(value["ItemsRemoved"], serde_json::json!([]));
+        assert_eq!(value["ItemsUpdated"], serde_json::json!([]));
+        assert_eq!(value["FoldersAddedTo"], serde_json::json!([]));
+        assert_eq!(value["FoldersRemovedFrom"], serde_json::json!([]));
+        assert_eq!(value["CollectionFolders"], serde_json::json!([]));
+        assert_eq!(value["IsEmpty"], true);
+    }
 }


### PR DESCRIPTION
## Summary

- restore Jellyfin enum casing for remote playstate commands after route normalization
- include the expected `LibraryUpdateInfo` body in `LibraryChanged` websocket messages
- add focused serialization and command-mapping tests

## Testing

Validated on top of the compile repair in #271:

- `cargo fmt --all -- --check`
- `cargo test -p remux-server --lib jellyfin -- --test-threads=1` (5 passed)

This PR remains independent; current `main` CI is blocked by the regression repaired in #271.