### PR TITLE
refactor(tests): share the media tracker fixtures

### DIFF
--- a/crates/remux-server/src/db/user.rs
+++ b/crates/remux-server/src/db/user.rs
@@ -1104,35 +1104,10 @@ mod playback_threshold_tests {
     use super::*;
     use crate::{db, integration_test::new_test_server};
 
-    const RUNTIME: i64 = 6_000;
+    use crate::integration_test::MOVIE_RUNTIME_SECONDS as RUNTIME;
 
     fn ticks(seconds: i64) -> i64 {
         seconds * 10_000_000
-    }
-
-    async fn movie(ctx: &crate::AppContext) -> db::Media {
-        let external_ids = db::ExternalIds {
-            imdb: db::NonEmptyString::try_new("tt0113277".to_string()).ok(),
-            tmdb: Some(949),
-            ..Default::default()
-        };
-        let mut m = db::Media {
-            id: uuid::Uuid::from(&db::MediaIdRaw {
-                kind: db::MediaKind::Movie,
-                external_ids: external_ids.clone(),
-                season: None,
-                episode: None,
-            }),
-            title: "Heat".into(),
-            kind: db::MediaKind::Movie,
-            runtime: Some(RUNTIME),
-            external_ids,
-            ..Default::default()
-        };
-        m.save(&ctx.db)
-            .await
-            .unwrap();
-        m
     }
 
     async fn stop_at(
@@ -1164,7 +1139,7 @@ mod playback_threshold_tests {
             .await
             .unwrap()
             .unwrap();
-        let media = movie(ctx).await;
+        let media = crate::integration_test::seed_movie(ctx).await;
 
         assert!(
             stop_at(ctx, &user, &media, RUNTIME * 95 / 100).await,
@@ -1198,7 +1173,7 @@ mod playback_threshold_tests {
             .await
             .unwrap()
             .unwrap();
-        let media = movie(ctx).await;
+        let media = crate::integration_test::seed_movie(ctx).await;
 
         stop_at(ctx, &user, &media, RUNTIME * 95 / 100).await;
 

--- a/crates/remux-server/src/integration_test.rs
+++ b/crates/remux-server/src/integration_test.rs
@@ -242,3 +242,137 @@ pub fn assert_api_keys_are_real(value: &serde_json::Value, token: &str) {
         "expected the response to carry an ApiKey: {value}"
     );
 }
+
+/// Long enough that a percentage of it lands on a whole second, so a test can
+/// say "stopped at 95%" without the threshold turning on a rounding.
+pub const MOVIE_RUNTIME_SECONDS: i64 = 6_000;
+
+fn stable_id(kind: db::MediaKind, external_ids: &db::ExternalIds) -> Uuid {
+    Uuid::from(&db::MediaIdRaw {
+        kind,
+        external_ids: external_ids.clone(),
+        season: None,
+        episode: None,
+    })
+}
+
+/// A movie carrying the ids a tracking service keys on. Shared so the ids only
+/// have to agree with themselves: a test asserting on `tmdb` is otherwise
+/// asserting against a literal three modules away.
+pub async fn seed_movie(ctx: &AppContext) -> db::Media {
+    let external_ids = db::ExternalIds {
+        imdb: db::NonEmptyString::try_new("tt0113277".to_string()).ok(),
+        tmdb: Some(949),
+        ..Default::default()
+    };
+    let mut media = db::Media {
+        id: stable_id(db::MediaKind::Movie, &external_ids),
+        title: "Heat".into(),
+        kind: db::MediaKind::Movie,
+        runtime: Some(MOVIE_RUNTIME_SECONDS),
+        external_ids,
+        ..Default::default()
+    };
+    media
+        .save(&ctx.db)
+        .await
+        .unwrap();
+    media
+}
+
+/// The first episode of a series, with the season and series rows it hangs
+/// off. Only the series carries ids, which is what makes it the fixture for
+/// "an episode is matched through its series".
+pub async fn seed_episode(ctx: &AppContext) -> db::Media {
+    let external_ids = db::ExternalIds {
+        imdb: db::NonEmptyString::try_new("tt0306414".to_string()).ok(),
+        tvdb: Some(79126),
+        ..Default::default()
+    };
+    let mut series = db::Media {
+        id: stable_id(db::MediaKind::Series, &external_ids),
+        title: "The Wire".into(),
+        kind: db::MediaKind::Series,
+        external_ids,
+        ..Default::default()
+    };
+    series
+        .save(&ctx.db)
+        .await
+        .unwrap();
+
+    let mut season = db::Media {
+        title: "Season 1".into(),
+        kind: db::MediaKind::Season,
+        parent_id: Some(series.id),
+        grandparent_id: Some(series.id),
+        idx: Some(1),
+        ..Default::default()
+    };
+    season
+        .save(&ctx.db)
+        .await
+        .unwrap();
+
+    let mut episode = db::Media {
+        title: "The Target".into(),
+        kind: db::MediaKind::Episode,
+        parent_id: Some(season.id),
+        grandparent_id: Some(series.id),
+        idx: Some(1),
+        parent_idx: Some(1),
+        ..Default::default()
+    };
+    episode
+        .save(&ctx.db)
+        .await
+        .unwrap();
+    episode
+}
+
+/// Stores an addon row and installs `provider` as its media-tracker
+/// capability. The runtime list has to be rebuilt wholesale because the real
+/// one is built from registered presets, which have no way to carry a stub.
+pub async fn register_media_tracker(
+    ctx: &AppContext,
+    name: &str,
+    provider: std::sync::Arc<dyn crate::addons::media_tracker::MediaTrackerAddon>,
+) -> crate::addons::Addon {
+    let now = Utc::now().naive_utc();
+    let row = crate::addons::Addon {
+        id: crate::common::get_uuid(),
+        name: name.into(),
+        preset: crate::addons::AddonPresetRef {
+            kind: "scripted".into(),
+            config: serde_json::Value::Null.into(),
+        },
+        resources: vec![],
+        types: vec![],
+        enabled: true,
+        priority: 0,
+        created_at: now,
+        updated_at: now,
+        system: false,
+        is_default: true,
+        http_redirect_stream: false,
+        service_filter: vec![],
+    };
+    row.insert(&ctx.db)
+        .await
+        .unwrap();
+
+    let mut runtimes = ctx
+        .addons
+        .list_for_user(&ctx.db, None)
+        .await;
+    runtimes.push(crate::addons::AddonRuntime {
+        row: row.clone(),
+        caps: crate::addons::AddonCapabilities {
+            media_tracker: Some(provider),
+            ..Default::default()
+        },
+    });
+    ctx.addons
+        .replace_runtimes_for_test(runtimes);
+    row
+}

--- a/crates/remux-server/src/services/media_tracker.rs
+++ b/crates/remux-server/src/services/media_tracker.rs
@@ -209,44 +209,12 @@ mod tests {
         filters: Vec<MediaTrackerEventKind>,
         provider: StubMediaTracker,
     ) -> Uuid {
-        let now = Utc::now().naive_utc();
-        let addon = Addon {
-            id: crate::common::get_uuid(),
-            name: name.into(),
-            preset: AddonPresetRef {
-                kind: "scripted".into(),
-                config: serde_json::Value::Null.into(),
-            },
-            resources: vec![],
-            types: vec![],
-            enabled: true,
-            priority: 0,
-            created_at: now,
-            updated_at: now,
-            system: false,
-            is_default: true,
-            http_redirect_stream: false,
-            service_filter: vec![],
-        };
-        addon
-            .insert(&ctx.db)
-            .await
-            .unwrap();
-
-        let mut runtimes: Vec<AddonRuntime> = ctx
-            .addons
-            .list_for_user(&ctx.db, None)
-            .await;
-        runtimes.push(AddonRuntime {
-            row: addon.clone(),
-            caps: AddonCapabilities {
-                media_tracker: Some(Arc::new(provider)),
-                ..Default::default()
-            },
-        });
-        ctx.addons
-            .replace_runtimes_for_test(runtimes);
-
+        let addon = crate::integration_test::register_media_tracker(
+            ctx,
+            name,
+            Arc::new(provider),
+        )
+        .await;
         let mut tracker = UserMediaTracker::new(
             user_id(ctx).await,
             addon.id,
@@ -270,82 +238,6 @@ mod tests {
             .id
     }
 
-    /// Movies and series carry a UUID derived from their external ids, so the
-    /// id cannot be left to `Default`.
-    fn stable_id(kind: db::MediaKind, external_ids: &db::ExternalIds) -> Uuid {
-        Uuid::from(&db::MediaIdRaw {
-            kind,
-            external_ids: external_ids.clone(),
-            season: None,
-            episode: None,
-        })
-    }
-
-    async fn movie(ctx: &AppContext) -> db::Media {
-        let external_ids = db::ExternalIds {
-            imdb: db::NonEmptyString::try_new("tt0113277".to_string()).ok(),
-            tmdb: Some(949),
-            ..Default::default()
-        };
-        let mut m = db::Media {
-            id: stable_id(db::MediaKind::Movie, &external_ids),
-            title: "Heat".into(),
-            kind: db::MediaKind::Movie,
-            external_ids,
-            ..Default::default()
-        };
-        m.save(&ctx.db)
-            .await
-            .unwrap();
-        m
-    }
-
-    async fn episode(ctx: &AppContext) -> db::Media {
-        let external_ids = db::ExternalIds {
-            imdb: db::NonEmptyString::try_new("tt0306414".to_string()).ok(),
-            tvdb: Some(79126),
-            ..Default::default()
-        };
-        let mut series = db::Media {
-            id: stable_id(db::MediaKind::Series, &external_ids),
-            title: "The Wire".into(),
-            kind: db::MediaKind::Series,
-            external_ids,
-            ..Default::default()
-        };
-        series
-            .save(&ctx.db)
-            .await
-            .unwrap();
-
-        let mut season = db::Media {
-            title: "Season 1".into(),
-            kind: db::MediaKind::Season,
-            parent_id: Some(series.id),
-            grandparent_id: Some(series.id),
-            idx: Some(1),
-            ..Default::default()
-        };
-        season
-            .save(&ctx.db)
-            .await
-            .unwrap();
-
-        let mut ep = db::Media {
-            title: "The Target".into(),
-            kind: db::MediaKind::Episode,
-            parent_id: Some(season.id),
-            grandparent_id: Some(series.id),
-            idx: Some(1),
-            parent_idx: Some(1),
-            ..Default::default()
-        };
-        ep.save(&ctx.db)
-            .await
-            .unwrap();
-        ep
-    }
-
     async fn queued(ctx: &AppContext, tracker: Uuid) -> Vec<DeliveryQueue> {
         DeliveryQueue::list_for_media_tracker(&ctx.db, tracker, 10)
             .await
@@ -365,7 +257,7 @@ mod tests {
             vec![MediaTrackerEventKind::MarkPlayed],
         )
         .await;
-        let media = episode(ctx).await;
+        let media = crate::integration_test::seed_episode(ctx).await;
 
         enqueue(
             ctx,
@@ -402,7 +294,7 @@ mod tests {
             vec![MediaTrackerEventKind::MarkPlayed],
         )
         .await;
-        let media = movie(ctx).await;
+        let media = crate::integration_test::seed_movie(ctx).await;
 
         let n = enqueue(
             ctx,
@@ -444,7 +336,7 @@ mod tests {
             StubMediaTracker(vec![MediaTrackerEventKind::MarkPlayed]),
         )
         .await;
-        let media = movie(ctx).await;
+        let media = crate::integration_test::seed_movie(ctx).await;
 
         let n = enqueue(
             ctx,
@@ -479,7 +371,7 @@ mod tests {
             vec![MediaTrackerEventKind::MarkPlayed],
         )
         .await;
-        let media = movie(ctx).await;
+        let media = crate::integration_test::seed_movie(ctx).await;
         ctx.addons
             .replace_runtimes_for_test(Vec::new());
 
@@ -513,7 +405,7 @@ mod tests {
             vec![MediaTrackerEventKind::MarkPlayed],
         )
         .await;
-        let media = movie(ctx).await;
+        let media = crate::integration_test::seed_movie(ctx).await;
 
         let n = enqueue(
             ctx,
@@ -547,7 +439,7 @@ mod tests {
             vec![MediaTrackerEventKind::PlaybackStop],
         )
         .await;
-        let media = movie(ctx).await;
+        let media = crate::integration_test::seed_movie(ctx).await;
         let auth = crate::integration_test::auth_header_with_token(&token);
 
         server
@@ -596,7 +488,7 @@ mod tests {
             vec![MediaTrackerEventKind::Favorite],
         )
         .await;
-        let media = movie(ctx).await;
+        let media = crate::integration_test::seed_movie(ctx).await;
         let user = user_id(ctx).await;
 
         server
@@ -633,7 +525,7 @@ mod tests {
             vec![MediaTrackerEventKind::Rating],
         )
         .await;
-        let media = movie(ctx).await;
+        let media = crate::integration_test::seed_movie(ctx).await;
         let url = format!("/useritems/{}/rating{path_suffix}", media.id);
         let header = (
             http::header::AUTHORIZATION,

--- a/crates/remux-server/src/tasks/delivery_queue_sync.rs
+++ b/crates/remux-server/src/tasks/delivery_queue_sync.rs
@@ -302,39 +302,13 @@ mod tests {
         }
     }
 
-    fn addon_row(name: &str) -> crate::addons::Addon {
-        let now = Utc::now().naive_utc();
-        crate::addons::Addon {
-            id: crate::common::get_uuid(),
-            name: name.into(),
-            preset: AddonPresetRef {
-                kind: "scripted".into(),
-                config: serde_json::Value::Null.into(),
-            },
-            resources: vec![],
-            types: vec![],
-            enabled: true,
-            priority: 0,
-            created_at: now,
-            updated_at: now,
-            system: false,
-            is_default: true,
-            http_redirect_stream: false,
-            service_filter: vec![],
-        }
-    }
-
-    /// Installs `addon` as the media tracker capability of a stored addon row and
-    /// connects `user` to it. Returns the media tracker's id.
     async fn connect(
         ctx: &AppContext,
         user: &str,
         addon: Arc<ScriptedAddon>,
     ) -> (Uuid, crate::addons::Addon) {
-        let row = addon_row(user);
-        row.insert(&ctx.db)
-            .await
-            .unwrap();
+        let row =
+            crate::integration_test::register_media_tracker(ctx, user, addon).await;
 
         let mut u =
             crate::db::User::new_with_password(String::new(), user.into(), "pw", None)
@@ -352,21 +326,6 @@ mod tests {
         conn.upsert(&ctx.db)
             .await
             .unwrap();
-
-        let mut runtimes: Vec<AddonRuntime> = ctx
-            .addons
-            .list_for_user(&ctx.db, None)
-            .await;
-        runtimes.push(AddonRuntime {
-            row: row.clone(),
-            caps: AddonCapabilities {
-                media_tracker: Some(addon),
-                ..Default::default()
-            },
-        });
-        ctx.addons
-            .replace_runtimes_for_test(runtimes);
-
         (conn.id, row)
     }
 
@@ -599,52 +558,7 @@ mod tests {
         let addon = ScriptedAddon::new(vec![]);
         let (conn, _) = connect(ctx, "hana", addon.clone()).await;
 
-        let series_ids = crate::db::ExternalIds {
-            imdb: crate::db::NonEmptyString::try_new("tt0306414".to_string()).ok(),
-            tvdb: Some(79126),
-            ..Default::default()
-        };
-        let mut series = crate::db::Media {
-            id: Uuid::from(&crate::db::MediaIdRaw {
-                kind: crate::db::MediaKind::Series,
-                external_ids: series_ids.clone(),
-                season: None,
-                episode: None,
-            }),
-            title: "The Wire".into(),
-            kind: crate::db::MediaKind::Series,
-            external_ids: series_ids,
-            ..Default::default()
-        };
-        series
-            .save(&ctx.db)
-            .await
-            .unwrap();
-        let mut season = crate::db::Media {
-            title: "Season 1".into(),
-            kind: crate::db::MediaKind::Season,
-            parent_id: Some(series.id),
-            grandparent_id: Some(series.id),
-            idx: Some(1),
-            ..Default::default()
-        };
-        season
-            .save(&ctx.db)
-            .await
-            .unwrap();
-        let mut episode = crate::db::Media {
-            title: "The Target".into(),
-            kind: crate::db::MediaKind::Episode,
-            parent_id: Some(season.id),
-            grandparent_id: Some(series.id),
-            idx: Some(1),
-            parent_idx: Some(1),
-            ..Default::default()
-        };
-        episode
-            .save(&ctx.db)
-            .await
-            .unwrap();
+        let episode = crate::integration_test::seed_episode(ctx).await;
 
         queue_item(&ctx.db, conn, episode.id).await;
         drain(ctx, &reporter())


### PR DESCRIPTION
The movie, episode-tree and addon-registry fixtures were built by hand in three test modules; they move to `integration_test`.