### PR TITLE
fix(streams): prefer advertised seeder counts

### DIFF
--- a/crates/remux-sdks/src/stremio/mod.rs
+++ b/crates/remux-sdks/src/stremio/mod.rs
@@ -837,6 +837,7 @@ pub struct Stream {
     pub parsed_file: Option<ParsedFile>,
     pub name: Option<String>,
     pub description: Option<String>,
+    pub title: Option<String>,
     pub behavior_hints: Option<BehaviorHints>,
     pub stream_data: Option<StreamData>,
 }

--- a/crates/remux-server/src/addons/stremio.rs
+++ b/crates/remux-server/src/addons/stremio.rs
@@ -1559,7 +1559,18 @@ async fn stremio_streams(
                     .description
                     .clone(),
                 filename: metadata.filename,
-                seeders: metadata.seeders,
+                seeders: metadata
+                    .seeders
+                    .or_else(|| {
+                        parse_seeders_from_strings(&[
+                            s.name
+                                .as_deref(),
+                            s.description
+                                .as_deref(),
+                            s.title
+                                .as_deref(),
+                        ])
+                    }),
                 size: sd
                     .and_then(|d| d.size)
                     .or(s.size),
@@ -1608,6 +1619,48 @@ async fn stremio_streams(
             })
         })
         .collect())
+}
+
+fn parse_seeders_from_strings(candidates: &[Option<&str>]) -> Option<i64> {
+    candidates
+        .iter()
+        .filter_map(|candidate| *candidate)
+        .find_map(parse_seeders)
+}
+
+fn parse_seeders(value: &str) -> Option<i64> {
+    if let Some(index) = value.find('👤') {
+        let remainder = &value[index + '👤'.len_utf8()..];
+        if let Some(seeders) = first_unsigned_integer(remainder) {
+            return Some(seeders);
+        }
+    }
+
+    let lowercase = value.to_ascii_lowercase();
+    for label in ["seeders", "seeds"] {
+        if let Some(index) = lowercase.find(label) {
+            let remainder = &value[index + label.len()..];
+            if let Some(seeders) = first_unsigned_integer(remainder) {
+                return Some(seeders);
+            }
+        }
+    }
+    None
+}
+
+fn first_unsigned_integer(value: &str) -> Option<i64> {
+    let digits: String = value
+        .chars()
+        .skip_while(|character| !character.is_ascii_digit())
+        .take_while(char::is_ascii_digit)
+        .collect();
+    (!digits.is_empty())
+        .then(|| {
+            digits
+                .parse()
+                .ok()
+        })
+        .flatten()
 }
 
 #[cfg(test)]
@@ -1660,6 +1713,22 @@ mod tests {
         );
         assert_eq!(metadata.seeders, Some(84));
         assert_eq!(metadata.file_idx, Some(7));
+    }
+
+    #[test]
+    fn parses_explicit_seeder_counts_from_stream_text() {
+        assert_eq!(parse_seeders("👤 42"), Some(42));
+        assert_eq!(parse_seeders("Seeds: 0"), Some(0));
+        assert_eq!(parse_seeders("seeders 123 | size 2024 MB"), Some(123));
+        assert_eq!(parse_seeders("Peers: 99"), None);
+    }
+
+    #[test]
+    fn checks_all_stream_text_fields_for_seeders() {
+        assert_eq!(
+            parse_seeders_from_strings(&[None, Some("1080p"), Some("Seeds: 17")]),
+            Some(17)
+        );
     }
 
     #[test]

--- a/crates/remux-server/src/db/stream_group.rs
+++ b/crates/remux-server/src/db/stream_group.rs
@@ -236,8 +236,8 @@ impl StreamGroup {
 
     /// Filter a list of media sources by the enabled stream groups.
     ///
-    /// Returns one representative source per matching group (the first
-    /// match by priority order), plus any unmatched sources when
+    /// Returns one representative source per matching group (the source with
+    /// the highest advertised seeder count), plus any unmatched sources when
     /// `show_ungrouped` is true.  When no groups are enabled the original
     /// list is returned unchanged.
     pub async fn filter_sources(
@@ -285,10 +285,13 @@ impl StreamGroup {
             }
 
             if !group.hidden {
-                // Only the first (highest-priority) match is shown.
+                // Only one match is shown. Prefer the healthiest advertised
+                // torrent, retaining source order as the tie-breaker.
                 // group_id marks it as a group representative; the real stream
                 // UUID stays in best.id so internal probe URLs stay correct.
-                let mut best = matching[0].clone();
+                let mut best = preferred_group_source(&matching)
+                    .expect("matching sources are non-empty")
+                    .clone();
                 best.title = group.display_name();
                 best.group_id = Some(group.id);
                 result.push(best);
@@ -305,6 +308,34 @@ impl StreamGroup {
 
         result
     }
+}
+
+fn preferred_group_source<'a>(matching: &'a [&Media]) -> Option<&'a Media> {
+    matching
+        .iter()
+        .copied()
+        .max_by(|left, right| {
+            advertised_seeders(left)
+                .cmp(&advertised_seeders(right))
+                .then_with(|| {
+                    right
+                        .idx
+                        .unwrap_or(i64::MAX)
+                        .cmp(
+                            &left
+                                .idx
+                                .unwrap_or(i64::MAX),
+                        )
+                })
+        })
+}
+
+fn advertised_seeders(media: &Media) -> i64 {
+    media
+        .stream_info
+        .as_ref()
+        .and_then(|stream| stream.seeders)
+        .unwrap_or(0)
 }
 
 /// Filter a list of source Media items using a `StreamFilter`.
@@ -734,6 +765,41 @@ mod tests {
             filename: Some(filename.to_string()),
             ..Default::default()
         }
+    }
+
+    fn source_with_seeders(seeders: Option<i64>, idx: i64) -> Media {
+        Media {
+            idx: Some(idx),
+            stream_info: Some(StreamInfo {
+                seeders,
+                ..info("movie.mkv")
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn group_representative_prefers_more_seeders() {
+        let first = source_with_seeders(Some(3), 0);
+        let second = source_with_seeders(Some(20), 1);
+        let matching = [&first, &second];
+
+        assert_eq!(
+            preferred_group_source(&matching).map(|source| source.id),
+            Some(second.id)
+        );
+    }
+
+    #[test]
+    fn group_representative_keeps_source_order_when_seeders_tie() {
+        let first = source_with_seeders(Some(20), 0);
+        let second = source_with_seeders(Some(20), 1);
+        let matching = [&second, &first];
+
+        assert_eq!(
+            preferred_group_source(&matching).map(|source| source.id),
+            Some(first.id)
+        );
     }
 
     // "UHD BluRay" credits the source disc; the explicit "1080p" token is the


### PR DESCRIPTION
## Summary

- deserialize the optional Stremio stream title
- recover explicitly advertised seeder counts from stream text when structured metadata is absent
- use the highest advertised seeder count when choosing one representative for a stream group
- retain provider order as the tie-breaker

## Why

Some Stremio addons expose torrent health only in the stream name, description, or title. Remux currently discards the title and can choose the first matching grouped source even when another candidate advertises substantially more seeders.

Structured seeder metadata remains authoritative. The fallback parser only accepts the person marker or explicit seeders/seeds labels, and it performs no network probes or downloads.

## Tests

- full remux-server library suite: 497 passed
- cargo fmt --all -- --check
- cargo clippy -p remux-server --lib -- -D warnings

## AI Disclosure

Created in collaboration with Codex