### PR TITLE
perf(playback): avoid blocking probes for torrents

### DIFF
--- a/crates/remux-server/src/playback/probe.rs
+++ b/crates/remux-server/src/playback/probe.rs
@@ -895,6 +895,9 @@ pub(crate) async fn resolve_stream_root(
 }
 
 /// Resolve probe data for a single source: cache hit → skip → live probe with fallback.
+/// Uncached P2P sources return inferred stream metadata immediately so
+/// `PlaybackInfo` is not blocked waiting for torrent pieces; ordinary network
+/// sources still use authoritative probing for codec decisions.
 pub(crate) async fn probe_stream(
     stream: &db::Media,
     url_opt: Option<String>,
@@ -921,6 +924,16 @@ pub(crate) async fn probe_stream(
             return Ok((info, stream.clone()));
         }
         debug!(id = %stream.id, "probe cache stale (no video stream), re-probing");
+    } else if stream
+        .stream_info
+        .as_ref()
+        .is_some_and(|stream_info| stream_info.is_p2p())
+    {
+        // Probing a torrent URL requests media pieces. PlaybackInfo and version
+        // dropdowns must remain metadata-only, so defer authoritative probing
+        // until the playback-owned HLS path starts the selected source.
+        debug!(id = %stream.id, "uncached P2P source — returning inferred metadata without downloading pieces");
+        return Ok((api::MediaSourceInfo::from(stream.clone()), stream.clone()));
     }
     probe_with_fallback(
         stream.clone(),
@@ -998,9 +1011,41 @@ fn select_candidates(
         .collect()
 }
 
+fn probe_attempt_timeout(primary: &db::Media, configured_secs: u64) -> u64 {
+    if primary
+        .stream_info
+        .as_ref()
+        .is_some_and(|info| info.is_p2p())
+    {
+        configured_secs.min(30)
+    } else {
+        configured_secs
+    }
+}
+
+fn probe_overall_deadline(
+    primary: &db::Media,
+    attempt_timeout_secs: u64,
+    candidate_count: usize,
+) -> Option<std::time::Duration> {
+    primary
+        .stream_info
+        .as_ref()
+        .is_some_and(|info| info.is_p2p())
+        .then(|| {
+            std::time::Duration::from_secs(
+                attempt_timeout_secs * (candidate_count as u64).min(4) + 5,
+            )
+        })
+}
+
 /// Probe a stream URL, retrying with the next matching candidate on failure.
 ///
 /// Returns a 500 error if all candidates fail to probe.
+///
+/// Probes are sequential, but both the per-source timeout and total fallback
+/// duration are bounded so a large candidate pool cannot multiply startup
+/// latency without limit.
 async fn probe_with_fallback<F>(
     primary: db::Media,
     primary_url: Option<String>,
@@ -1040,8 +1085,25 @@ where
         .collect();
     let total_available = probe_pool.len();
     let mut attempts = 0usize;
+    // Bound P2P probing so one unreachable swarm cannot dominate the fallback
+    // sequence. Local and HTTP/debrid sources retain the administrator's
+    // configured timeout.
+    let effective_timeout = probe_attempt_timeout(&primary, timeout_secs);
+    // P2P fallback probing is bounded across the candidate pool. Direct HTTP,
+    // debrid, and local sources retain their existing fallback behavior.
+    let overall_deadline =
+        probe_overall_deadline(&primary, effective_timeout, all_to_try.len());
+    let overall_start = std::time::Instant::now();
 
     for (stream, url_opt) in all_to_try {
+        if overall_deadline.is_some_and(|deadline| overall_start.elapsed() >= deadline)
+        {
+            warn!(
+                timeout = ?overall_deadline,
+                attempts, "probe overall deadline exceeded"
+            );
+            break;
+        }
         let is_retry = stream.id != primary.id;
         let url = match url_opt {
             Some(u) => u,
@@ -1052,7 +1114,7 @@ where
         };
         attempts += 1;
         if is_retry {
-            info!(
+            debug!(
                 failed_id = %primary.id,
                 next_id = %stream.id,
                 next_url = %url,
@@ -1064,7 +1126,7 @@ where
         let db2 = db.clone();
         let f = probe_fn.clone();
         let probe_result = tokio::time::timeout(
-            std::time::Duration::from_secs(timeout_secs),
+            std::time::Duration::from_secs(effective_timeout),
             tokio::task::spawn_blocking(move || f(url2)),
         )
         .await;
@@ -1140,7 +1202,7 @@ where
                 warn!(url = %url, error = %e, "probe task panicked");
             }
             Err(_) => {
-                warn!(url = %url, timeout = timeout_secs, "probe timed out");
+                warn!(url = %url, timeout = effective_timeout, "probe timed out");
             }
         }
     }
@@ -1281,6 +1343,23 @@ mod probe_tests {
         let all = vec![primary.clone(), p2p];
         let result = select_candidates(&primary, &all, true, 10, false, 3000);
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn probe_timeout_cap_does_not_override_non_p2p_configuration() {
+        assert_eq!(
+            probe_attempt_timeout(&http_media("http://example.com"), 75),
+            75
+        );
+        assert_eq!(probe_attempt_timeout(&p2p_media(), 75), 30);
+        assert_eq!(
+            probe_overall_deadline(&http_media("http://example.com"), 75, 10),
+            None
+        );
+        assert_eq!(
+            probe_overall_deadline(&p2p_media(), 30, 10),
+            Some(std::time::Duration::from_secs(125))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- return inferred metadata for uncached torrent sources instead of reading media pieces during PlaybackInfo
- cap individual torrent probe attempts at 30 seconds
- bound the aggregate fallback probe window for torrents
- preserve the configured timeout and existing fallback behavior for local, HTTP, debrid, RTSP, and OpenDAL sources

## Why

PlaybackInfo and source-picker requests should remain metadata-only. Probing an uncached torrent can otherwise start piece requests and make the UI wait on an unavailable swarm before the user has started playback.

## Tests

- full remux-server suite: 495 passed
- focused P2P versus HTTP timeout test
- cargo fmt --all --check
- cargo clippy -p remux-server --all-targets -- -D warnings

## AI Disclosure

Created in collaboration with Codex
