### PR TITLE
fix: include filename stem in PlaybackInfo MediaSource path

### DIFF
--- a/crates/remux-server/src/services/stream_service.rs
+++ b/crates/remux-server/src/services/stream_service.rs
@@ -546,7 +546,22 @@ impl StreamService {
             source.e_tag = cid;
             source.name = Some(name);
             source.has_segments = true;
-            source.path = Some(format!("/remux/{}", effective_stream.id));
+            // Include the release filename's stem when available (same
+            // convention as MediaSourceInfo::from(db::Media) in
+            // conversions.rs) so clients that surface `Path` as a display
+            // field show the real release name instead of a bare UUID.
+            // This path previously always dropped it, even when the addon
+            // supplied behaviorHints.filename and it was sitting right
+            // there in effective_stream.stream_info.
+            let stem = effective_stream
+                .stream_info
+                .as_ref()
+                .and_then(|si| si.filename.as_deref())
+                .and_then(|f| std::path::Path::new(f).file_stem().and_then(|s| s.to_str()));
+            source.path = Some(match stem {
+                Some(s) => format!("/remux/{}/{}", effective_stream.id, s),
+                None => format!("/remux/{}", effective_stream.id),
+            });
             source.is_remote = false;
             // Re-apply binge-group headers — ffmpeg probing produces a fresh
             // MediaSourceInfo and would otherwise drop provider hints.


### PR DESCRIPTION
\`StreamService::build\` unconditionally overwrote \`source.path\` with the bare \`/remux/{id}\` after ffmpeg probing, discarding the filename stem that \`MediaSourceInfo::from(db::Media)\` (\`conversions.rs\`) already includes when available.

Any Jellyfin-protocol client that surfaces \`MediaSource.Path\` as a display field shows a raw UUID instead of the release name, with no way to distinguish same-resolution candidates from different releases/groups.

Fix: reuse the existing filename-stem logic from \`conversions.rs\` when rebuilding \`source.path\` post-probe.

---
Written with AI assistance (Claude Sonnet 5, Anthropic).