### PR TITLE
feat: add native BetterPosters addon

### DIFF
--- a/crates/remux-server/src/addons/better_posters.rs
+++ b/crates/remux-server/src/addons/better_posters.rs
@@ -1,0 +1,542 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
+use uuid::Uuid;
+
+use super::{
+    AddonCapabilities, AddonKind, AddonMetadata, AddonOption, AddonOptionType,
+    AddonPreset, AddonPresetRegistration, AddonSelectOption, MediaKind, MetaAddon,
+    PrimaryPosterOverride, ResourceType,
+};
+use crate::{AppContext, api, db};
+
+const BASE_URL: &str = "https://btttr.cc";
+
+static BETTER_POSTERS_CONFIG_REVISION: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) fn config_revision() -> u64 {
+    BETTER_POSTERS_CONFIG_REVISION.load(Ordering::Relaxed)
+}
+
+fn publish_config_revision(cfg: &serde_json::Value) {
+    let mut hasher = DefaultHasher::new();
+    cfg.to_string().hash(&mut hasher);
+    BETTER_POSTERS_CONFIG_REVISION.store(hasher.finish(), Ordering::Relaxed);
+}
+
+pub struct BetterPostersPreset;
+
+impl AddonPreset for BetterPostersPreset {
+    fn id(&self) -> &'static str {
+        "better-posters"
+    }
+
+    fn metadata(&self) -> AddonMetadata {
+        AddonMetadata {
+            id: "better-posters".to_string(),
+            display_name: "BetterPosters".to_string(),
+            description: "Use btttr.cc as the effective primary poster provider for movies and series.".to_string(),
+            icon: None,
+            supported_resources: vec![AddonMetadata::simple_resource(ResourceType::Meta)],
+            supported_types: vec![MediaKind::Movie, MediaKind::Series],
+            supported_resources_user: vec![],
+            supported_types_user: vec![],
+            options: vec![
+                bool_option(
+                    "trend_tags",
+                    "Trend Tags",
+                    "Trending, New, IMDb ranking and similar BetterPosters trend tags.",
+                    false,
+                ),
+                bool_option(
+                    "quality_tags",
+                    "Quality Tags",
+                    "Show quality badges such as 4K, Dolby Vision and Atmos.",
+                    false,
+                ),
+                bool_option(
+                    "genre",
+                    "Genre",
+                    "Show the genre label at the bottom of the poster.",
+                    false,
+                ),
+                bool_option(
+                    "rating",
+                    "Rating",
+                    "Show the rating at the bottom of the poster.",
+                    false,
+                ),
+                select_option(
+                    "rating_source",
+                    "Rating Source",
+                    "Rating source used when Rating is enabled.",
+                    "average",
+                    &[
+                        ("Average", "average"),
+                        ("IMDb", "imdb"),
+                        ("TMDB", "tmdb"),
+                        ("Rotten Tomatoes", "rotten_tomatoes"),
+                        ("Metacritic", "metacritic"),
+                        ("Trakt", "trakt"),
+                        ("Letterboxd", "letterboxd"),
+                        ("Roger Ebert", "roger_ebert"),
+                    ],
+                ),
+                bool_option(
+                    "age_rating",
+                    "Age Rating",
+                    "Show age/certification badges such as PG-13, TV-MA and R.",
+                    false,
+                ),
+                bool_option(
+                    "watch_progress",
+                    "Watch Progress",
+                    "Show watched/episode progress using the authenticated Jellyfin user's local Remux watch state. No Trakt or PublicMetaDB account is required.",
+                    false,
+                ),
+                select_option(
+                    "language",
+                    "Language",
+                    "Language used by BetterPosters for poster labels.",
+                    "en",
+                    &[
+                        ("English", "en"),
+                        ("Spanish", "es"),
+                        ("French", "fr"),
+                        ("German", "de"),
+                        ("Portuguese (Brazil)", "pt-BR"),
+                        ("Portuguese (Portugal)", "pt-PT"),
+                        ("Italian", "it"),
+                        ("Dutch", "nl"),
+                        ("Polish", "pl"),
+                        ("Russian", "ru"),
+                        ("Turkish", "tr"),
+                        ("Arabic", "ar"),
+                        ("Japanese", "ja"),
+                        ("Korean", "ko"),
+                        ("Chinese", "zh"),
+                        ("Hindi", "hi"),
+                        ("Swedish", "sv"),
+                        ("Czech", "cs"),
+                    ],
+                ),
+            ],
+        }
+    }
+
+    fn from_cfg(
+        &self,
+        _addon_id: Uuid,
+        cfg: &serde_json::Value,
+        _config: &crate::Config,
+    ) -> Result<AddonCapabilities> {
+        publish_config_revision(cfg);
+        let addon = Arc::new(BetterPostersAddon {
+            trend_tags: cfg_bool(cfg, "trend_tags", false),
+            quality_tags: cfg_bool(cfg, "quality_tags", false),
+            genre: cfg_bool(cfg, "genre", false),
+            rating: cfg_bool(cfg, "rating", false),
+            rating_source: cfg_string(cfg, "rating_source", "average"),
+            age_rating: cfg_bool(cfg, "age_rating", false),
+            watch_progress: cfg_bool(cfg, "watch_progress", false),
+            language: cfg_string(cfg, "language", "en"),
+        });
+
+        Ok(AddonCapabilities {
+            kind: Some(addon.clone()),
+            meta: Some(addon),
+            ..Default::default()
+        })
+    }
+}
+
+inventory::submit! {
+    AddonPresetRegistration(|| Box::new(BetterPostersPreset))
+}
+
+pub struct BetterPostersAddon {
+    trend_tags: bool,
+    quality_tags: bool,
+    genre: bool,
+    rating: bool,
+    rating_source: String,
+    age_rating: bool,
+    watch_progress: bool,
+    language: String,
+}
+
+#[async_trait]
+impl AddonKind for BetterPostersAddon {
+    fn id(&self) -> &'static str {
+        "better-posters"
+    }
+}
+
+#[async_trait]
+impl MetaAddon for BetterPostersAddon {
+    async fn supports(&self, media: &db::Media) -> bool {
+        matches!(media.kind, db::MediaKind::Movie | db::MediaKind::Series)
+    }
+
+    async fn meta_fetch(
+        &self,
+        _media: &db::Media,
+        _ctx: &AppContext,
+        _config: &api::ServerConfiguration,
+    ) -> Result<Option<db::Media>> {
+        Ok(None)
+    }
+
+    async fn images_fetch(
+        &self,
+        media: &db::Media,
+        ctx: &AppContext,
+    ) -> Result<Vec<api::RemoteImageInfo>> {
+        let Some(imdb_id) = self
+            .resolve_imdb_id(media, ctx)
+            .await?
+        else {
+            return Ok(vec![]);
+        };
+        let url = self.standard_url(&imdb_id);
+        Ok(vec![api::RemoteImageInfo {
+            provider_name: Some("BetterPosters".to_string()),
+            url: Some(url.clone()),
+            thumbnail_url: Some(url),
+            type_: Some("Primary".to_string()),
+            width: None,
+            height: None,
+        }])
+    }
+
+    async fn primary_poster_override(
+        &self,
+        media: &db::Media,
+        ctx: &AppContext,
+        user: Option<&db::User>,
+    ) -> Result<Option<PrimaryPosterOverride>> {
+        let Some(imdb_id) = self
+            .resolve_imdb_id(media, ctx)
+            .await?
+        else {
+            return Ok(None);
+        };
+
+        let standard_url = self.standard_url(&imdb_id);
+        if !self.watch_progress {
+            return Ok(Some(PrimaryPosterOverride {
+                url: standard_url,
+                fallback_url: None,
+                private_cache: false,
+            }));
+        }
+
+        let Some(user) = user else {
+            return Ok(Some(PrimaryPosterOverride {
+                url: standard_url,
+                fallback_url: None,
+                private_cache: false,
+            }));
+        };
+
+        let filename = self
+            .progress_filename(media, ctx, user)
+            .await?;
+        if filename == "poster" {
+            return Ok(Some(PrimaryPosterOverride {
+                url: standard_url,
+                fallback_url: None,
+                private_cache: true,
+            }));
+        }
+
+        Ok(Some(PrimaryPosterOverride {
+            url: self.progress_url(media, &imdb_id, &filename),
+            fallback_url: Some(standard_url),
+            private_cache: true,
+        }))
+    }
+}
+
+impl BetterPostersAddon {
+    async fn resolve_imdb_id(
+        &self,
+        media: &db::Media,
+        ctx: &AppContext,
+    ) -> Result<Option<String>> {
+        if let Some(imdb) = media
+            .external_ids
+            .imdb
+            .as_ref()
+        {
+            return Ok(Some(
+                imdb.as_str()
+                    .to_string(),
+            ));
+        }
+
+        Ok(super::tmdb::resolve_imdb_from_ctx(
+            &media.external_ids,
+            media.kind == db::MediaKind::Series,
+            ctx,
+        )
+        .await?
+        .map(|id| id.as_str().to_string()))
+    }
+
+    async fn progress_filename(
+        &self,
+        media: &db::Media,
+        ctx: &AppContext,
+        user: &db::User,
+    ) -> Result<String> {
+        match media.kind {
+            db::MediaKind::Movie => {
+                let played =
+                    db::UserMediaState::get_by_user_and_media(&ctx.db, user, media)
+                        .await?
+                        .is_some_and(|s| s.play_count > 0);
+                Ok(if played { "auto~w" } else { "poster" }.to_string())
+            }
+            db::MediaKind::Series => {
+                let (total, watched): (i64, i64) = sqlx::query_as(
+                    r#"
+                    SELECT COUNT(*) AS total,
+                           COALESCE(SUM(CASE WHEN ums.play_count > 0 THEN 1 ELSE 0 END), 0) AS watched
+                    FROM media e
+                    LEFT JOIN user_media_state ums
+                      ON ums.media_id = e.id AND ums.user_id = ?1
+                    WHERE e.kind = 'episode' AND e.grandparent_id = ?2
+                    "#,
+                )
+                .bind(user.id)
+                .bind(media.id)
+                .fetch_one(&ctx.db)
+                .await?;
+
+                Ok(match (watched, total) {
+                    (_, 0) | (0, _) => "poster".to_string(),
+                    (w, t) if w >= t => "auto~w".to_string(),
+                    (w, t) => format!("auto~s{w}o{t}"),
+                })
+            }
+            _ => Ok("poster".to_string()),
+        }
+    }
+
+    fn standard_url(&self, imdb_id: &str) -> String {
+        let mut url = format!(
+            "{BASE_URL}/{}/imdb/poster-default/{imdb_id}.jpg",
+            self.standard_path()
+        );
+        self.append_query(&mut url);
+        url
+    }
+
+    fn progress_url(&self, media: &db::Media, imdb_id: &str, filename: &str) -> String {
+        let media_type = match media.kind {
+            db::MediaKind::Series => "series",
+            _ => "movie",
+        };
+        let mut url = format!(
+            "{BASE_URL}/{}/{media_type}/{imdb_id}/{filename}.jpg",
+            self.dynamic_overlay_path()
+        );
+        self.append_query(&mut url);
+        url
+    }
+
+    fn standard_path(&self) -> String {
+        let mut suffix = match (self.genre, self.rating) {
+            (true, true) => String::new(),
+            (false, true) => "r".to_string(),
+            (true, false) => "g".to_string(),
+            (false, false) => "n".to_string(),
+        };
+        if self.quality_tags {
+            suffix.push('q');
+        }
+        if self.age_rating {
+            suffix.push('a');
+        }
+        if suffix.is_empty() {
+            "poster".to_string()
+        } else {
+            format!("poster-{suffix}")
+        }
+    }
+
+    fn dynamic_overlay_path(&self) -> String {
+        let mut suffix = String::new();
+        if self.genre {
+            suffix.push('g');
+        }
+        if self.rating {
+            suffix.push('r');
+        }
+        if self.quality_tags {
+            suffix.push('q');
+        }
+        if self.age_rating {
+            suffix.push('a');
+        }
+        if suffix.is_empty() {
+            "poster".to_string()
+        } else {
+            format!("poster-{suffix}")
+        }
+    }
+
+    fn append_query(&self, url: &mut String) {
+        let mut params: Vec<String> = Vec::new();
+        if !self.trend_tags {
+            params.push("tag=none".to_string());
+        }
+        if self.language != "en"
+            && !self
+                .language
+                .is_empty()
+        {
+            params.push(format!("lang={}", self.language));
+        }
+        if self.rating {
+            if let Some(code) = rating_source_code(&self.rating_source) {
+                params.push(format!("rs={code}"));
+            }
+        }
+        if !params.is_empty() {
+            url.push('?');
+            url.push_str(&params.join("&"));
+        }
+    }
+}
+
+fn cfg_bool(cfg: &serde_json::Value, key: &str, default: bool) -> bool {
+    cfg.get(key)
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(default)
+}
+
+fn cfg_string(cfg: &serde_json::Value, key: &str, default: &str) -> String {
+    cfg.get(key)
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or(default)
+        .to_string()
+}
+
+fn bool_option(id: &str, name: &str, description: &str, default: bool) -> AddonOption {
+    AddonOption {
+        id: id.to_string(),
+        name: name.to_string(),
+        description: Some(description.to_string()),
+        required: false,
+        default: Some(serde_json::Value::Bool(default)),
+        kind: AddonOptionType::Boolean,
+    }
+}
+
+fn select_option(
+    id: &str,
+    name: &str,
+    description: &str,
+    default: &str,
+    options: &[(&str, &str)],
+) -> AddonOption {
+    AddonOption {
+        id: id.to_string(),
+        name: name.to_string(),
+        description: Some(description.to_string()),
+        required: false,
+        default: Some(serde_json::Value::String(default.to_string())),
+        kind: AddonOptionType::Select {
+            options: options
+                .iter()
+                .map(|(label, value)| AddonSelectOption {
+                    label: (*label).to_string(),
+                    value: (*value).to_string(),
+                })
+                .collect(),
+        },
+    }
+}
+
+fn rating_source_code(source: &str) -> Option<&'static str> {
+    match source {
+        "imdb" => Some("IM"),
+        "tmdb" => Some("TM"),
+        "rotten_tomatoes" => Some("RT"),
+        "metacritic" => Some("MC"),
+        "trakt" => Some("TR"),
+        "letterboxd" => Some("LB"),
+        "roger_ebert" => Some("RE"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn addon() -> BetterPostersAddon {
+        BetterPostersAddon {
+            trend_tags: true,
+            quality_tags: false,
+            genre: true,
+            rating: true,
+            rating_source: "average".to_string(),
+            age_rating: false,
+            watch_progress: true,
+            language: "en".to_string(),
+        }
+    }
+
+    #[test]
+    fn official_default_url_matches_current_builder() {
+        assert_eq!(
+            addon().standard_url("tt0133093"),
+            "https://btttr.cc/poster/imdb/poster-default/tt0133093.jpg"
+        );
+    }
+
+    #[test]
+    fn official_query_options_are_encoded_in_expected_shape() {
+        let mut a = addon();
+        a.trend_tags = false;
+        a.language = "de".to_string();
+        a.rating_source = "letterboxd".to_string();
+        assert_eq!(
+            a.standard_url("tt0133093"),
+            "https://btttr.cc/poster/imdb/poster-default/tt0133093.jpg?tag=none&lang=de&rs=LB"
+        );
+    }
+
+    #[test]
+    fn dynamic_progress_overlay_uses_local_progress_protocol() {
+        let a = addon();
+        let media = db::Media {
+            kind: db::MediaKind::Series,
+            ..Default::default()
+        };
+        assert_eq!(
+            a.progress_url(&media, "tt0903747", "auto~s3o5"),
+            "https://btttr.cc/poster-gr/series/tt0903747/auto~s3o5.jpg"
+        );
+    }
+
+    #[test]
+    fn path_variants_match_official_stable_builder() {
+        let mut a = addon();
+        a.genre = false;
+        a.rating = false;
+        a.quality_tags = true;
+        a.age_rating = true;
+        assert_eq!(a.standard_path(), "poster-nqa");
+    }
+}

--- a/crates/remux-server/src/addons/mod.rs
+++ b/crates/remux-server/src/addons/mod.rs
@@ -2,6 +2,7 @@
 //! media types it serves; user-added instances are rows in the `addons` table.
 
 pub mod addon;
+pub mod better_posters;
 pub mod deezer;
 pub mod eclipse;
 pub mod introdb;
@@ -730,6 +731,14 @@ pub trait CatalogAddon: Send + Sync {
     ) -> Result<Option<Pin<Box<dyn Stream<Item = db::Media> + Send>>>>;
 }
 
+#[derive(Debug, Clone)]
+pub struct PrimaryPosterOverride {
+    pub url: String,
+    pub fallback_url: Option<String>,
+    /// True when the effective poster depends on the authenticated user's local state.
+    pub private_cache: bool,
+}
+
 #[async_trait]
 pub trait MetaAddon: Send + Sync {
     async fn supports(&self, media: &db::Media) -> bool;
@@ -753,6 +762,16 @@ pub trait MetaAddon: Send + Sync {
         ctx: &AppContext,
     ) -> Result<Vec<crate::api::RemoteImageInfo>> {
         Ok(vec![])
+    }
+    /// Return an effective primary poster without mutating persisted media artwork.
+    /// The image API consults this before the stored Primary/Thumb image.
+    async fn primary_poster_override(
+        &self,
+        _media: &db::Media,
+        _ctx: &AppContext,
+        _user: Option<&db::User>,
+    ) -> Result<Option<PrimaryPosterOverride>> {
+        Ok(None)
     }
 }
 
@@ -2451,6 +2470,35 @@ impl AddonService {
             }
         }
         Ok(out)
+    }
+
+    #[tracing::instrument(skip_all, fields(title = %media.title, kind = %media.kind))]
+    pub async fn primary_poster_override(
+        &self,
+        media: &db::Media,
+        ctx: &AppContext,
+        user: Option<&db::User>,
+    ) -> Option<PrimaryPosterOverride> {
+        let addons = self
+            .addons_for::<dyn MetaAddon>(media, &ctx.db, None)
+            .await;
+
+        for r in addons {
+            match r
+                .meta
+                .as_ref()
+                .unwrap()
+                .primary_poster_override(media, ctx, user)
+                .await
+            {
+                Ok(Some(poster)) => return Some(poster),
+                Ok(None) => {}
+                Err(e) => {
+                    warn!(addon = %r.row.name, error = %e, "primary_poster_override failed")
+                }
+            }
+        }
+        None
     }
 
     #[tracing::instrument(skip_all, fields(title = %media.title, kind = %media.kind))]

--- a/crates/remux-server/src/addons/tmdb.rs
+++ b/crates/remux-server/src/addons/tmdb.rs
@@ -780,6 +780,15 @@ async fn tmdb_client_from_ctx(
     Ok(client)
 }
 
+pub(crate) async fn resolve_imdb_from_ctx(
+    ids: &db::ExternalIds,
+    is_tv: bool,
+    ctx: &AppContext,
+) -> Result<Option<db::NonEmptyString>> {
+    let client = tmdb_client_from_ctx(ctx).await?;
+    Ok(resolve_imdb_from_ids(ids, is_tv, &client).await)
+}
+
 async fn tmdb_series_seasons(
     series: &db::Media,
     ctx: &AppContext,

--- a/crates/remux-server/src/api/images.rs
+++ b/crates/remux-server/src/api/images.rs
@@ -57,7 +57,8 @@ async fn items_images_inner(
     id: Uuid,
     image_type: api::ImageType,
     q: api::ImageQuery,
-) -> Result<impl IntoResponse> {
+    user: Option<&db::User>,
+) -> Result<axum::response::Response> {
     let opts = ImageProcessOptions {
         fill_width: q.fill_width,
         fill_height: q.fill_height,
@@ -74,6 +75,65 @@ async fn items_images_inner(
             .format
             .clone(),
     };
+
+    let explicit_remote = q
+        .tag
+        .as_ref()
+        .is_some_and(|tag| tag.contains("://"));
+    if !explicit_remote
+        && matches!(image_type, api::ImageType::Primary | api::ImageType::Thumb)
+    {
+        let media = match db::Media::get_by_id(
+            &state
+                .ctx
+                .db,
+            &id,
+        )
+        .await?
+        {
+            Some(media) => Some(std::sync::Arc::new(media)),
+            None => state
+                .ctx
+                .store
+                .get::<db::Media>(id.to_string()),
+        };
+
+        if let Some(media) = media {
+            if let Some(poster) = state
+                .ctx
+                .addons
+                .primary_poster_override(&media, &state.ctx, user)
+                .await
+            {
+                for url in std::iter::once(&poster.url).chain(
+                    poster
+                        .fallback_url
+                        .iter(),
+                ) {
+                    match fetch_upstream(url).await {
+                        Ok((bytes, content_type)) => {
+                            let cache_control = if poster.private_cache {
+                                "private, max-age=300"
+                            } else {
+                                "max-age=86400"
+                            };
+                            return Ok((
+                                [
+                                    (header::CONTENT_TYPE, content_type),
+                                    (header::CACHE_CONTROL, cache_control.to_string()),
+                                ],
+                                bytes,
+                            )
+                                .into_response());
+                        }
+                        Err(error) => {
+                            tracing::warn!(%error, %url, "effective primary poster override failed");
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     // Resolve to (raw_bytes, content_type, source_key_for_cache, is_remote).
     // is_remote=true means the bytes came from an external URL and must not be
@@ -315,19 +375,39 @@ pub async fn get_item_image_infos(
 #[get("/items/{id}/images/{image_type}")]
 pub async fn items_images(
     State(state): State<AppState>,
+    auth::OptionalAuthSession(session): auth::OptionalAuthSession,
     Path((id, image_type)): Path<(Uuid, api::ImageType)>,
     Query(q): Query<api::ImageQuery>,
 ) -> Result<impl IntoResponse> {
-    items_images_inner(state, id, image_type, q).await
+    items_images_inner(
+        state,
+        id,
+        image_type,
+        q,
+        session
+            .as_ref()
+            .map(|s| &s.user),
+    )
+    .await
 }
 
 #[get("/items/{id}/images/{image_type}/{index}")]
 pub async fn items_images_indexed(
     State(state): State<AppState>,
+    auth::OptionalAuthSession(session): auth::OptionalAuthSession,
     Path((id, image_type, _index)): Path<(Uuid, api::ImageType, usize)>,
     Query(q): Query<api::ImageQuery>,
 ) -> Result<impl IntoResponse> {
-    items_images_inner(state, id, image_type, q).await
+    items_images_inner(
+        state,
+        id,
+        image_type,
+        q,
+        session
+            .as_ref()
+            .map(|s| &s.user),
+    )
+    .await
 }
 
 // --- POST (upload) ---

--- a/crates/remux-server/src/api/models.rs
+++ b/crates/remux-server/src/api/models.rs
@@ -249,6 +249,28 @@ fn media_image_tag(media: &db::Media, kind: db::ImageKind) -> Option<String> {
         })
 }
 
+fn effective_primary_image_tag(media: &db::Media) -> Option<String> {
+    let base = media_image_tag(media, db::ImageKind::Primary)?;
+    let config_revision = crate::addons::better_posters::config_revision();
+    match media.kind {
+        db::MediaKind::Movie => {
+            let watched = media
+                .user_state
+                .as_ref()
+                .is_some_and(|state| state.play_count > 0);
+            Some(format!(
+                "{base}-bp{config_revision:016x}-state-{}",
+                if watched { "w" } else { "u" }
+            ))
+        }
+        db::MediaKind::Series => Some(format!(
+            "{base}-bp{config_revision:016x}-state-u{}",
+            media.unplayed_item_count.unwrap_or(-1)
+        )),
+        _ => Some(base),
+    }
+}
+
 fn parent_image_tag(parent: Option<&db::Media>, kind: db::ImageKind) -> Option<String> {
     parent?
         .images
@@ -442,7 +464,7 @@ pub fn db_media_to_item(media: db::Media, hide_sources: bool) -> BaseItemDto {
             .clone(),
         parent_index_number: media.parent_idx,
         image_tags: Some(ImageTags {
-            primary: media_image_tag(&media, db::ImageKind::Primary).or_else(|| {
+            primary: effective_primary_image_tag(&media).or_else(|| {
                 if media.kind == db::MediaKind::Track {
                     // Tracks inherit album art when they have no dedicated cover.
                     parent_image_tag(

--- a/crates/remux-server/src/db/auth.rs
+++ b/crates/remux-server/src/db/auth.rs
@@ -385,6 +385,24 @@ pub struct AuthSession {
     pub user: db::User,
 }
 
+#[derive(Clone, Default)]
+pub struct OptionalAuthSession(pub Option<AuthSession>);
+
+impl FromRequestParts<AppState> for OptionalAuthSession {
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        Ok(Self(
+            AuthSession::from_request_parts(parts, state)
+                .await
+                .ok(),
+        ))
+    }
+}
+
 //#[async_trait]
 impl FromRequestParts<AppState> for AuthSession {
     type Rejection = ApiError;


### PR DESCRIPTION
### **Summary**

Adds BetterPosters as a native Remux addon and makes it available as the effective poster provider for movies and series.

The integration is designed to work across normal library browsing and search results rather than only exposing BetterPosters through the manual image picker.

### **What changed**
Added a native BetterPosters addon under the existing Remux addon system.
Added configuration for BetterPosters poster options, including:
trend tags
quality tags
genre
rating
rating source
age rating
watch progress
language
BetterPosters posters are resolved at image request time instead of replacing the original stored artwork.
Original artwork remains available as a fallback if BetterPosters cannot return an image.
Remote search results are supported as well as media already stored in the library.
Reuses Remux's existing TMDB/IMDb resolution where an IMDb ID is not already available.
Added optional authenticated image requests so poster generation can use the requesting Jellyfin user's local playback state.
Local watch state is used for watched/progress poster variants instead of requiring Trakt or PublicMetaDB.
Primary image tags include BetterPosters configuration/watch state so Jellyfin clients request updated artwork when poster settings or playback state change.
User-specific posters use private caching to avoid sharing watch-state artwork between users.

### **Implementation notes**

The BetterPosters addon does not overwrite the media's primary image in the database.

Instead, the image endpoint resolves an effective poster when a client requests Primary or Thumb artwork:

Resolve the media from the database or Remux's cached search results.
Resolve an IMDb ID, using the existing TMDB mapping when needed.
Build the BetterPosters URL from the addon configuration.
Include local user watch state when watch-progress overlays are enabled.
Proxy the resulting image through Remux.
Fall back to the existing Remux artwork path if BetterPosters is unavailable.

Keeping this at image-request time means disabling the addon immediately restores the original artwork and avoids permanently modifying library metadata.

The image cache tag is also derived from the relevant BetterPosters settings and local watch state. This is needed because Jellyfin clients cache posters by ImageTag; without changing the tag, toggling an overlay or changing watched state can leave an older generated poster visible.

### **Testing**

Tested with:

cargo fmt --all
cargo check -p remux-server

I also built and ran the modified server in Docker and verified BetterPosters artwork is returned through the Jellyfin UI while changing addon configuration.

### **AI disclosure**

AI was used to help research the Remux addon/image paths and draft parts of the initial implementation. I reviewed and edited the resulting code, compiled and tested it against my Remux checkout, and worked through the integration and runtime issues before submitting this PR.
<img width="330" height="717" alt="image" src="https://github.com/user-attachments/assets/9810e5dc-f00d-439f-a187-7a8b0ba8e06c" /> <img width="330" height="717" alt="image" src="https://github.com/user-attachments/assets/8715b922-6859-4128-8f05-be7005afd217" />
