### PR TITLE
perf(tracking): drain deliveries grouped by tracker

### DIFF
--- a/crates/remux-dashboard/src/pages/settings.rs
+++ b/crates/remux-dashboard/src/pages/settings.rs
@@ -21,6 +21,7 @@ pub fn ServerSettingsCard(app_state: AppState) -> Element {
     let mut cultures: Signal<Vec<CultureDto>> = use_signal(Vec::new);
     let mut catalog_max_items = use_signal(|| 100_i64);
     let mut meta_concurrency = use_signal(|| 12_i64);
+    let mut delivery_concurrency = use_signal(|| 8_i64);
     let mut filter_digital_release = use_signal(|| true);
     let mut digital_release_buffer = use_signal(|| 0_i64);
     let mut subtitle_languages = use_signal(String::new);
@@ -59,6 +60,7 @@ pub fn ServerSettingsCard(app_state: AppState) -> Element {
                             .unwrap_or(100),
                     );
                     meta_concurrency.set(cfg.meta_concurrency);
+                    delivery_concurrency.set(cfg.delivery_concurrency);
                     filter_digital_release.set(cfg.filter_by_digital_release_date);
                     digital_release_buffer.set(cfg.digital_release_buffer_days);
                     subtitle_languages.set(
@@ -105,6 +107,7 @@ pub fn ServerSettingsCard(app_state: AppState) -> Element {
             .clone();
         let max = *catalog_max_items.peek();
         let concurrency = *meta_concurrency.peek();
+        let delivery = *delivery_concurrency.peek();
         let filter_dr = *filter_digital_release.peek();
         let dr_buffer = *digital_release_buffer.peek();
         let sub_langs_str = subtitle_languages
@@ -122,6 +125,7 @@ pub fn ServerSettingsCard(app_state: AppState) -> Element {
         cfg.quick_connect_available = Some(qc_enabled);
         cfg.catalog_max_items = Some(max);
         cfg.meta_concurrency = concurrency;
+        cfg.delivery_concurrency = delivery;
         cfg.filter_by_digital_release_date = filter_dr;
         cfg.digital_release_buffer_days = dr_buffer;
         cfg.subtitle_languages = Some(
@@ -240,6 +244,26 @@ pub fn ServerSettingsCard(app_state: AppState) -> Element {
                             }
                             p { class: "field-hint",
                                 "Number of items to enrich with metadata concurrently during library import. Higher values are faster but increase memory usage and may trigger rate limits on metadata sources. Default: 12."
+                            }
+                        }
+
+                        div { class: "field",
+                            label { class: "field-label", r#for: "s-delivery-concurrency", "Delivery Concurrency" }
+                            input {
+                                id: "s-delivery-concurrency",
+                                r#type: "number",
+                                class: "field-input",
+                                min: "1",
+                                max: "200",
+                                value: "{delivery_concurrency}",
+                                oninput: move |e| {
+                                    if let Ok(n) = e.value().parse::<i64>() {
+                                        delivery_concurrency.set(n);
+                                    }
+                                },
+                            }
+                            p { class: "field-hint",
+                                "Number of media trackers whose queued watch activity is sent concurrently. One tracker's events are always sent in order, one at a time, so this only controls how many trackers are worked on at once. Default: 8."
                             }
                         }
 

--- a/crates/remux-sdks/src/remux/mod.rs
+++ b/crates/remux-sdks/src/remux/mod.rs
@@ -479,9 +479,8 @@ pub struct ServerConfiguration {
     /// Number of items to process concurrently during metadata fetch (default: 12).
     #[default(12_i64)]
     pub meta_concurrency: i64,
-    /// Number of media trackers whose queued deliveries are drained
-    /// concurrently. One tracker's rows always go out in order, one at a
-    /// time (default: 8).
+    /// Number of media trackers drained concurrently; one tracker's queued
+    /// deliveries always go out in order, one at a time (default: 8).
     #[default(8_i64)]
     pub delivery_concurrency: i64,
     #[default(Some(true))]

--- a/crates/remux-sdks/src/remux/mod.rs
+++ b/crates/remux-sdks/src/remux/mod.rs
@@ -479,6 +479,11 @@ pub struct ServerConfiguration {
     /// Number of items to process concurrently during metadata fetch (default: 12).
     #[default(12_i64)]
     pub meta_concurrency: i64,
+    /// Number of media trackers whose queued deliveries are drained
+    /// concurrently. One tracker's rows always go out in order, one at a
+    /// time (default: 8).
+    #[default(8_i64)]
+    pub delivery_concurrency: i64,
     #[default(Some(true))]
     pub p2p_enabled: Option<bool>,
     #[default(Some(0_i64))]

--- a/crates/remux-server/src/db/delivery_queue.rs
+++ b/crates/remux-server/src/db/delivery_queue.rs
@@ -249,11 +249,14 @@ impl DeliveryQueue {
         .await?)
     }
 
+    /// Due rows, oldest first. `created_at` breaks ties so two rows queued in
+    /// the same tick come back in the order they were written: the drain pass
+    /// delivers one tracker's rows in exactly this order.
     pub async fn due(db: &SqlitePool, limit: i64) -> Result<Vec<Self>> {
         Ok(sqlx::query_as::<_, Self>(&format!(
             "SELECT {COLS} FROM delivery_queue \
              WHERE status = 'pending' AND next_attempt_at <= ?1 \
-             ORDER BY next_attempt_at ASC LIMIT ?2"
+             ORDER BY next_attempt_at ASC, created_at ASC LIMIT ?2"
         ))
         .bind(Utc::now().naive_utc())
         .bind(limit)

--- a/crates/remux-server/src/tasks/delivery_queue_sync.rs
+++ b/crates/remux-server/src/tasks/delivery_queue_sync.rs
@@ -1,6 +1,10 @@
 use anyhow::Result;
 use async_trait::async_trait;
-use std::sync::Arc;
+use futures::StreamExt;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
 use tracing::{debug, warn};
 
 use super::{ProgressReporter, Task, TaskCategory, TaskService};
@@ -73,7 +77,10 @@ impl Task for DeliveryQueueSyncTask {
 /// Attempt every due row once. Returns how many were delivered.
 ///
 /// Failures are recorded per row and never abort the pass: one dead provider
-/// must not stop another user's deliveries from going out.
+/// must not stop another user's deliveries from going out. Trackers are drained
+/// concurrently, bounded by `delivery_concurrency`, because a row costs a round
+/// trip to whatever it is delivered to and a provider that answers slowly
+/// should hold up nobody but its own.
 pub async fn drain(ctx: &AppContext, progress: &ProgressReporter) -> Result<usize> {
     let due = db::DeliveryQueue::due(&ctx.db, BATCH).await?;
     if due.is_empty() {
@@ -81,45 +88,107 @@ pub async fn drain(ctx: &AppContext, progress: &ProgressReporter) -> Result<usiz
     }
 
     let total = due.len() as f64;
-    let mut delivered = 0usize;
+    let concurrency = db::Settings::get_config_or_default(&ctx.db)
+        .await
+        .delivery_concurrency
+        .max(1) as usize;
 
-    for (i, row) in due
-        .into_iter()
-        .enumerate()
-    {
-        match deliver(ctx, &row.kind).await {
-            Ok(()) => {
-                db::DeliveryQueue::mark_delivered(&ctx.db, row.id).await?;
-                record_outcome(ctx, &row.kind, None).await?;
-                delivered += 1;
-            }
-            Err(err) => {
-                let status = db::DeliveryQueue::record_failure(
-                    &ctx.db,
-                    row.id,
-                    row.attempts,
-                    &err,
-                )
-                .await?;
-                // A retryable blip is the worker's business, not the user's, so
-                // only a terminal outcome touches the deliverer's health.
-                if status != db::DeliveryStatus::Pending {
-                    record_outcome(ctx, &row.kind, Some(&err)).await?;
-                }
-                warn!(
-                    delivery_id = %row.id,
-                    kind = %row.kind.kind(),
-                    attempts = row.attempts + 1,
-                    ?status,
-                    error = %err,
-                    "delivery failed"
-                );
-            }
+    // A queue per tracker, each holding its rows in the order `due` returned
+    // them. Two rows for one tracker have to settle in order, a stop after the
+    // start it follows, and one at a time, since their outcomes move the same
+    // health status. Grouping is what guarantees that. Fanning every row out
+    // and serializing after the fact would leave the order resting on how the
+    // executor happens to poll, which is not something to build on.
+    let mut by_tracker: Vec<(Uuid, Vec<db::DeliveryQueue>)> = Vec::new();
+    for row in due {
+        let db::QueueKind::MediaTracker {
+            user_media_tracker_id,
+            ..
+        } = &row.kind;
+        let tracker = *user_media_tracker_id;
+        match by_tracker
+            .iter_mut()
+            .find(|(id, _)| *id == tracker)
+        {
+            Some((_, rows)) => rows.push(row),
+            None => by_tracker.push((tracker, vec![row])),
         }
-        progress.set((i as f64 + 1.0) / total * 100.0);
     }
 
-    Ok(delivered)
+    let delivered = Arc::new(AtomicUsize::new(0));
+    let processed = Arc::new(AtomicUsize::new(0));
+
+    futures::stream::iter(by_tracker)
+        .map(|(_, rows)| {
+            let ctx = ctx.clone();
+            let progress = progress.clone();
+            let delivered = Arc::clone(&delivered);
+            let processed = Arc::clone(&processed);
+            async move {
+                for row in rows {
+                    if process_row(&ctx, &row).await {
+                        delivered.fetch_add(1, Ordering::Relaxed);
+                    }
+                    let n = processed.fetch_add(1, Ordering::Relaxed) + 1;
+                    progress.set(n as f64 / total * 100.0);
+                }
+            }
+        })
+        .buffer_unordered(concurrency)
+        .for_each(|()| async {})
+        .await;
+
+    Ok(delivered.load(Ordering::Relaxed))
+}
+
+/// One row through to a settled outcome. Returns whether it was delivered.
+///
+/// A failure recording the outcome is logged rather than propagated: it's one
+/// row's bookkeeping, not a reason to give up on the rest of the pass.
+async fn process_row(ctx: &AppContext, row: &db::DeliveryQueue) -> bool {
+    match deliver(ctx, &row.kind).await {
+        Ok(()) => {
+            if let Err(e) = db::DeliveryQueue::mark_delivered(&ctx.db, row.id).await {
+                warn!(delivery_id = %row.id, error = %e, "failed to mark delivery delivered");
+            }
+            if let Err(e) = record_outcome(ctx, &row.kind, None).await {
+                warn!(delivery_id = %row.id, error = %e, "failed to record delivery outcome");
+            }
+            true
+        }
+        Err(err) => {
+            let status = match db::DeliveryQueue::record_failure(
+                &ctx.db,
+                row.id,
+                row.attempts,
+                &err,
+            )
+            .await
+            {
+                Ok(status) => status,
+                Err(e) => {
+                    warn!(delivery_id = %row.id, error = %e, "failed to record delivery failure");
+                    return false;
+                }
+            };
+            // A retryable blip is the worker's business, not the user's, so
+            // only a terminal outcome touches the deliverer's health.
+            if status != db::DeliveryStatus::Pending {
+                if let Err(e) = record_outcome(ctx, &row.kind, Some(&err)).await {
+                    warn!(delivery_id = %row.id, error = %e, "failed to record delivery outcome");
+                }
+            }
+            warn!(
+                delivery_id = %row.id,
+                kind = %row.kind.kind(),
+                attempts = row.attempts + 1,
+                ?status,
+                error = %err,
+                "delivery failed"
+            );
+            false
+        }
+    }
 }
 
 /// Hand one row to whatever its kind talks to. Adding a kind means adding an
@@ -610,6 +679,53 @@ mod tests {
                 .status,
             DeliveryStatus::FailedPermanent,
             "no amount of retrying gives the item an id"
+        );
+    }
+
+    /// Two events about one tracker have to reach it in the order they were
+    /// queued: a stop arriving before the start it followed reads as a rewind,
+    /// and both move the same health status. Draining groups rows by tracker
+    /// for exactly that, so this is what would break if it stopped.
+    #[tokio::test]
+    async fn one_trackers_rows_go_out_in_the_order_they_were_queued() {
+        let (_s, guard) = new_test_server()
+            .await
+            .unwrap();
+        let ctx = &guard.0;
+        let addon = ScriptedAddon::new(vec![]);
+        let (conn, _) = connect(ctx, "gita", addon.clone()).await;
+
+        // Own imdb id each, or they would be one media row under three names,
+        // and distinct due times, so `due` has one legal order to preserve.
+        let now = Utc::now().naive_utc();
+        let titles = ["Dune", "Sicario", "Arrival"];
+        for (i, title) in titles
+            .iter()
+            .enumerate()
+        {
+            let media = movie(&ctx.db, title, &format!("tt000000{i}")).await;
+            let row = queue_item(&ctx.db, conn, media).await;
+            sqlx::query("UPDATE delivery_queue SET next_attempt_at = ?1 WHERE id = ?2")
+                .bind(now - chrono::Duration::seconds((titles.len() - i) as i64))
+                .bind(row)
+                .execute(&ctx.db)
+                .await
+                .unwrap();
+        }
+
+        assert_eq!(
+            drain(ctx, &reporter())
+                .await
+                .unwrap(),
+            3
+        );
+        assert_eq!(
+            addon
+                .seen()
+                .into_iter()
+                .map(|(_, title)| title)
+                .collect::<Vec<_>>(),
+            titles
         );
     }
 

--- a/crates/remux-server/src/tasks/delivery_queue_sync.rs
+++ b/crates/remux-server/src/tasks/delivery_queue_sync.rs
@@ -78,27 +78,23 @@ impl Task for DeliveryQueueSyncTask {
 ///
 /// Failures are recorded per row and never abort the pass: one dead provider
 /// must not stop another user's deliveries from going out. Trackers are drained
-/// concurrently, bounded by `delivery_concurrency`, because a row costs a round
-/// trip to whatever it is delivered to and a provider that answers slowly
-/// should hold up nobody but its own.
+/// concurrently, bounded by `delivery_concurrency`.
 pub async fn drain(ctx: &AppContext, progress: &ProgressReporter) -> Result<usize> {
     let due = db::DeliveryQueue::due(&ctx.db, BATCH).await?;
     if due.is_empty() {
         return Ok(0);
     }
 
-    let total = due.len() as f64;
+    let total = due.len();
     let concurrency = db::Settings::get_config_or_default(&ctx.db)
         .await
         .delivery_concurrency
         .max(1) as usize;
 
     // A queue per tracker, each holding its rows in the order `due` returned
-    // them. Two rows for one tracker have to settle in order, a stop after the
-    // start it follows, and one at a time, since their outcomes move the same
-    // health status. Grouping is what guarantees that. Fanning every row out
-    // and serializing after the fact would leave the order resting on how the
-    // executor happens to poll, which is not something to build on.
+    // them. Two rows for one tracker have to settle in order and one at a
+    // time: a stop before the start it followed reads as a rewind, and both
+    // move the same health status.
     let mut by_tracker: Vec<(Uuid, Vec<db::DeliveryQueue>)> = Vec::new();
     for row in due {
         let db::QueueKind::MediaTracker {
@@ -125,12 +121,29 @@ pub async fn drain(ctx: &AppContext, progress: &ProgressReporter) -> Result<usiz
             let delivered = Arc::clone(&delivered);
             let processed = Arc::clone(&processed);
             async move {
+                let queued = rows.len();
+                let mut attempted = 0usize;
                 for row in rows {
-                    if process_row(&ctx, &row).await {
+                    let status = process_row(&ctx, &row).await;
+                    attempted += 1;
+                    if status == db::DeliveryStatus::Delivered {
                         delivered.fetch_add(1, Ordering::Relaxed);
                     }
-                    let n = processed.fetch_add(1, Ordering::Relaxed) + 1;
-                    progress.set(n as f64 / total * 100.0);
+                    progress
+                        .report(processed.fetch_add(1, Ordering::Relaxed) + 1, total);
+                    // Still pending means a retry is coming. Letting the rows
+                    // behind it go out first is the reordering the grouping
+                    // exists to prevent, so the rest of this tracker waits.
+                    if status == db::DeliveryStatus::Pending {
+                        break;
+                    }
+                }
+                let held = queued - attempted;
+                if held > 0 {
+                    progress.report(
+                        processed.fetch_add(held, Ordering::Relaxed) + held,
+                        total,
+                    );
                 }
             }
         })
@@ -141,11 +154,11 @@ pub async fn drain(ctx: &AppContext, progress: &ProgressReporter) -> Result<usiz
     Ok(delivered.load(Ordering::Relaxed))
 }
 
-/// One row through to a settled outcome. Returns whether it was delivered.
+/// One row through to a settled outcome. Returns the status it landed in.
 ///
 /// A failure recording the outcome is logged rather than propagated: it's one
 /// row's bookkeeping, not a reason to give up on the rest of the pass.
-async fn process_row(ctx: &AppContext, row: &db::DeliveryQueue) -> bool {
+async fn process_row(ctx: &AppContext, row: &db::DeliveryQueue) -> db::DeliveryStatus {
     match deliver(ctx, &row.kind).await {
         Ok(()) => {
             if let Err(e) = db::DeliveryQueue::mark_delivered(&ctx.db, row.id).await {
@@ -154,7 +167,7 @@ async fn process_row(ctx: &AppContext, row: &db::DeliveryQueue) -> bool {
             if let Err(e) = record_outcome(ctx, &row.kind, None).await {
                 warn!(delivery_id = %row.id, error = %e, "failed to record delivery outcome");
             }
-            true
+            db::DeliveryStatus::Delivered
         }
         Err(err) => {
             let status = match db::DeliveryQueue::record_failure(
@@ -168,7 +181,9 @@ async fn process_row(ctx: &AppContext, row: &db::DeliveryQueue) -> bool {
                 Ok(status) => status,
                 Err(e) => {
                     warn!(delivery_id = %row.id, error = %e, "failed to record delivery failure");
-                    return false;
+                    // The row is still pending in the table, so report it as
+                    // such rather than letting the ones behind it past.
+                    return db::DeliveryStatus::Pending;
                 }
             };
             // A retryable blip is the worker's business, not the user's, so
@@ -186,7 +201,7 @@ async fn process_row(ctx: &AppContext, row: &db::DeliveryQueue) -> bool {
                 error = %err,
                 "delivery failed"
             );
-            false
+            status
         }
     }
 }
@@ -682,10 +697,6 @@ mod tests {
         );
     }
 
-    /// Two events about one tracker have to reach it in the order they were
-    /// queued: a stop arriving before the start it followed reads as a rewind,
-    /// and both move the same health status. Draining groups rows by tracker
-    /// for exactly that, so this is what would break if it stopped.
     #[tokio::test]
     async fn one_trackers_rows_go_out_in_the_order_they_were_queued() {
         let (_s, guard) = new_test_server()
@@ -695,8 +706,7 @@ mod tests {
         let addon = ScriptedAddon::new(vec![]);
         let (conn, _) = connect(ctx, "gita", addon.clone()).await;
 
-        // Own imdb id each, or they would be one media row under three names,
-        // and distinct due times, so `due` has one legal order to preserve.
+        // Own imdb id each, or they would be one media row under three names.
         let now = Utc::now().naive_utc();
         let titles = ["Dune", "Sicario", "Arrival"];
         for (i, title) in titles
@@ -727,6 +737,51 @@ mod tests {
                 .collect::<Vec<_>>(),
             titles
         );
+    }
+
+    /// The rows behind a retryable failure belong to the same tracker, so
+    /// letting them past would land a stop without the start it followed.
+    #[tokio::test]
+    async fn a_retryable_failure_holds_back_the_rest_of_its_trackers_queue() {
+        let (_s, guard) = new_test_server()
+            .await
+            .unwrap();
+        let ctx = &guard.0;
+        let addon = ScriptedAddon::new(vec![Err(MediaTrackerError::retryable("down"))]);
+        let (conn, _) = connect(ctx, "hana", addon.clone()).await;
+
+        let mut rows = Vec::new();
+        for (i, title) in ["Dune", "Sicario", "Arrival"]
+            .iter()
+            .enumerate()
+        {
+            let media = movie(&ctx.db, title, &format!("tt000000{i}")).await;
+            rows.push(queue_item(&ctx.db, conn, media).await);
+        }
+
+        assert_eq!(
+            drain(ctx, &reporter())
+                .await
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            addon
+                .seen()
+                .len(),
+            1,
+            "the rows behind the failure wait for the next pass"
+        );
+        for row in rows {
+            assert_eq!(
+                DeliveryQueue::get(&ctx.db, row)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .status,
+                DeliveryStatus::Pending
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
Towards #207. Independent of the other tracking PRs.

One slow provider held up every other user's deliveries behind it. Trackers now drain concurrently, bounded by a new `delivery_concurrency` setting.

Rows are grouped by tracker rather than fanned out and locked, because two rows for one tracker have to go out in order and one at a time.