### PR TITLE
fix(server): stop advertising unsupported SyncPlay

### DIFF
--- a/crates/remux-sdks/src/remux/mod.rs
+++ b/crates/remux-sdks/src/remux/mod.rs
@@ -2766,9 +2766,9 @@ impl Default for UserDto {
 #[serde(rename_all = "PascalCase")]
 #[strum(serialize_all = "PascalCase")]
 pub enum SyncPlayUserAccessType {
-    #[default]
     CreateAndJoinGroups,
     JoinGroups,
+    #[default]
     None,
 }
 
@@ -2863,7 +2863,7 @@ pub struct UserPolicy {
     #[serde(default = "default_password_reset_provider_id")]
     pub password_reset_provider_id: String,
     #[serde(default, deserialize_with = "deserialize_optional_with_default")]
-    #[default(SyncPlayUserAccessType::CreateAndJoinGroups)]
+    #[default(SyncPlayUserAccessType::None)]
     pub sync_play_access: SyncPlayUserAccessType,
 }
 
@@ -6424,6 +6424,16 @@ pub struct RefreshItemQuery {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn user_policy_does_not_advertise_unimplemented_sync_play() {
+        assert_eq!(
+            UserPolicy::default().sync_play_access,
+            SyncPlayUserAccessType::None
+        );
+        let policy: UserPolicy = serde_json::from_str("{}").unwrap();
+        assert_eq!(policy.sync_play_access, SyncPlayUserAccessType::None);
+    }
 
     #[test]
     fn language_normalization_accepts_codes_and_full_names() {

--- a/crates/remux-server/src/api/models.rs
+++ b/crates/remux-server/src/api/models.rs
@@ -199,6 +199,9 @@ pub fn db_user_to_dto(data_dir: &std::path::Path, user: db::User) -> UserDto {
         .map(|p| p.0)
         .unwrap_or_default();
     policy.is_administrator = user.is_admin;
+    // SyncPlay requires group lifecycle, playback commands, and websocket
+    // coordination. Do not advertise it while those server APIs are absent.
+    policy.sync_play_access = SyncPlayUserAccessType::None;
     let defaults = UserPolicy::default();
     macro_rules! default_if_empty {
         ($field:ident) => {

--- a/crates/remux-server/src/api/system.rs
+++ b/crates/remux-server/src/api/system.rs
@@ -22,8 +22,6 @@ use anyhow;
 use axum_anyhow::ApiResult as Result;
 use remux_sdks::remux::IntroOptions;
 
-use super::mock_items;
-
 fn request_local_address(headers: &HeaderMap, fallback_port: u16) -> String {
     let scheme = headers
         .get("x-forwarded-proto")
@@ -384,10 +382,10 @@ pub async fn system_endpoint(
 
 #[get("/syncplay/list")]
 pub async fn syncplay_list(
-    State(state): State<AppState>,
+    State(_state): State<AppState>,
     _session: auth::AuthSession,
 ) -> Result<impl IntoResponse> {
-    mock_items(State(state)).await
+    Ok(Json(Vec::<serde_json::Value>::new()))
 }
 
 #[route("/quickconnect/enabled", method = "GET", method = "POST")]
@@ -1132,6 +1130,7 @@ mod test {
             .await;
 
         resp.assert_status_ok();
+        resp.assert_json(&json!([]));
     }
 
     // --- GET+POST /quickconnect/enabled ---


### PR DESCRIPTION
## Summary

- default `SyncPlayAccess` to `None`
- return an empty SyncPlay group list instead of mock media items
- add coverage for the advertised policy and endpoint response

## Why

Remux does not implement SyncPlay group lifecycle or playback coordination, but its user policy currently advertises permission to create and join groups. Jellyfin clients then expose a SyncPlay button that can only enter a perpetual loading state. Reporting the unsupported capability accurately lets clients hide or disable that path.

## Tests

- `cargo test -p remux-sdks user_policy_does_not_advertise_unimplemented_sync_play --lib -- --test-threads=1`
- `cargo test -p remux-server syncplay --lib -- --test-threads=1`
- `cargo fmt --all -- --check`
- `cargo clippy -p remux-server --lib -- -D warnings`

## AI Disclosure

Created in collaboration with Codex
