### PR TITLE
fix(playback): prefer item language for stream defaults

### DIFF
--- a/crates/remux-sdks/Cargo.toml
+++ b/crates/remux-sdks/Cargo.toml
@@ -28,7 +28,7 @@ merge = "0.2"
 default2 = "1"
 duration-str = "0.18"
 serde_derive = "1"
-isolang = { version = "2.4.0", features = ["list_languages"] }
+isolang = { version = "2.4.0", features = ["list_languages", "lowercase_names"] }
 nutype = { version = "0.6", features = ["serde", "regex"] }
 regex = "1"
 

--- a/crates/remux-sdks/src/remux/mod.rs
+++ b/crates/remux-sdks/src/remux/mod.rs
@@ -2100,6 +2100,7 @@ pub fn lang_to_two_letter(lang: &str) -> Option<String> {
     }
     isolang::Language::from_639_3(&lang)
         .or_else(|| isolang::Language::from_str(&lang).ok())
+        .or_else(|| isolang::Language::from_name_lowercase(&lang))
         .and_then(|l| l.to_639_1())
         .map(|s| s.to_string())
 }
@@ -6423,6 +6424,13 @@ pub struct RefreshItemQuery {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn language_normalization_accepts_codes_and_full_names() {
+        assert_eq!(lang_to_two_letter("en").as_deref(), Some("en"));
+        assert_eq!(lang_to_two_letter("eng").as_deref(), Some("en"));
+        assert_eq!(lang_to_two_letter("English").as_deref(), Some("en"));
+    }
 
     #[test]
     fn next_up_cutoff_accepts_rfc3339() {

--- a/crates/remux-server/src/api/playback.rs
+++ b/crates/remux-server/src/api/playback.rs
@@ -124,6 +124,18 @@ fn apply_item_runtime_fallback(
         .and_then(|seconds| seconds.to_ticks(TickUnit::Seconds));
 }
 
+fn playback_original_language(
+    item: Option<&db::Media>,
+    selected_source_language: Option<String>,
+) -> Option<String> {
+    item.and_then(|media| {
+        media
+            .original_language
+            .clone()
+    })
+    .or(selected_source_language)
+}
+
 async fn items_playbackinfo_inner(
     state: AppState,
     session: auth::AuthSession,
@@ -183,7 +195,7 @@ async fn items_playbackinfo_inner(
     });
     let is_live = media.is_live();
     let is_track_item = media.is_track();
-    let original_language = media
+    let selected_source_language = media
         .original_language
         .clone();
     service
@@ -204,6 +216,8 @@ async fn items_playbackinfo_inner(
     let item_runtime_seconds = subtitle_media
         .as_ref()
         .and_then(|item| item.runtime);
+    let original_language =
+        playback_original_language(subtitle_media.as_ref(), selected_source_language);
 
     let is_track = is_track_item
         || subtitle_media
@@ -1147,6 +1161,27 @@ mod tests {
         super::apply_item_runtime_fallback(&mut source, Some(142));
 
         assert_eq!(source.run_time_ticks, Some(900_000_000));
+    }
+
+    #[test]
+    fn parent_item_language_overrides_missing_or_stale_source_language() {
+        let parent = crate::db::Media {
+            original_language: Some("en".to_string()),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            super::playback_original_language(Some(&parent), None),
+            Some("en".to_string())
+        );
+        assert_eq!(
+            super::playback_original_language(Some(&parent), Some("ru".to_string())),
+            Some("en".to_string())
+        );
+        assert_eq!(
+            super::playback_original_language(None, Some("fr".to_string())),
+            Some("fr".to_string())
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- resolve default audio and subtitle language from the top-level movie or episode
- fall back to the selected source language when parent metadata is unavailable
- normalize two-letter codes, three-letter codes, and full language names such as English
- cover missing and stale source-language metadata

## Why

External stream rows can omit or carry stale original_language metadata while the library item has the canonical language. Using the source value can select the wrong default audio or subtitle track. Language metadata can also arrive as a full name rather than an ISO code, so normalization must support all documented forms. This keeps selection consistent without changing an explicit client track choice.

## Tests

- cargo fmt --check
- cargo test -p remux-sdks language_normalization_accepts_codes_and_full_names
- cargo test -p remux-server parent_item_language_overrides_missing_or_stale_source_language
- cargo clippy -p remux-server --all-targets -- -D warnings

## AI Disclosure

Created in collaboration with Codex