### PR TITLE
fix(torrent): preserve bundle files during stream deduplication

### DIFF
--- a/crates/remux-server/src/addons/mod.rs
+++ b/crates/remux-server/src/addons/mod.rs
@@ -2579,8 +2579,25 @@ impl AddonService {
             .stream_info
             .as_ref()?;
         match &si.descriptor {
-            crate::stream::StreamDescriptor::Torrent { info_hash, .. } => {
-                Some(format!("torrent:{}", info_hash.to_lowercase()))
+            crate::stream::StreamDescriptor::Torrent {
+                info_hash,
+                file_hint,
+                file_idx,
+                ..
+            } => {
+                let file_key = file_hint
+                    .as_deref()
+                    .or(si
+                        .filename
+                        .as_deref())
+                    .filter(|name| !name.is_empty())
+                    .map(str::to_ascii_lowercase)
+                    .unwrap_or_else(|| {
+                        file_idx
+                            .map(|index| format!("#{index}"))
+                            .unwrap_or_default()
+                    });
+                Some(format!("torrent:{}:{file_key}", info_hash.to_lowercase()))
             }
             crate::stream::StreamDescriptor::Http { url, .. } => {
                 let filename = si
@@ -3160,6 +3177,38 @@ pub fn make_media_id(addon_id: Uuid, local_id: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn torrent_stream(hash: &str, file_hint: &str, file_idx: usize) -> db::Media {
+        db::Media {
+            stream_info: Some(crate::stream::StreamInfo {
+                descriptor: crate::stream::StreamDescriptor::Torrent {
+                    info_hash: hash.to_string(),
+                    file_hint: Some(file_hint.to_string()),
+                    file_idx: Some(file_idx),
+                    trackers: Vec::new(),
+                },
+                filename: Some(file_hint.to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn torrent_dedup_preserves_distinct_files_in_a_bundle() {
+        let first = torrent_stream("abc", "Bundle/Movie.One.mkv", 0);
+        let duplicate = torrent_stream("ABC", "Bundle/Movie.One.mkv", 7);
+        let second = torrent_stream("abc", "Bundle/Movie.Two.mkv", 1);
+
+        assert_eq!(
+            AddonService::stream_dedup_key(&first),
+            AddonService::stream_dedup_key(&duplicate)
+        );
+        assert_ne!(
+            AddonService::stream_dedup_key(&first),
+            AddonService::stream_dedup_key(&second)
+        );
+    }
 
     fn make_image(path: &str) -> db::MediaImage {
         db::MediaImage {


### PR DESCRIPTION
## Summary

- include the selected torrent file identity in stream deduplication
- preserve distinct movies or episodes that share one bundle info hash
- continue collapsing duplicate provider results for the same file

## Why

Torrent streams were deduplicated by info hash alone. In a multi-file torrent, that collapses every selected file into one stream and can make the requested movie or episode disappear before playback selection.

The key now uses the file hint or filename, with the file index as a fallback when no name is available.

## Tests

- `cargo test -p remux-server torrent_dedup_preserves_distinct_files_in_a_bundle --lib -- --test-threads=1`
- `cargo fmt --all -- --check`
- `cargo clippy -p remux-server --lib -- -D warnings`

## AI Disclosure

Created in collaboration with Codex
