### PR TITLE
fix(ci): restore server compilation and formatting

### DIFF
--- a/crates/remux-server/src/api/items.rs
+++ b/crates/remux-server/src/api/items.rs
@@ -472,11 +472,16 @@ pub async fn get_items(
             let mut items = Vec::with_capacity(slice.len());
             if !item_ids.is_empty() {
                 let mut by_id: std::collections::HashMap<Uuid, db::Media> =
-                    db::Media::get_by_ids(&state.ctx.db, &item_ids)
-                        .await?
-                        .into_iter()
-                        .map(|m| (m.id, m))
-                        .collect();
+                    db::Media::get_by_ids(
+                        &state
+                            .ctx
+                            .db,
+                        &item_ids,
+                    )
+                    .await?
+                    .into_iter()
+                    .map(|m| (m.id, m))
+                    .collect();
                 for rel in slice {
                     if let Some(media) = by_id.remove(&rel.right_media_id) {
                         let mut dto = api::db_media_to_item(media, hide_sources);
@@ -864,7 +869,11 @@ pub async fn items(
     //trace!(?q);
     let items = get_items(state.clone(), session.clone(), q.clone(), true)
         .await?
-        .preload_playlist_runtimes(&state.ctx.db)
+        .preload_playlist_runtimes(
+            &state
+                .ctx
+                .db,
+        )
         .await
         .with_permissions()
         .with_client_patches()
@@ -1604,7 +1613,9 @@ async fn item_for_user(
     .context_not_found("item not found")?;
 
     db::Media::preload_playlist_runtimes(
-        &state.ctx.db,
+        &state
+            .ctx
+            .db,
         std::slice::from_mut(&mut media),
     )
     .await;

--- a/crates/remux-server/src/api/models.rs
+++ b/crates/remux-server/src/api/models.rs
@@ -710,11 +710,7 @@ pub fn db_media_to_item(media: db::Media, hide_sources: bool) -> BaseItemDto {
             })
             .flatten(),
         album_id: (media.kind == db::MediaKind::Track)
-            .then(|| {
-                media
-                    .parent_id
-                    .map(|id| id.simple().to_string())
-            })
+            .then_some(media.parent_id)
             .flatten(),
         album_primary_image_tag: (media.kind == db::MediaKind::Track)
             .then(|| {

--- a/crates/remux-server/src/api/playlists.rs
+++ b/crates/remux-server/src/api/playlists.rs
@@ -99,7 +99,13 @@ pub async fn create_playlist(
     if !ids.is_empty() {
         let resolved =
             crate::services::MediaResolveService::resolve_ids(&ids, &state.ctx).await;
-        let resolved = retain_playlist_items(&state.ctx.db, resolved).await?;
+        let resolved = retain_playlist_items(
+            &state
+                .ctx
+                .db,
+            resolved,
+        )
+        .await?;
         if !resolved.is_empty() {
             db::MediaRelation::add_playlist_items(
                 &state
@@ -215,10 +221,7 @@ pub struct PlaylistItemsQuery {
     pub start_index: Option<u32>,
     pub limit: Option<u32>,
     /// Jellyfin `IncludeItemTypes` filter, applied before pagination.
-    #[serde(
-        default,
-        deserialize_with = "deserialize_separated_str"
-    )]
+    #[serde(default, deserialize_with = "deserialize_separated_str")]
     pub include_item_types: Option<Vec<api::MediaType>>,
 }
 
@@ -255,11 +258,16 @@ pub async fn get_playlist_items(
     let mut by_id: std::collections::HashMap<Uuid, db::Media> = if item_ids.is_empty() {
         std::collections::HashMap::new()
     } else {
-        db::Media::get_by_ids(&state.ctx.db, &item_ids)
-            .await?
-            .into_iter()
-            .map(|m| (m.id, m))
-            .collect()
+        db::Media::get_by_ids(
+            &state
+                .ctx
+                .db,
+            &item_ids,
+        )
+        .await?
+        .into_iter()
+        .map(|m| (m.id, m))
+        .collect()
     };
 
     let mut ordered: Vec<(Uuid, db::Media)> = relations
@@ -286,23 +294,15 @@ pub async fn get_playlist_items(
         .unwrap_or(0) as usize;
     let start = start.min(ordered.len());
     let slice = match q.limit {
-        Some(limit) => {
-            &ordered[start..][..(limit as usize).min(ordered.len() - start)]
-        }
+        Some(limit) => &ordered[start..][..(limit as usize).min(ordered.len() - start)],
         None => &ordered[start..],
     };
 
     let items: Vec<api::BaseItemDto> = slice
         .iter()
         .map(|(relation_id, media)| {
-            let mut dto = api::db_media_to_item(
-                media.clone(),
-                false,
-            );
-            dto.playlist_item_id = Some(
-                relation_id
-                    .to_string(),
-            );
+            let mut dto = api::db_media_to_item(media.clone(), false);
+            dto.playlist_item_id = Some(relation_id.to_string());
             dto
         })
         .collect();
@@ -342,7 +342,13 @@ pub async fn add_playlist_items(
 
     let resolved =
         crate::services::MediaResolveService::resolve_ids(&q.ids, &state.ctx).await;
-    let resolved = retain_playlist_items(&state.ctx.db, resolved).await?;
+    let resolved = retain_playlist_items(
+        &state
+            .ctx
+            .db,
+        resolved,
+    )
+    .await?;
     db::MediaRelation::add_playlist_items(
         &state
             .ctx

--- a/crates/remux-server/src/db/media.rs
+++ b/crates/remux-server/src/db/media.rs
@@ -203,7 +203,10 @@ impl MediaKind {
     /// Whether the kind is a directly-playable leaf item, as opposed to a
     /// container that only groups other media (albums, artists, series, ...).
     pub fn is_playable_leaf(&self) -> bool {
-        matches!(self, Self::Movie | Self::Episode | Self::Track | Self::TvChannel)
+        matches!(
+            self,
+            Self::Movie | Self::Episode | Self::Track | Self::TvChannel
+        )
     }
 }
 
@@ -1767,17 +1770,29 @@ impl Media {
     pub async fn preload_playlist_runtimes(db: &SqlitePool, records: &mut [Self]) {
         let playlist_ids: Vec<Uuid> = records
             .iter()
-            .filter(|m| m.kind == MediaKind::Playlist && m.runtime.is_none())
+            .filter(|m| {
+                m.kind == MediaKind::Playlist
+                    && m.runtime
+                        .is_none()
+            })
             .map(|m| m.id)
             .collect();
         let album_ids: Vec<Uuid> = records
             .iter()
-            .filter(|m| m.kind == MediaKind::Album && m.runtime.is_none())
+            .filter(|m| {
+                m.kind == MediaKind::Album
+                    && m.runtime
+                        .is_none()
+            })
             .map(|m| m.id)
             .collect();
         let artist_ids: Vec<Uuid> = records
             .iter()
-            .filter(|m| m.kind == MediaKind::Artist && m.runtime.is_none())
+            .filter(|m| {
+                m.kind == MediaKind::Artist
+                    && m.runtime
+                        .is_none()
+            })
             .map(|m| m.id)
             .collect();
         if playlist_ids.is_empty() && album_ids.is_empty() && artist_ids.is_empty() {


### PR DESCRIPTION
## Summary

- return track album IDs as `Uuid` values to match `BaseItemDto.album_id`
- apply the current rustfmt output to recently merged playlist and media code

## Why

Current `main` fails the server build because the album ID conversion still produces `Option<String>` after the API field changed to `Option<Uuid>`. Its formatting check also fails on the recently merged playlist/media changes. These two focused commits restore both required checks without changing runtime behavior beyond the corrected album ID type.

## Tests

- `cargo check -p remux-server --lib`
- `cargo fmt --all -- --check`

## AI Disclosure

Created in collaboration with Codex
