### PR TITLE
fix(subtitles): expose matching torrent sidecars

### DIFF
--- a/crates/remux-server/src/api/playback.rs
+++ b/crates/remux-server/src/api/playback.rs
@@ -1,7 +1,10 @@
 use anyhow::anyhow;
 use axum::Json;
 
-use super::subtitles::{inject_external_subtitles, scored_external_subtitles};
+use super::subtitles::{
+    inject_external_subtitles, inject_sidecar_subtitles, save_sidecar_subtitle_routes,
+    scored_external_subtitles,
+};
 use axum::{
     body::Body,
     extract::{Path, State},
@@ -264,6 +267,11 @@ async fn items_playbackinfo_inner(
             .results
             .len(),
     );
+    let mut sidecar_subtitle_routes = Vec::with_capacity(
+        probed
+            .results
+            .len(),
+    );
 
     // Per-user playback preferences + remembered selections, resolved per source
     // via `MediaSourceInfo::resolve_default_streams` (see below).
@@ -467,6 +475,20 @@ async fn items_playbackinfo_inner(
             TranscodeDecision::Transcode(outcome) => outcome.apply_to(&mut source),
         }
 
+        let sidecars = effective_stream
+            .stream_info
+            .as_ref()
+            .map(|stream| {
+                stream.subtitle_sidecars(
+                    &state
+                        .ctx
+                        .torrent,
+                )
+            })
+            .unwrap_or_default();
+        let routes = inject_sidecar_subtitles(&mut source, sidecars);
+        let subtitle_source_id = source.id;
+
         apply_subtitle_delivery(
             &mut source,
             id,
@@ -487,6 +509,7 @@ async fn items_playbackinfo_inner(
             }
         }
 
+        sidecar_subtitle_routes.push((subtitle_source_id, routes));
         media_sources.push(source);
     }
 
@@ -544,6 +567,35 @@ async fn items_playbackinfo_inner(
     if !specific_stream_requested && !media_sources.is_empty() {
         media_sources[0].id = id;
         media_sources[0].e_tag = id;
+    }
+
+    for (source, (delivery_source_id, routes)) in media_sources
+        .iter()
+        .zip(sidecar_subtitle_routes)
+    {
+        // DeliveryUrl contains the source ID from apply_subtitle_delivery, while
+        // some clients construct the route from the final MediaSourceInfo ID.
+        // Cache both keys when auto-play rewrites the first source ID.
+        if source.id != delivery_source_id {
+            save_sidecar_subtitle_routes(
+                &state.ctx,
+                &session
+                    .device
+                    .id,
+                id,
+                source.id,
+                routes.clone(),
+            );
+        }
+        save_sidecar_subtitle_routes(
+            &state.ctx,
+            &session
+                .device
+                .id,
+            id,
+            delivery_source_id,
+            routes,
+        );
     }
 
     // Live TV: apply stream flags on top of whatever the probe/transcoding decided.

--- a/crates/remux-server/src/api/subtitles.rs
+++ b/crates/remux-server/src/api/subtitles.rs
@@ -249,6 +249,144 @@ async fn fetch_external_subtitle_bytes(
         .map_err(|e| anyhow!("read subtitle bytes: {e}"))
 }
 
+fn external_subtitle_response(
+    bytes: axum::body::Bytes,
+    output_format: &str,
+) -> Response<Body> {
+    let body = String::from_utf8_lossy(&bytes).into_owned();
+    let (converted, content_type) = match output_format {
+        "vtt" | "webvtt" => (
+            crate::conversions::srt_to_vtt(&body),
+            "text/vtt; charset=utf-8",
+        ),
+        "js" | "json" => (
+            crate::conversions::srt_to_jellyfin_json(&body),
+            "application/json; charset=utf-8",
+        ),
+        _ => (body, "text/plain; charset=utf-8"),
+    };
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("Content-Type", content_type)
+        .header("Cache-Control", "public, max-age=3600")
+        .header("Access-Control-Allow-Origin", "*")
+        .body(Body::from(converted))
+        .unwrap()
+}
+
+#[derive(Clone)]
+pub(crate) struct SidecarSubtitleRoute {
+    index: i64,
+    subtitle: crate::addons::SubtitleInfo,
+}
+
+fn sidecar_subtitle_routes_key(
+    device_id: &str,
+    item_id: Uuid,
+    media_source_id: Uuid,
+) -> String {
+    format!("sidecar-subtitle-routes:{device_id}:{item_id}:{media_source_id}")
+}
+
+fn next_external_subtitle_index(
+    source_indices: impl IntoIterator<Item = i64>,
+    sidecar_indices: impl IntoIterator<Item = i64>,
+) -> i64 {
+    source_indices
+        .into_iter()
+        .chain(sidecar_indices)
+        .max()
+        .map_or(0, |index| index + 1)
+}
+
+pub(crate) fn inject_sidecar_subtitles(
+    source: &mut api::MediaSourceInfo,
+    subtitles: Vec<crate::addons::SubtitleInfo>,
+) -> Vec<SidecarSubtitleRoute> {
+    let next_idx = source
+        .media_streams
+        .iter()
+        .map(|stream| stream.index)
+        .max()
+        .map_or(0, |index| index + 1);
+
+    subtitles
+        .into_iter()
+        .enumerate()
+        .map(|(offset, subtitle)| {
+            let index = next_idx + offset as i64;
+            let mut stream = crate::conversions::subtitle_to_media_stream(&subtitle);
+            stream.index = index;
+            source
+                .media_streams
+                .push(stream);
+            SidecarSubtitleRoute { index, subtitle }
+        })
+        .collect()
+}
+
+pub(crate) fn save_sidecar_subtitle_routes(
+    ctx: &crate::AppContext,
+    device_id: &str,
+    item_id: Uuid,
+    media_source_id: Uuid,
+    routes: Vec<SidecarSubtitleRoute>,
+) {
+    if routes.is_empty() {
+        return;
+    }
+    ctx.store
+        .save(
+            sidecar_subtitle_routes_key(device_id, item_id, media_source_id),
+            routes,
+            std::time::Duration::from_secs(6 * 60 * 60),
+        );
+}
+
+fn load_sidecar_subtitle_routes(
+    ctx: &crate::AppContext,
+    device_id: &str,
+    item_id: Uuid,
+    media_source_id: Uuid,
+) -> Option<std::sync::Arc<Vec<SidecarSubtitleRoute>>> {
+    ctx.store
+        .get::<Vec<SidecarSubtitleRoute>>(&sidecar_subtitle_routes_key(
+            device_id,
+            item_id,
+            media_source_id,
+        ))
+}
+
+async fn sidecar_subtitle_response(
+    state: &AppState,
+    routes: Option<&[SidecarSubtitleRoute]>,
+    item_id: Uuid,
+    media_source_id: Uuid,
+    stream_index: i64,
+    format: &str,
+) -> Option<Response<Body>> {
+    let route = routes?
+        .iter()
+        .find(|route| route.index == stream_index)?;
+    let descriptor = route
+        .subtitle
+        .url
+        .as_ref()?;
+
+    Some(
+        match fetch_external_subtitle_bytes(state, descriptor).await {
+            Ok(bytes) => {
+                external_subtitle_response(bytes, &format.to_ascii_lowercase())
+            }
+            Err(error) => {
+                warn!(%error, %item_id, %media_source_id, stream_index,
+                "sidecar subtitle unavailable");
+                (StatusCode::NOT_FOUND, "subtitle unavailable").into_response()
+            }
+        },
+    )
+}
+
 async fn subtitles_stream_inner(
     state: AppState,
     session: auth::AuthSession,
@@ -257,6 +395,29 @@ async fn subtitles_stream_inner(
     stream_index: i64,
     format: String,
 ) -> Result<impl IntoResponse> {
+    let sidecar_routes = load_sidecar_subtitle_routes(
+        &state.ctx,
+        &session
+            .device
+            .id,
+        item_id,
+        media_source_id,
+    );
+    if let Some(response) = sidecar_subtitle_response(
+        &state,
+        sidecar_routes
+            .as_ref()
+            .map(|routes| routes.as_slice()),
+        item_id,
+        media_source_id,
+        stream_index,
+        &format,
+    )
+    .await
+    {
+        return Ok(response);
+    }
+
     // Try to resolve as an external subtitle injected during PlaybackInfo.
     // fetch_subtitles is cached (24h Stremio / SQLite Opendal) so this is cheap.
     if let Some(mut item_media) = db::Media::get_by_id(
@@ -293,10 +454,20 @@ async fn subtitles_stream_inner(
                         .collect()
                 })
                 .unwrap_or_default();
-            let next_idx = embedded_indices
-                .iter()
-                .max()
-                .map_or(0, |m| m + 1);
+            // Sidecars are inserted before add-on subtitles in PlaybackInfo,
+            // but are not present in the source's probe data. Include their
+            // advertised indexes so the requested add-on matches the selected
+            // menu entry.
+            let next_idx = next_external_subtitle_index(
+                embedded_indices
+                    .iter()
+                    .copied(),
+                sidecar_routes
+                    .as_deref()
+                    .into_iter()
+                    .flatten()
+                    .map(|entry| entry.index),
+            );
             let i = stream_index - next_idx;
             // Only attempt external resolution if the index is not an embedded stream.
             if i >= 0 && !embedded_indices.contains(&stream_index) {
@@ -336,27 +507,10 @@ async fn subtitles_stream_inner(
                         let output_format = format.to_ascii_lowercase();
                         match fetch_external_subtitle_bytes(&state, descriptor).await {
                             Ok(bytes) => {
-                                let body = String::from_utf8_lossy(&bytes).into_owned();
-                                let (converted, content_type) = match output_format
-                                    .as_str()
-                                {
-                                    "vtt" | "webvtt" => (
-                                        crate::conversions::srt_to_vtt(&body),
-                                        "text/vtt; charset=utf-8",
-                                    ),
-                                    "js" => (
-                                        crate::conversions::srt_to_jellyfin_json(&body),
-                                        "application/json",
-                                    ),
-                                    _ => (body, "text/plain; charset=utf-8"),
-                                };
-                                return Ok(Response::builder()
-                                    .status(StatusCode::OK)
-                                    .header("Content-Type", content_type)
-                                    .header("Cache-Control", "public, max-age=3600")
-                                    .header("Access-Control-Allow-Origin", "*")
-                                    .body(Body::from(converted))
-                                    .unwrap());
+                                return Ok(external_subtitle_response(
+                                    bytes,
+                                    &output_format,
+                                ));
                             }
                             Err(e) => {
                                 warn!(error = %e, item_id = %item_id, stream_index,
@@ -839,5 +993,50 @@ mod tests {
 
         assert_eq!(cache, api::SubtitleCodec::Ass);
         assert_eq!(subtitle_cache_ffmpeg_codec(&cache, Some("subrip")), "ass");
+    }
+
+    #[test]
+    fn sidecars_follow_existing_stream_indexes() {
+        let mut source = api::MediaSourceInfo {
+            media_streams: vec![
+                api::MediaStream {
+                    index: 0,
+                    type_: Some(api::MediaStreamType::Video),
+                    ..Default::default()
+                },
+                api::MediaStream {
+                    index: 2,
+                    type_: Some(api::MediaStreamType::Audio),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        let subtitles = vec![crate::addons::SubtitleInfo {
+            id: "sidecar-4".to_string(),
+            url: Some(crate::stream::StreamDescriptor::http(
+                "https://example.com/Movie.en.srt",
+            )),
+            lang: Some("en".to_string()),
+            is_forced: false,
+            is_hi: false,
+        }];
+
+        let routes = inject_sidecar_subtitles(&mut source, subtitles);
+
+        assert_eq!(routes.len(), 1);
+        assert_eq!(routes[0].index, 3);
+        assert_eq!(source.media_streams[2].index, 3);
+        assert_eq!(
+            source.media_streams[2]
+                .codec
+                .as_deref(),
+            Some("subrip")
+        );
+    }
+
+    #[test]
+    fn external_subtitles_follow_sidecars() {
+        assert_eq!(next_external_subtitle_index([0, 1], [2]), 3);
     }
 }

--- a/crates/remux-server/src/conversions.rs
+++ b/crates/remux-server/src/conversions.rs
@@ -356,6 +356,10 @@ pub fn subtitle_to_media_stream(sub: &SubtitleInfo) -> api::MediaStream {
         Some(StreamDescriptor::Local(p)) => p
             .to_str()
             .unwrap_or(""),
+        Some(StreamDescriptor::Torrent {
+            file_hint: Some(path),
+            ..
+        }) => path.as_str(),
         Some(StreamDescriptor::Opendal { path, .. }) => path.as_str(),
         _ => "",
     };

--- a/crates/remux-server/src/torrent.rs
+++ b/crates/remux-server/src/torrent.rs
@@ -10,10 +10,19 @@ use librqbit::{
 };
 use tracing::{debug, warn};
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct TorrentFile {
     name: String,
     length: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SidecarSubtitleFile {
+    file_idx: usize,
+    path: String,
+    language: Option<String>,
+    is_forced: bool,
+    is_hearing_impaired: bool,
 }
 
 pub struct TorrentManager {
@@ -65,6 +74,37 @@ impl TorrentManager {
             session,
             http_port: bound_port,
         })
+    }
+
+    fn managed_torrent_files(&self, info_hash: &str) -> Option<Vec<TorrentFile>> {
+        let api = Api::new(
+            self.session
+                .clone(),
+            None,
+            None,
+        );
+        let torrent_id = api
+            .api_torrent_list()
+            .torrents
+            .into_iter()
+            .find(|torrent| {
+                torrent
+                    .info_hash
+                    .eq_ignore_ascii_case(info_hash)
+            })?
+            .id?;
+        api.api_torrent_details(TorrentIdOrHash::Id(torrent_id))
+            .ok()?
+            .files
+            .map(|files| {
+                files
+                    .into_iter()
+                    .map(|file| TorrentFile {
+                        name: file.name,
+                        length: file.length,
+                    })
+                    .collect()
+            })
     }
 
     /// Gracefully shut down the librqbit session, releasing all sockets
@@ -251,6 +291,49 @@ impl TorrentManager {
     }
 }
 
+impl crate::stream::StreamInfo {
+    /// Return supported subtitle files associated with this stream when its
+    /// torrent metadata has already been initialized. This never starts a
+    /// download; subtitle bytes are requested only if a client selects a track.
+    pub(crate) fn subtitle_sidecars(
+        &self,
+        torrent: &TorrentManager,
+    ) -> Vec<crate::addons::SubtitleInfo> {
+        let crate::stream::StreamDescriptor::Torrent {
+            info_hash,
+            file_hint,
+            file_idx,
+            trackers,
+        } = &self.descriptor
+        else {
+            return Vec::new();
+        };
+        let Some(files) = torrent.managed_torrent_files(info_hash) else {
+            return Vec::new();
+        };
+        let Ok(selected_idx) =
+            select_file_index(&files, *file_idx, file_hint.as_deref())
+        else {
+            return Vec::new();
+        };
+        select_sidecar_subtitles(&files, selected_idx)
+            .into_iter()
+            .map(|sidecar| crate::addons::SubtitleInfo {
+                id: format!("torrent:{info_hash}:{}", sidecar.file_idx),
+                url: Some(crate::stream::StreamDescriptor::Torrent {
+                    info_hash: info_hash.clone(),
+                    file_hint: Some(sidecar.path),
+                    file_idx: Some(sidecar.file_idx),
+                    trackers: trackers.clone(),
+                }),
+                lang: sidecar.language,
+                is_forced: sidecar.is_forced,
+                is_hi: sidecar.is_hearing_impaired,
+            })
+            .collect()
+    }
+}
+
 fn stream_only_options() -> AddTorrentOptions {
     AddTorrentOptions {
         // An empty selection leaves piece ownership to librqbit's HTTP
@@ -270,6 +353,170 @@ fn is_video_file(name: &str) -> bool {
     remux_sdks::remux::VideoContainer::parse_known(&ext).is_some()
 }
 
+fn is_supported_sidecar_subtitle(name: &str) -> bool {
+    std::path::Path::new(name)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("srt"))
+}
+
+fn subtitle_language_from_name(name: &str) -> Option<String> {
+    let stem = std::path::Path::new(name)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or_default();
+    stem.split(|character: char| !character.is_ascii_alphabetic())
+        .rev()
+        .find_map(|token| {
+            let lowercase = token.to_ascii_lowercase();
+            if matches!(
+                lowercase.as_str(),
+                "cc" | "default"
+                    | "forced"
+                    | "foreign"
+                    | "sdh"
+                    | "signs"
+                    | "hearing"
+                    | "impaired"
+                    | "hearingimpaired"
+            ) || token == "HI"
+            {
+                return None;
+            }
+
+            isolang::Language::from_639_1(&lowercase)
+                .or_else(|| isolang::Language::from_639_3(&lowercase))
+                .or_else(|| {
+                    remux_sdks::remux::common_audio_languages()
+                        .iter()
+                        .find(|(code, _)| code.eq_ignore_ascii_case(&lowercase))
+                        .and_then(|(_, name)| isolang::Language::from_name(name))
+                })
+                .or_else(|| {
+                    isolang::languages().find(|language| {
+                        language
+                            .to_name()
+                            .eq_ignore_ascii_case(&lowercase)
+                    })
+                })
+                .and_then(|language| language.to_639_1())
+                .map(str::to_string)
+        })
+}
+
+fn subtitle_stem_matches_video(selected_stem: &str, subtitle_stem: &str) -> bool {
+    !selected_stem.is_empty()
+        && subtitle_stem
+            .strip_prefix(selected_stem)
+            .is_some_and(|suffix| {
+                suffix.is_empty()
+                    || suffix
+                        .chars()
+                        .next()
+                        .is_some_and(|character| !character.is_ascii_alphanumeric())
+            })
+}
+
+fn select_sidecar_subtitles(
+    files: &[TorrentFile],
+    selected_idx: usize,
+) -> Vec<SidecarSubtitleFile> {
+    let Some(selected) = files.get(selected_idx) else {
+        return Vec::new();
+    };
+    let selected_name = selected
+        .name
+        .replace('\\', "/");
+    let selected_path = std::path::Path::new(&selected_name);
+    let selected_parent = selected_path
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new(""));
+    let selected_stem = selected_path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let videos_in_parent = files
+        .iter()
+        .filter(|file| {
+            if !is_video_file(&file.name) {
+                return false;
+            }
+            let normalized = file
+                .name
+                .replace('\\', "/");
+            std::path::Path::new(&normalized)
+                .parent()
+                .unwrap_or_else(|| std::path::Path::new(""))
+                == selected_parent
+        })
+        .count();
+
+    files
+        .iter()
+        .enumerate()
+        .filter_map(|(file_idx, file)| {
+            if file.length == 0
+                || file.length > 20 * 1024 * 1024
+                || !is_supported_sidecar_subtitle(&file.name)
+            {
+                return None;
+            }
+            let normalized = file
+                .name
+                .replace('\\', "/");
+            let subtitle_path = std::path::Path::new(&normalized);
+            let subtitle_parent = subtitle_path
+                .parent()
+                .unwrap_or_else(|| std::path::Path::new(""));
+            let subtitle_stem = subtitle_path
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .unwrap_or_default()
+                .to_ascii_lowercase();
+            let basename_matches =
+                subtitle_stem_matches_video(&selected_stem, &subtitle_stem);
+            let same_directory = subtitle_parent == selected_parent;
+            let in_subtitle_directory = subtitle_parent
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| {
+                    name.eq_ignore_ascii_case("subs")
+                        || name.eq_ignore_ascii_case("subtitles")
+                })
+                && subtitle_parent
+                    .parent()
+                    .unwrap_or_else(|| std::path::Path::new(""))
+                    == selected_parent;
+            // Generic names such as `Subs/2_English.srt` are safe only when
+            // the selected directory contains a single video. Filename-matched
+            // subtitles remain safe for episode packs and movie collections.
+            if !basename_matches
+                && !(videos_in_parent == 1 && (same_directory || in_subtitle_directory))
+            {
+                return None;
+            }
+            let tokens: Vec<&str> = subtitle_stem
+                .split(|character: char| !character.is_ascii_alphanumeric())
+                .filter(|token| !token.is_empty())
+                .collect();
+            Some(SidecarSubtitleFile {
+                file_idx,
+                path: normalized.clone(),
+                language: subtitle_language_from_name(&normalized),
+                is_forced: tokens
+                    .iter()
+                    .any(|token| matches!(*token, "forced" | "foreign" | "signs")),
+                is_hearing_impaired: tokens
+                    .iter()
+                    .any(|token| {
+                        matches!(*token, "sdh" | "cc" | "hi" | "hearingimpaired")
+                    }),
+            })
+        })
+        .collect()
+}
+
 fn select_file_index(
     files: &[TorrentFile],
     requested_idx: Option<usize>,
@@ -280,11 +527,13 @@ fn select_file_index(
     }
 
     if let Some(wanted) = wanted_file {
+        let wanted_is_sidecar = is_supported_sidecar_subtitle(wanted);
         if let Some((index, _)) = files
             .iter()
             .enumerate()
             .find(|(_, file)| {
-                is_video_file(&file.name)
+                (is_video_file(&file.name)
+                    || (wanted_is_sidecar && is_supported_sidecar_subtitle(&file.name)))
                     && (file
                         .name
                         .eq_ignore_ascii_case(wanted)
@@ -418,5 +667,75 @@ mod tests {
     #[test]
     fn metadata_lookup_selects_no_files_for_download() {
         assert_eq!(stream_only_options().only_files, Some(Vec::new()));
+    }
+
+    #[test]
+    fn exact_sidecar_hint_selects_the_subtitle_file() {
+        let files = vec![
+            file("Movie.mkv", 2_000),
+            file("Subs/English.srt", 20),
+            file("release.nfo", 1),
+        ];
+
+        assert_eq!(
+            select_file_index(&files, Some(1), Some("Subs/English.srt")).unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn single_movie_release_exposes_supported_subtitle_directory() {
+        let files = vec![
+            file("Movie.mkv", 2_000),
+            file("Subs/2_English.srt", 20),
+            file("Subs/3_English.srt", 25),
+            file("Subs/4_English.ass", 30),
+        ];
+
+        let subtitles = select_sidecar_subtitles(&files, 0);
+        assert_eq!(subtitles.len(), 2);
+        assert_eq!(subtitles[0].file_idx, 1);
+        assert_eq!(
+            subtitles[0]
+                .language
+                .as_deref(),
+            Some("en")
+        );
+        assert_eq!(subtitles[1].file_idx, 2);
+    }
+
+    #[test]
+    fn movie_bundle_rejects_ambiguous_generic_subtitles() {
+        let files = vec![
+            file("Movie.One.mkv", 2_000),
+            file("Movie.Two.mkv", 2_100),
+            file("Subs/2_English.srt", 20),
+        ];
+
+        assert!(select_sidecar_subtitles(&files, 0).is_empty());
+        assert!(select_sidecar_subtitles(&files, 1).is_empty());
+    }
+
+    #[test]
+    fn episode_pack_uses_only_filename_matched_subtitles() {
+        let files = vec![
+            file("Show.S01E01.mkv", 1_000),
+            file("Show.S01E01.en.HI.forced.srt", 10),
+            file("Show.S01E02.mkv", 1_000),
+            file("Show.S01E02.en.srt", 10),
+            file("Show.S01E010.en.srt", 10),
+        ];
+
+        let subtitles = select_sidecar_subtitles(&files, 0);
+        assert_eq!(subtitles.len(), 1);
+        assert_eq!(subtitles[0].file_idx, 1);
+        assert_eq!(
+            subtitles[0]
+                .language
+                .as_deref(),
+            Some("en")
+        );
+        assert!(subtitles[0].is_forced);
+        assert!(subtitles[0].is_hearing_impaired);
     }
 }


### PR DESCRIPTION
## Summary

- discover matching `.srt` sidecars from already initialized torrent metadata through the stream abstraction
- associate filename-matched subtitles with bundle entries and allow generic subtitle directories only for unambiguous single-video releases
- expose sidecars through PlaybackInfo and download only the subtitle file selected by the client
- keep device- and media-source-scoped subtitle routes so injected indexes resolve consistently
- preserve language, forced, and hearing-impaired metadata from common subtitle filenames
- keep add-on subtitle indexes aligned when torrent sidecars are inserted first

## Why

Torrent releases often carry subtitles as separate files rather than embedded tracks. Those tracks were invisible to Jellyfin clients, and selecting one must not start every file in a bundle. The matching rules are deliberately conservative so a movie or episode does not receive a subtitle belonging to another bundled video.

## Tests

- `cargo test -p remux-server --lib -- --test-threads=1` (486 passed)
- `cargo clippy -p remux-server --lib -- -D warnings`

## AI Disclosure

Created in collaboration with Codex
