### PR TITLE
fix(subtitles): handle CRLF cue boundaries

### DIFF
--- a/crates/remux-server/src/conversions.rs
+++ b/crates/remux-server/src/conversions.rs
@@ -443,6 +443,10 @@ fn to_option_bool(flag: i64) -> Option<bool> {
 /// Convert SRT to WebVTT. Already-valid VTT is passed through unchanged.
 pub fn srt_to_vtt(input: &str) -> String {
     let input = input.trim_start_matches('\u{FEFF}');
+    let normalized = input
+        .replace("\r\n", "\n")
+        .replace('\r', "\n");
+    let input = normalized.as_str();
     if input
         .trim_start()
         .starts_with("WEBVTT")
@@ -500,8 +504,11 @@ pub fn srt_to_vtt(input: &str) -> String {
 
 /// Convert SRT to Jellyfin JSON TrackEvents format (1 tick = 100 ns).
 pub fn srt_to_jellyfin_json(input: &str) -> String {
+    let normalized = input
+        .replace("\r\n", "\n")
+        .replace('\r', "\n");
     let mut events: Vec<serde_json::Value> = Vec::new();
-    for block in input
+    for block in normalized
         .trim()
         .split("\n\n")
     {
@@ -573,4 +580,37 @@ fn srt_timestamp_to_ticks(ts: &str) -> Option<i64> {
         0
     };
     Some(((h * 3600 + m * 60 + s) * 1000 + ms) * 10_000)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn srt_to_vtt_converts_crlf_separated_cues() {
+        let input = "1\r\n00:00:47,791 --> 00:00:49,791\r\nHello\r\n\r\n2\r\n00:00:50,000 --> 00:00:52,000\r\nWorld\r\n";
+
+        let output = srt_to_vtt(input);
+
+        assert!(output.contains("00:00:47.791 --> 00:00:49.791"));
+        assert!(output.contains("00:00:50.000 --> 00:00:52.000"));
+        assert!(!output.contains("00:00:47,791"));
+    }
+
+    #[test]
+    fn srt_to_jellyfin_json_converts_crlf_separated_cues() {
+        let input = "1\r\n00:00:01,000 --> 00:00:02,000\r\nHello\r\n\r\n2\r\n00:00:03,000 --> 00:00:04,000\r\nWorld\r\n";
+
+        let output: serde_json::Value =
+            serde_json::from_str(&srt_to_jellyfin_json(input)).unwrap();
+
+        assert_eq!(
+            output["TrackEvents"]
+                .as_array()
+                .unwrap()
+                .len(),
+            2
+        );
+        assert_eq!(output["TrackEvents"][1]["Text"], "World");
+    }
 }


### PR DESCRIPTION
## Summary

- normalize Windows and legacy carriage-return line endings before splitting subtitle cues
- keep WebVTT and Jellyfin TrackEvents conversion aligned
- add regression coverage for both output formats

## Testing

- cargo test -p remux-server conversions::tests

## AI Disclosure

Created in collaboration with Codex