### PR TITLE
fix(playback): notify clients after playback stops

### DIFF
--- a/crates/remux-server/src/api/playback.rs
+++ b/crates/remux-server/src/api/playback.rs
@@ -1378,6 +1378,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn playback_stop_notifies_clients_that_user_data_changed() {
+        let (server, guard, token) = authenticated_server().await;
+        let auth = auth_header_with_token(&token);
+        let media = insert_test_source(&guard.0).await;
+        let play_session_id = "test-user-data-changed";
+        let mut events = guard
+            .0
+            .ws_tx
+            .subscribe();
+
+        server
+            .post("/sessions/playing")
+            .add_header(
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth).unwrap(),
+            )
+            .json(&json!({
+                "ItemId": media.id,
+                "PlaySessionId": play_session_id,
+                "PositionTicks": 0
+            }))
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
+
+        server
+            .post("/sessions/playing/stopped")
+            .add_header(
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth).unwrap(),
+            )
+            .json(&json!({
+                "ItemId": media.id,
+                "PlaySessionId": play_session_id,
+                "PositionTicks": 30_000_000i64
+            }))
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
+
+        let changed_item_id =
+            tokio::time::timeout(std::time::Duration::from_secs(1), async {
+                loop {
+                    if let crate::ws::WsEvent::UserDataChanged { item_id, .. } = events
+                        .recv()
+                        .await
+                        .unwrap()
+                    {
+                        break item_id;
+                    }
+                }
+            })
+            .await
+            .expect("playback stop should broadcast UserDataChanged");
+
+        assert_eq!(changed_item_id, media.id);
+    }
+
+    #[tokio::test]
     async fn test_playback_full_lifecycle() {
         let (server, _ctx, token) = authenticated_server().await;
         let auth = auth_header_with_token(&token);

--- a/crates/remux-server/src/api/session.rs
+++ b/crates/remux-server/src/api/session.rs
@@ -180,6 +180,18 @@ pub async fn report_playback_stopped(
                 .map(|s| s.play_session_id)
         });
     if let Some(ref psid) = effective_psid {
+        let changed_item_id = (!data
+            .item_id
+            .is_nil())
+        .then_some(data.item_id)
+        .or_else(|| {
+            state
+                .ctx
+                .sessions
+                .get(psid)
+                .map(|playback| playback.item_id)
+                .filter(|item_id| !item_id.is_nil())
+        });
         state
             .ctx
             .sessions
@@ -197,6 +209,17 @@ pub async fn report_playback_stopped(
             .ctx
             .ws_tx
             .send(crate::ws::WsEvent::SessionsChanged);
+        if let Some(item_id) = changed_item_id {
+            let _ = state
+                .ctx
+                .ws_tx
+                .send(crate::ws::WsEvent::UserDataChanged {
+                    user_id: session
+                        .user
+                        .id,
+                    item_id,
+                });
+        }
     }
     Ok(StatusCode::NO_CONTENT.into_response())
 }

--- a/crates/remux-server/src/ws.rs
+++ b/crates/remux-server/src/ws.rs
@@ -26,6 +26,7 @@ pub enum SessionMessageType {
     LibraryChanged,
     UserDeleted,
     UserUpdated,
+    UserDataChanged,
     SessionsStart,
     SessionsStop,
     KeepAlive,
@@ -54,6 +55,13 @@ struct LibraryUpdateInfo {
     is_empty: bool,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct UserDataChangeInfo {
+    user_id: Uuid,
+    user_data_list: Vec<api::UserItemDataDto>,
+}
+
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
 struct InboundMessage {
@@ -65,6 +73,10 @@ struct InboundMessage {
 pub enum WsEvent {
     UserUpdated(Uuid),
     UserDeleted(Uuid),
+    UserDataChanged {
+        user_id: Uuid,
+        item_id: Uuid,
+    },
     LibraryChanged,
     SessionsChanged,
     RemotePlay {
@@ -165,6 +177,30 @@ async fn handle_socket(mut socket: WebSocket, state: AppState, session: AuthSess
                             return;
                         }
                     }
+                    Ok(WsEvent::UserDataChanged { user_id, item_id }) if user_id == session.user.id => {
+                        if let Ok(Some(media)) = db::Media::get_by_id(&state.ctx.db, &item_id).await {
+                            let user_data_list = db::UserMediaState::get_by_user_and_media(
+                                &state.ctx.db,
+                                &session.user,
+                                &media,
+                            )
+                            .await
+                            .ok()
+                            .flatten()
+                            .map(|user_data| vec![api::db_state_to_dto(user_data, &media)])
+                            .unwrap_or_default();
+                            if !send_msg(
+                                &mut socket,
+                                SessionMessageType::UserDataChanged,
+                                Some(UserDataChangeInfo { user_id, user_data_list }),
+                            )
+                            .await
+                            {
+                                return;
+                            }
+                        }
+                    }
+                    Ok(WsEvent::UserDataChanged { .. }) => {}
                     Ok(WsEvent::LibraryChanged) => {
                         if !send_msg(
                             &mut socket,
@@ -283,5 +319,27 @@ mod tests {
         assert_eq!(value["FoldersRemovedFrom"], serde_json::json!([]));
         assert_eq!(value["CollectionFolders"], serde_json::json!([]));
         assert_eq!(value["IsEmpty"], true);
+    }
+
+    #[test]
+    fn user_data_change_info_uses_jellyfin_message_shape() {
+        let user_id = Uuid::new_v4();
+        let item_id = Uuid::new_v4();
+        let value = serde_json::to_value(UserDataChangeInfo {
+            user_id,
+            user_data_list: vec![api::UserItemDataDto {
+                item_id,
+                ..Default::default()
+            }],
+        })
+        .unwrap();
+
+        assert_eq!(value["UserId"], user_id.to_string());
+        assert_eq!(
+            value["UserDataList"][0]["ItemId"],
+            item_id
+                .simple()
+                .to_string()
+        );
     }
 }


### PR DESCRIPTION
## Problem

When playback stops, Remux persists the updated position and played state, but it only broadcasts SessionsChanged. That message refreshes active-session information; Jellyfin clients use UserDataChanged to refresh item-level state.

As a result, Continue Watching, resume position, and played-state controls can remain stale on connected clients until the page is reloaded or another library refresh occurs.

## Fix

- resolve the stopped item's ID from the request or active playback session
- broadcast UserDataChanged only after the stop has successfully persisted
- deliver the standard Jellyfin payload only to sessions belonging to the affected user
- include the updated UserItemDataDto for the stopped item

This does not change progress calculations, resume thresholds, or when an item is considered played. It only notifies clients about state Remux already saved.

## Testing

- cargo test -p remux-server playback_stop_notifies_clients_that_user_data_changed
- cargo test -p remux-server user_data_change_info_uses_jellyfin_message_shape
- cargo fmt --all -- --check

## AI Disclosure

Created in collaboration with Codex