### PR TITLE
fix(torrent): stream only the selected bundle file

### DIFF
--- a/crates/remux-server/src/stream.rs
+++ b/crates/remux-server/src/stream.rs
@@ -2,11 +2,11 @@ use crate::ResultExt;
 use async_trait::async_trait;
 use axum::{body::Body, http::HeaderMap, response::Response};
 use axum_anyhow::ApiResult as Result;
-use futures_util::TryStreamExt;
+use futures_util::{StreamExt, TryStreamExt};
 use nutype::nutype;
 use std::{io, path::PathBuf};
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
-use tokio_util::io::ReaderStream;
+use tokio_util::io::{ReaderStream, StreamReader};
 use uuid::Uuid;
 
 use crate::AppState;
@@ -318,13 +318,32 @@ impl TorrentSource {
     }
 }
 
-#[async_trait]
-impl StreamSource for HttpSource {
-    async fn serve(&self, _state: &AppState, headers: &HeaderMap) -> Result<Response> {
+impl HttpSource {
+    async fn serve_inner(
+        &self,
+        headers: &HeaderMap,
+        bound_finite_ranges: bool,
+    ) -> Result<Response> {
+        let requested_range = bound_finite_ranges
+            .then(|| {
+                headers
+                    .get(http::header::RANGE)
+                    .and_then(|value| {
+                        value
+                            .to_str()
+                            .ok()
+                    })
+                    .and_then(parse_open_or_finite_range)
+            })
+            .flatten();
         let mut req = STREAM_PROXY_CLIENT
             .clone()
             .get(&self.url);
-        if let Some(v) = headers.get(http::header::RANGE) {
+        if let Some((start, _)) = requested_range {
+            // librqbit accepts only `bytes=N-`. Normalize finite ranges and
+            // cap the proxied response body to the client's requested length.
+            req = req.header(http::header::RANGE, format!("bytes={start}-"));
+        } else if let Some(v) = headers.get(http::header::RANGE) {
             req = req.header(http::header::RANGE, v.clone());
         }
         for (k, v) in &self.request_headers {
@@ -336,18 +355,52 @@ impl StreamSource for HttpSource {
             .await
             .context_bad_request("upstream request failed")?;
 
-        let status = upstream.status();
+        let upstream_status = upstream.status();
         let upstream_headers = upstream
             .headers()
             .clone();
-        let body = Body::from_stream(
-            upstream
-                .bytes_stream()
-                .map_err(io::Error::other),
-        );
+        let total_length = upstream_headers
+            .get(http::header::CONTENT_RANGE)
+            .and_then(|value| {
+                value
+                    .to_str()
+                    .ok()
+            })
+            .and_then(|value| value.rsplit_once('/'))
+            .and_then(|(_, total)| {
+                total
+                    .parse::<u64>()
+                    .ok()
+            });
+        let bounded_range = requested_range
+            .filter(|(_, end)| {
+                end.is_some() && upstream_status == http::StatusCode::PARTIAL_CONTENT
+            })
+            .map(|(start, end)| {
+                let requested_end = end.expect("filtered to finite range");
+                let end = total_length
+                    .map(|total| requested_end.min(total.saturating_sub(1)))
+                    .unwrap_or(requested_end);
+                let length = end
+                    .saturating_sub(start)
+                    .saturating_add(1);
+                (start, end, length)
+            });
+        let stream = upstream
+            .bytes_stream()
+            .map_err(io::Error::other);
+        let body = if let Some((_, _, length)) = bounded_range {
+            Body::from_stream(ReaderStream::new(StreamReader::new(stream).take(length)))
+        } else {
+            Body::from_stream(stream)
+        };
 
         let mut resp = Response::builder()
-            .status(status)
+            .status(if bounded_range.is_some() {
+                http::StatusCode::PARTIAL_CONTENT
+            } else {
+                upstream_status
+            })
             .body(body)
             .unwrap();
         let out = resp.headers_mut();
@@ -360,6 +413,21 @@ impl StreamSource for HttpSource {
                 _ => {}
             }
         }
+        if let Some((start, end, length)) = bounded_range {
+            out.insert(
+                http::header::CONTENT_LENGTH,
+                http::HeaderValue::from_str(&length.to_string())
+                    .expect("range length is a valid header"),
+            );
+            let total = total_length
+                .map(|total| total.to_string())
+                .unwrap_or_else(|| "*".to_string());
+            out.insert(
+                http::header::CONTENT_RANGE,
+                http::HeaderValue::from_str(&format!("bytes {start}-{end}/{total}"))
+                    .expect("range is a valid header"),
+            );
+        }
         if !out.contains_key(http::header::CONTENT_TYPE) {
             out.insert(
                 http::header::CONTENT_TYPE,
@@ -368,6 +436,33 @@ impl StreamSource for HttpSource {
         }
 
         Ok(resp)
+    }
+}
+
+fn parse_open_or_finite_range(range: &str) -> Option<(u64, Option<u64>)> {
+    let bytes = range.strip_prefix("bytes=")?;
+    let (start, end) = bytes.split_once('-')?;
+    if start.is_empty() || end.contains(',') {
+        return None;
+    }
+    let start = start
+        .parse()
+        .ok()?;
+    let end = (!end.is_empty())
+        .then(|| {
+            end.parse()
+                .ok()
+        })
+        .flatten();
+    end.is_none_or(|end| end >= start)
+        .then_some((start, end))
+}
+
+#[async_trait]
+impl StreamSource for HttpSource {
+    async fn serve(&self, _state: &AppState, headers: &HeaderMap) -> Result<Response> {
+        self.serve_inner(headers, false)
+            .await
     }
 }
 
@@ -444,7 +539,7 @@ impl StreamSource for TorrentSource {
             request_headers: Default::default(),
             response_headers: Default::default(),
         }
-        .serve(state, headers)
+        .serve_inner(headers, true)
         .await
     }
 }
@@ -518,7 +613,7 @@ fn extract_query_param(url: &str, param: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{STREAM_PROXY_CLIENT, TrackerUrl, is_tracker_url};
+    use super::{HttpSource, STREAM_PROXY_CLIENT, TrackerUrl, is_tracker_url};
 
     #[test]
     fn tracker_url_validates_absolute_urls() {
@@ -543,6 +638,82 @@ mod tests {
     #[test]
     fn stream_proxy_client_builds_without_panic() {
         let _ = &*STREAM_PROXY_CLIENT;
+    }
+
+    #[tokio::test]
+    async fn torrent_proxy_bounds_finite_ranges() {
+        let server = httpmock::MockServer::start();
+        let payload = vec![b'x'; 2048];
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/file.mkv")
+                .header("Range", "bytes=0-");
+            then.status(206)
+                .header("Content-Range", "bytes 0-2047/2048")
+                .header("Accept-Ranges", "bytes")
+                .body(payload);
+        });
+
+        let source = HttpSource {
+            url: format!("{}/file.mkv", server.base_url()),
+            request_headers: Default::default(),
+            response_headers: Default::default(),
+        };
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            http::header::RANGE,
+            http::HeaderValue::from_static("bytes=0-1023"),
+        );
+
+        let response = source
+            .serve_inner(&headers, true)
+            .await
+            .unwrap();
+        assert_eq!(response.status(), http::StatusCode::PARTIAL_CONTENT);
+        assert_eq!(response.headers()[http::header::CONTENT_LENGTH], "1024");
+        assert_eq!(
+            response.headers()[http::header::CONTENT_RANGE],
+            "bytes 0-1023/2048"
+        );
+        let body = axum::body::to_bytes(response.into_body(), 2048)
+            .await
+            .unwrap();
+        assert_eq!(body.len(), 1024);
+    }
+
+    #[tokio::test]
+    async fn torrent_proxy_does_not_rewrite_full_responses_as_partial() {
+        let server = httpmock::MockServer::start();
+        let payload = vec![b'x'; 2048];
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/file.mkv")
+                .header("Range", "bytes=0-");
+            then.status(200)
+                .header("Accept-Ranges", "bytes")
+                .body(payload);
+        });
+
+        let source = HttpSource {
+            url: format!("{}/file.mkv", server.base_url()),
+            request_headers: Default::default(),
+            response_headers: Default::default(),
+        };
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            http::header::RANGE,
+            http::HeaderValue::from_static("bytes=0-1023"),
+        );
+
+        let response = source
+            .serve_inner(&headers, true)
+            .await
+            .unwrap();
+        assert_eq!(response.status(), http::StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 2048)
+            .await
+            .unwrap();
+        assert_eq!(body.len(), 2048);
     }
 
     #[tokio::test]

--- a/crates/remux-server/src/torrent.rs
+++ b/crates/remux-server/src/torrent.rs
@@ -3,12 +3,18 @@ use std::{path::PathBuf, sync::Arc, time::Duration};
 use anyhow::{Context, Result};
 use librqbit::{
     AddTorrent, AddTorrentOptions, AddTorrentResponse, Session, SessionOptions,
-    SessionPersistenceConfig,
+    SessionPersistenceConfig, TorrentStatsState,
     api::{Api, TorrentIdOrHash},
     dht::PersistentDhtConfig,
     http_api::HttpApi,
 };
 use tracing::{debug, warn};
+
+#[derive(Debug)]
+struct TorrentFile {
+    name: String,
+    length: u64,
+}
 
 pub struct TorrentManager {
     session: Arc<Session>,
@@ -82,19 +88,9 @@ impl TorrentManager {
             "resolving torrent"
         );
 
-        let opts = wanted_file
-            .as_deref()
-            .map(|name| AddTorrentOptions {
-                // Ask librqbit to download only the matching file so we don't pull the
-                // whole torrent.  The regex is anchored at the end so "Movie.mkv" doesn't
-                // match "Movie.mkv.nfo".
-                only_files_regex: Some(format!("(?i){}$", regex::escape(name))),
-                ..Default::default()
-            });
-
         let response = self
             .session
-            .add_torrent(AddTorrent::from_url(magnet), opts)
+            .add_torrent(AddTorrent::from_url(magnet), Some(stream_only_options()))
             .await
             .context("failed to add torrent")?;
 
@@ -111,31 +107,69 @@ impl TorrentManager {
             .context("timed out waiting for torrent metadata")?
             .context("torrent initialization failed")?;
 
-        // file_idx from the magnet params takes precedence; fall back to name search.
-        let file_idx = if let Some(idx) = file_idx_override {
-            idx
-        } else {
-            handle
-                .with_metadata(|meta| {
-                    if let Some(name) = wanted_file.as_deref() {
-                        meta.file_infos
-                            .iter()
-                            .enumerate()
-                            .find(|(_, fi)| {
-                                fi.relative_filename
-                                    .file_name()
-                                    .and_then(|n| n.to_str())
-                                    .map(|n| n.eq_ignore_ascii_case(name))
-                                    .unwrap_or(false)
-                            })
-                            .map(|(idx, _)| idx)
-                            .unwrap_or(0)
-                    } else {
-                        0
-                    }
+        let files = handle.with_metadata(|metadata| {
+            metadata
+                .file_infos
+                .iter()
+                .map(|file| TorrentFile {
+                    name: file
+                        .relative_filename
+                        .to_string_lossy()
+                        .into_owned(),
+                    length: file.len,
                 })
-                .unwrap_or(0)
-        };
+                .collect::<Vec<_>>()
+        })?;
+        let file_idx =
+            select_file_index(&files, file_idx_override, wanted_file.as_deref())?;
+
+        // Existing persisted torrents may have been created with every file
+        // selected. Clear that natural queue as well; active FileStreams keep
+        // requesting their own pieces independently.
+        let api = Api::new(
+            self.session
+                .clone(),
+            None,
+            None,
+        );
+        api.api_torrent_action_update_only_files(
+            TorrentIdOrHash::Id(torrent_id),
+            &std::collections::HashSet::new(),
+        )
+        .await
+        .context("failed to clear torrent file selection")?;
+        if !matches!(
+            handle
+                .stats()
+                .state,
+            TorrentStatsState::Live
+        ) {
+            if let Err(error) = api
+                .api_torrent_action_start(TorrentIdOrHash::Id(torrent_id))
+                .await
+            {
+                // Another request may have started the torrent between the
+                // state check and this action. Only suppress that race.
+                if matches!(
+                    handle
+                        .stats()
+                        .state,
+                    TorrentStatsState::Live
+                ) {
+                    debug!(torrent_id, "torrent was started concurrently");
+                } else {
+                    return Err(error).context("failed to start torrent");
+                }
+            }
+        }
+
+        debug!(
+            torrent_id,
+            file_idx,
+            file = %files[file_idx].name,
+            file_count = files.len(),
+            "selected torrent stream file"
+        );
 
         Ok(format!(
             "http://127.0.0.1:{}/torrents/{}/stream/{}",
@@ -217,6 +251,101 @@ impl TorrentManager {
     }
 }
 
+fn stream_only_options() -> AddTorrentOptions {
+    AddTorrentOptions {
+        // An empty selection leaves piece ownership to librqbit's HTTP
+        // FileStream. Metadata lookup therefore cannot start downloading or
+        // allocating every file in a bundle.
+        only_files: Some(Vec::new()),
+        ..Default::default()
+    }
+}
+
+fn is_video_file(name: &str) -> bool {
+    let extension = std::path::Path::new(name)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .unwrap_or_default();
+    matches!(
+        extension
+            .to_ascii_lowercase()
+            .as_str(),
+        "mkv" | "mp4" | "m4v" | "avi" | "mov" | "webm" | "ts" | "m2ts" | "mpg" | "mpeg"
+    )
+}
+
+fn select_file_index(
+    files: &[TorrentFile],
+    requested_idx: Option<usize>,
+    wanted_file: Option<&str>,
+) -> Result<usize> {
+    if files.is_empty() {
+        anyhow::bail!("torrent contains no files");
+    }
+
+    if let Some(wanted) = wanted_file {
+        if let Some((index, _)) = files
+            .iter()
+            .enumerate()
+            .find(|(_, file)| {
+                is_video_file(&file.name)
+                    && (file
+                        .name
+                        .eq_ignore_ascii_case(wanted)
+                        || std::path::Path::new(&file.name)
+                            .file_name()
+                            .and_then(|name| name.to_str())
+                            .is_some_and(|name| name.eq_ignore_ascii_case(wanted)))
+            })
+        {
+            return Ok(index);
+        }
+    }
+
+    if let Some(index) = requested_idx.filter(|index| {
+        files
+            .get(*index)
+            .is_some_and(|file| is_video_file(&file.name))
+    }) {
+        return Ok(index);
+    }
+
+    let mut videos: Vec<(usize, &TorrentFile)> = files
+        .iter()
+        .enumerate()
+        .filter(|(_, file)| is_video_file(&file.name))
+        .collect();
+    if videos.len() == 1 {
+        return Ok(videos[0].0);
+    }
+
+    videos.sort_by_key(|(_, file)| std::cmp::Reverse(file.length));
+    if let [largest, second, ..] = videos.as_slice() {
+        // Samples and extras are common, but similarly sized videos indicate
+        // a real bundle and require an exact provider hint.
+        if largest
+            .1
+            .length
+            >= second
+                .1
+                .length
+                .saturating_mul(2)
+        {
+            return Ok(largest.0);
+        }
+    }
+
+    match requested_idx {
+        Some(index) => anyhow::bail!(
+            "torrent file index {index} does not identify a video and no unique video could be selected"
+        ),
+        None => anyhow::bail!(
+            "torrent contains {} video files; a valid file index or filename is required",
+            videos.len()
+        ),
+    }
+}
+
 /// Extract the `file=` query parameter we encode into our magnet URIs.
 fn parse_file_param(magnet: &str) -> Option<String> {
     let query = magnet
@@ -238,4 +367,60 @@ fn parse_file_idx_param(magnet: &str) -> Option<usize> {
             v.parse()
                 .ok()
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn file(name: &str, length: u64) -> TorrentFile {
+        TorrentFile {
+            name: name.to_string(),
+            length,
+        }
+    }
+
+    #[test]
+    fn bundle_uses_exact_requested_file() {
+        let files = vec![
+            file("Bundle/Movie.One.mkv", 2_000),
+            file("Bundle/Movie.Two.mkv", 2_100),
+            file("Bundle/Movie.Three.mkv", 1_900),
+        ];
+
+        assert_eq!(
+            select_file_index(&files, Some(0), Some("Movie.Two.mkv")).unwrap(),
+            1
+        );
+        assert_eq!(select_file_index(&files, Some(2), None).unwrap(), 2);
+    }
+
+    #[test]
+    fn bundle_rejects_ambiguous_or_non_video_indexes() {
+        let files = vec![
+            file("Bundle/Movie.One.mkv", 2_000),
+            file("Bundle/release.nfo", 1),
+            file("Bundle/Movie.Two.mkv", 2_100),
+        ];
+
+        assert!(select_file_index(&files, Some(1), None).is_err());
+        assert!(select_file_index(&files, Some(99), None).is_err());
+        assert!(select_file_index(&files, None, None).is_err());
+    }
+
+    #[test]
+    fn single_feature_release_ignores_samples() {
+        let files = vec![
+            file("Release/sample.mkv", 100),
+            file("Release/Movie.mkv", 2_000),
+            file("Release/subtitles.srt", 2),
+        ];
+
+        assert_eq!(select_file_index(&files, None, None).unwrap(), 1);
+    }
+
+    #[test]
+    fn metadata_lookup_selects_no_files_for_download() {
+        assert_eq!(stream_only_options().only_files, Some(Vec::new()));
+    }
 }


### PR DESCRIPTION
## Summary

- initialize torrents with an empty file selection so metadata lookup does not download or allocate every file in a bundle
- resolve the requested video from an exact filename, a validated file index, or an unambiguous main feature
- reject ambiguous bundles instead of silently streaming file zero
- clear persisted file selections and bound finite HTTP ranges only when librqbit returns a partial response
- start paused torrents without suppressing unrelated start failures

## Why

Bundle torrents can contain several similarly sized movies, samples, metadata, and subtitles. The previous path could trust an invalid index, fall back to the first file, or leave files selected for background download. Finite client ranges were also forwarded to librqbit even though its stream endpoint accepts only open-ended ranges.

## Tests

- `cargo test -p remux-server torrent::tests`
- `cargo test -p remux-server torrent_proxy`
- `cargo clippy -p remux-server --all-targets -- -D warnings`
- `cargo test -p remux-server -- --test-threads=1` (453 library tests and 1 binary test passed; 1 doc test ignored)

## AI Disclosure

Created in collaboration with Codex