### PR TITLE
feat: drag and drop polish

### DIFF
--- a/crates/remux-dashboard/src/components/drag_and_drop_list/component.rs
+++ b/crates/remux-dashboard/src/components/drag_and_drop_list/component.rs
@@ -5,6 +5,9 @@ use dioxus_primitives::drag_and_drop_list::{
     DragAndDropListItemProps, DragAndDropListItemsProps,
 };
 
+const AUTO_SCROLL_EDGE_PX: f64 = 96.0;
+const AUTO_SCROLL_MAX_STEP_PX: f64 = 12.0;
+
 #[css_module("/src/components/drag_and_drop_list/style.css")]
 struct Styles;
 
@@ -86,21 +89,35 @@ pub fn DragAndDropList(props: DragAndDropListProps) -> Element {
         .collect();
 
     rsx! {
-        drag_and_drop_list::DragAndDropList {
-            class: Styles::dx_dnd_list,
-            items,
-            aria_label: props.aria_label,
-            attributes: props.attributes,
-            drag_and_drop_list::DragAndDropInstructions {}
-            DragAndDropListItems {
-                aria_label,
+        div {
+            ondrag: auto_scroll_page,
+            drag_and_drop_list::DragAndDropList {
+                class: Styles::dx_dnd_list,
+                items,
+                aria_label: props.aria_label,
+                attributes: props.attributes,
+                drag_and_drop_list::DragAndDropInstructions {}
+                DragAndDropListItems {
+                    aria_label,
+                }
+                drag_and_drop_list::DragAndDropLiveRegion {}
+                if let Some(on_reorder) = props.on_reorder {
+                    ReorderObserver { on_reorder }
+                }
+                {props.children}
             }
-            drag_and_drop_list::DragAndDropLiveRegion {}
-            if let Some(on_reorder) = props.on_reorder {
-                ReorderObserver { on_reorder }
-            }
-            {props.children}
         }
+    }
+}
+
+fn edge_scroll_delta(cursor_y: f64, viewport_height: f64) -> f64 {
+    if cursor_y < AUTO_SCROLL_EDGE_PX {
+        -AUTO_SCROLL_MAX_STEP_PX * (1.0 - cursor_y.max(0.0) / AUTO_SCROLL_EDGE_PX)
+    } else if cursor_y > viewport_height - AUTO_SCROLL_EDGE_PX {
+        AUTO_SCROLL_MAX_STEP_PX
+            * (1.0 - (viewport_height - cursor_y).max(0.0) / AUTO_SCROLL_EDGE_PX)
+    } else {
+        0.0
     }
 }
 
@@ -148,6 +165,27 @@ pub fn DragAndDropListItems(props: DragAndDropListItemsProps) -> Element {
     }
 }
 
+fn auto_scroll_page(event: DragEvent) {
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let Some(viewport_height) = window
+        .inner_height()
+        .ok()
+        .and_then(|height| height.as_f64())
+    else {
+        return;
+    };
+
+    let cursor_y = event
+        .client_coordinates()
+        .y;
+    let scroll_delta = edge_scroll_delta(cursor_y, viewport_height);
+    if scroll_delta != 0.0 {
+        window.scroll_by_with_x_and_y(0.0, scroll_delta);
+    }
+}
+
 #[component]
 pub fn DragAndDropDropIndicator(props: DragAndDropDropIndicatorProps) -> Element {
     rsx! {
@@ -168,6 +206,24 @@ fn DragIcon() -> Element {
             "aria-hidden": "true",
             size: "16px",
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scrolls_toward_viewport_edges() {
+        assert_eq!(edge_scroll_delta(0.0, 800.0), -AUTO_SCROLL_MAX_STEP_PX);
+        assert_eq!(edge_scroll_delta(400.0, 800.0), 0.0);
+        assert_eq!(edge_scroll_delta(800.0, 800.0), AUTO_SCROLL_MAX_STEP_PX);
+    }
+
+    #[test]
+    fn scroll_speed_increases_nearer_the_edge() {
+        assert!(edge_scroll_delta(20.0, 800.0) < edge_scroll_delta(80.0, 800.0));
+        assert!(edge_scroll_delta(780.0, 800.0) > edge_scroll_delta(720.0, 800.0));
     }
 }
 

--- a/crates/remux-dashboard/src/components/drag_and_drop_list/component.rs
+++ b/crates/remux-dashboard/src/components/drag_and_drop_list/component.rs
@@ -2,7 +2,7 @@ use dioxus::prelude::*;
 use dioxus_icons::lucide::{GripVertical, X};
 use dioxus_primitives::drag_and_drop_list::{
     self, DragAndDropContext, DragAndDropDropIndicatorProps, DragAndDropItemContext,
-    DragAndDropListItemProps, DragAndDropListItemsProps,
+    DragAndDropListItemProps,
 };
 
 const AUTO_SCROLL_EDGE_PX: f64 = 96.0;
@@ -19,6 +19,10 @@ pub struct DragAndDropListProps {
     /// Set if the list items should be removable
     #[props(default)]
     pub is_removable: bool,
+
+    /// Whether the list can currently be reordered.
+    #[props(default = true)]
+    pub interactive: bool,
 
     /// Accessible label for the list
     #[props(default)]
@@ -59,6 +63,7 @@ fn ReorderObserver(on_reorder: EventHandler<Vec<String>>) -> Element {
 #[component]
 pub fn DragAndDropList(props: DragAndDropListProps) -> Element {
     let is_removable = props.is_removable;
+    let interactive = props.interactive;
     let aria_label = props
         .aria_label
         .clone()
@@ -90,6 +95,13 @@ pub fn DragAndDropList(props: DragAndDropListProps) -> Element {
 
     rsx! {
         div {
+            class: if interactive {
+                String::new()
+            } else {
+                Styles::dx_dnd_list_locked.to_string()
+            },
+            inert: (!interactive).then_some("true"),
+            aria_busy: if interactive { "false" } else { "true" },
             ondrag: auto_scroll_page,
             drag_and_drop_list::DragAndDropList {
                 class: Styles::dx_dnd_list,
@@ -99,6 +111,7 @@ pub fn DragAndDropList(props: DragAndDropListProps) -> Element {
                 drag_and_drop_list::DragAndDropInstructions {}
                 DragAndDropListItems {
                     aria_label,
+                    interactive,
                 }
                 drag_and_drop_list::DragAndDropLiveRegion {}
                 if let Some(on_reorder) = props.on_reorder {
@@ -136,28 +149,39 @@ pub fn DragAndDropListItem(props: DragAndDropListItemProps) -> Element {
     }
 }
 
+#[derive(Props, Clone, PartialEq)]
+struct LocalDragAndDropListItemsProps {
+    aria_label: String,
+    #[props(default = true)]
+    interactive: bool,
+}
+
 #[component]
-pub fn DragAndDropListItems(props: DragAndDropListItemsProps) -> Element {
+fn DragAndDropListItems(props: LocalDragAndDropListItemsProps) -> Element {
+    let interactive = props.interactive;
     rsx! {
         drag_and_drop_list::DragAndDropListItems {
             class: Styles::dx_dnd_list_ul,
             aria_label: props.aria_label,
-            attributes: props.attributes,
             for item in drag_and_drop_list::use_drag_and_drop_list_items() {
                 Fragment {
                     key: "{item.key}",
-                    DragAndDropDropIndicator {
-                        index: item.index,
-                        position: "before",
+                    if interactive {
+                        DragAndDropDropIndicator {
+                            index: item.index,
+                            position: "before",
+                        }
                     }
                     DragAndDropListItem {
                         index: item.index,
                         item_key: item.key.clone(),
                         {item.children}
                     }
-                    DragAndDropDropIndicator {
-                        index: item.index,
-                        position: "after",
+                    if interactive {
+                        DragAndDropDropIndicator {
+                            index: item.index,
+                            position: "after",
+                        }
                     }
                 }
             }

--- a/crates/remux-dashboard/src/components/drag_and_drop_list/component.rs
+++ b/crates/remux-dashboard/src/components/drag_and_drop_list/component.rs
@@ -2,7 +2,7 @@ use dioxus::prelude::*;
 use dioxus_icons::lucide::{GripVertical, X};
 use dioxus_primitives::drag_and_drop_list::{
     self, DragAndDropContext, DragAndDropDropIndicatorProps, DragAndDropItemContext,
-    DragAndDropListItemProps,
+    DragAndDropListItemProps, DragAndDropListItemsProps,
 };
 
 const AUTO_SCROLL_EDGE_PX: f64 = 96.0;
@@ -19,10 +19,6 @@ pub struct DragAndDropListProps {
     /// Set if the list items should be removable
     #[props(default)]
     pub is_removable: bool,
-
-    /// Whether the list can currently be reordered.
-    #[props(default = true)]
-    pub interactive: bool,
 
     /// Accessible label for the list
     #[props(default)]
@@ -63,7 +59,6 @@ fn ReorderObserver(on_reorder: EventHandler<Vec<String>>) -> Element {
 #[component]
 pub fn DragAndDropList(props: DragAndDropListProps) -> Element {
     let is_removable = props.is_removable;
-    let interactive = props.interactive;
     let aria_label = props
         .aria_label
         .clone()
@@ -95,13 +90,6 @@ pub fn DragAndDropList(props: DragAndDropListProps) -> Element {
 
     rsx! {
         div {
-            class: if interactive {
-                String::new()
-            } else {
-                Styles::dx_dnd_list_locked.to_string()
-            },
-            inert: (!interactive).then_some("true"),
-            aria_busy: if interactive { "false" } else { "true" },
             ondrag: auto_scroll_page,
             drag_and_drop_list::DragAndDropList {
                 class: Styles::dx_dnd_list,
@@ -111,7 +99,6 @@ pub fn DragAndDropList(props: DragAndDropListProps) -> Element {
                 drag_and_drop_list::DragAndDropInstructions {}
                 DragAndDropListItems {
                     aria_label,
-                    interactive,
                 }
                 drag_and_drop_list::DragAndDropLiveRegion {}
                 if let Some(on_reorder) = props.on_reorder {
@@ -149,39 +136,28 @@ pub fn DragAndDropListItem(props: DragAndDropListItemProps) -> Element {
     }
 }
 
-#[derive(Props, Clone, PartialEq)]
-struct LocalDragAndDropListItemsProps {
-    aria_label: String,
-    #[props(default = true)]
-    interactive: bool,
-}
-
 #[component]
-fn DragAndDropListItems(props: LocalDragAndDropListItemsProps) -> Element {
-    let interactive = props.interactive;
+pub fn DragAndDropListItems(props: DragAndDropListItemsProps) -> Element {
     rsx! {
         drag_and_drop_list::DragAndDropListItems {
             class: Styles::dx_dnd_list_ul,
             aria_label: props.aria_label,
+            attributes: props.attributes,
             for item in drag_and_drop_list::use_drag_and_drop_list_items() {
                 Fragment {
                     key: "{item.key}",
-                    if interactive {
-                        DragAndDropDropIndicator {
-                            index: item.index,
-                            position: "before",
-                        }
+                    DragAndDropDropIndicator {
+                        index: item.index,
+                        position: "before",
                     }
                     DragAndDropListItem {
                         index: item.index,
                         item_key: item.key.clone(),
                         {item.children}
                     }
-                    if interactive {
-                        DragAndDropDropIndicator {
-                            index: item.index,
-                            position: "after",
-                        }
+                    DragAndDropDropIndicator {
+                        index: item.index,
+                        position: "after",
                     }
                 }
             }

--- a/crates/remux-dashboard/src/components/drag_and_drop_list/style.css
+++ b/crates/remux-dashboard/src/components/drag_and_drop_list/style.css
@@ -4,6 +4,16 @@
   width: 100%;
 }
 
+.dx-dnd-list-locked {
+  opacity: 0.5;
+  cursor: wait;
+  pointer-events: none;
+}
+
+.dx-dnd-list-locked .dx-dnd-list-item {
+  cursor: wait;
+}
+
 .dx-dnd-list-ul {
   display: flex;
   flex-direction: column;
@@ -50,10 +60,15 @@
   .dx-dnd-list-item:hover {
     /* --gap-shift: -1px; */
 
-    background-color: rgba(0,0,0,0.03);
+    background-color: rgb(0 0 0 / 3%);
     box-shadow:
       0 1px 2px rgb(0 0 0 / 4%),
       0 3px 8px rgb(0 0 0 / 4%);
+  }
+
+  .dx-dnd-list-locked .dx-dnd-list-item:hover {
+    background-color: transparent;
+    box-shadow: none;
   }
 
   .dx-dnd-list-item:active {

--- a/crates/remux-dashboard/src/components/drag_and_drop_list/style.css
+++ b/crates/remux-dashboard/src/components/drag_and_drop_list/style.css
@@ -4,16 +4,6 @@
   width: 100%;
 }
 
-.dx-dnd-list-locked {
-  opacity: 0.5;
-  cursor: wait;
-  pointer-events: none;
-}
-
-.dx-dnd-list-locked .dx-dnd-list-item {
-  cursor: wait;
-}
-
 .dx-dnd-list-ul {
   display: flex;
   flex-direction: column;
@@ -60,15 +50,10 @@
   .dx-dnd-list-item:hover {
     /* --gap-shift: -1px; */
 
-    background-color: rgb(0 0 0 / 3%);
+    background-color: rgba(0,0,0,0.03);
     box-shadow:
       0 1px 2px rgb(0 0 0 / 4%),
       0 3px 8px rgb(0 0 0 / 4%);
-  }
-
-  .dx-dnd-list-locked .dx-dnd-list-item:hover {
-    background-color: transparent;
-    box-shadow: none;
   }
 
   .dx-dnd-list-item:active {

--- a/crates/remux-dashboard/src/pages/addons.rs
+++ b/crates/remux-dashboard/src/pages/addons.rs
@@ -292,6 +292,7 @@ pub fn AddonsPage(app_state: AppState) -> Element {
                                             .collect();
                                         let client = client.clone();
                                         spawn(async move {
+                                            loading.set(true);
                                             for (id, priority) in updates {
                                                 let _ = client.execute(UpdateAddon {
                                                     id,
@@ -301,6 +302,8 @@ pub fn AddonsPage(app_state: AppState) -> Element {
                                                     },
                                                 }).await;
                                             }
+                                            loading.set(false);
+
                                             let value = *refresh.peek() + 1;
                                             refresh.set(value);
                                         });

--- a/crates/remux-dashboard/src/pages/addons.rs
+++ b/crates/remux-dashboard/src/pages/addons.rs
@@ -20,6 +20,7 @@ pub fn AddonsPage(app_state: AppState) -> Element {
     let mut addons: Signal<Vec<AddonDto>> = use_signal(Vec::new);
     let mut kinds: Signal<Vec<AddonMetadata>> = use_signal(Vec::new);
     let mut loading = use_signal(|| true);
+    let mut reordering = use_signal(|| false);
     let mut error: Signal<Option<String>> = use_signal(|| None);
     let mut refresh = use_signal(|| 0_u32);
     let mut active_tab: Signal<&'static str> = use_signal(|| "global");
@@ -279,6 +280,7 @@ pub fn AddonsPage(app_state: AppState) -> Element {
                                     key: "{list_key}",
                                     items,
                                     aria_label: "Addons",
+                                    interactive: !*reordering.read(),
                                     on_reorder: move |new_order: Vec<String>| {
                                         let updates: Vec<(Uuid, i64)> = new_order
                                             .iter()
@@ -292,7 +294,7 @@ pub fn AddonsPage(app_state: AppState) -> Element {
                                             .collect();
                                         let client = client.clone();
                                         spawn(async move {
-                                            loading.set(true);
+                                            reordering.set(true);
                                             for (id, priority) in updates {
                                                 let _ = client.execute(UpdateAddon {
                                                     id,
@@ -302,10 +304,7 @@ pub fn AddonsPage(app_state: AppState) -> Element {
                                                     },
                                                 }).await;
                                             }
-                                            loading.set(false);
-
-                                            let value = *refresh.peek() + 1;
-                                            refresh.set(value);
+                                            reordering.set(false);
                                         });
                                     },
                                 }

--- a/crates/remux-dashboard/src/pages/addons.rs
+++ b/crates/remux-dashboard/src/pages/addons.rs
@@ -18,6 +18,8 @@ use uuid::Uuid;
 #[component]
 pub fn AddonsPage(app_state: AppState) -> Element {
     let mut addons: Signal<Vec<AddonDto>> = use_signal(Vec::new);
+    let mut global_addon_order: Signal<Vec<String>> = use_signal(Vec::new);
+    let mut user_addon_order: Signal<Vec<String>> = use_signal(Vec::new);
     let mut kinds: Signal<Vec<AddonMetadata>> = use_signal(Vec::new);
     let mut loading = use_signal(|| true);
     let mut error: Signal<Option<String>> = use_signal(|| None);
@@ -78,6 +80,26 @@ pub fn AddonsPage(app_state: AppState) -> Element {
                 .await;
             match (kinds_res, addons_res) {
                 (Ok(k), Ok(a)) => {
+                    global_addon_order.set(
+                        a.iter()
+                            .filter(|addon| addon.is_default)
+                            .map(|addon| {
+                                addon
+                                    .id
+                                    .to_string()
+                            })
+                            .collect(),
+                    );
+                    user_addon_order.set(
+                        a.iter()
+                            .filter(|addon| !addon.is_default)
+                            .map(|addon| {
+                                addon
+                                    .id
+                                    .to_string()
+                            })
+                            .collect(),
+                    );
                     kinds.set(k);
                     addons.set(a);
                     error.set(None);
@@ -146,10 +168,11 @@ pub fn AddonsPage(app_state: AppState) -> Element {
                         if visible.is_empty() {
                             rsx! { EmptyState { message: "No addons configured — add one to get started." } }
                         } else {
-                            let original_priorities: HashMap<String, i64> = visible
-                                .iter()
-                                .map(|addon| (addon.id.to_string(), addon.priority))
-                                .collect();
+                            let mut addon_order = if *active_tab.read() == "global" {
+                                global_addon_order
+                            } else {
+                                user_addon_order
+                            };
                             let list_key = visible
                                 .iter()
                                 .map(|addon| addon.id.to_string())
@@ -280,16 +303,23 @@ pub fn AddonsPage(app_state: AppState) -> Element {
                                     items,
                                     aria_label: "Addons",
                                     on_reorder: move |new_order: Vec<String>| {
+                                        let previous_positions: HashMap<String, usize> = addon_order
+                                            .peek()
+                                            .iter()
+                                            .enumerate()
+                                            .map(|(index, id)| (id.clone(), index))
+                                            .collect();
                                         let updates: Vec<(Uuid, i64)> = new_order
                                             .iter()
                                             .enumerate()
                                             .filter_map(|(index, id)| {
                                                 let priority = index as i64 * 10;
-                                                (original_priorities.get(id).copied() != Some(priority))
+                                                (previous_positions.get(id).copied() != Some(index))
                                                     .then(|| id.parse().ok().map(|id| (id, priority)))
                                                     .flatten()
                                             })
                                             .collect();
+                                        addon_order.set(new_order);
                                         let client = client.clone();
                                         let mut reorder_error = error;
                                         spawn(async move {

--- a/crates/remux-dashboard/src/pages/addons.rs
+++ b/crates/remux-dashboard/src/pages/addons.rs
@@ -20,7 +20,6 @@ pub fn AddonsPage(app_state: AppState) -> Element {
     let mut addons: Signal<Vec<AddonDto>> = use_signal(Vec::new);
     let mut kinds: Signal<Vec<AddonMetadata>> = use_signal(Vec::new);
     let mut loading = use_signal(|| true);
-    let mut reordering = use_signal(|| false);
     let mut error: Signal<Option<String>> = use_signal(|| None);
     let mut refresh = use_signal(|| 0_u32);
     let mut active_tab: Signal<&'static str> = use_signal(|| "global");
@@ -280,7 +279,6 @@ pub fn AddonsPage(app_state: AppState) -> Element {
                                     key: "{list_key}",
                                     items,
                                     aria_label: "Addons",
-                                    interactive: !*reordering.read(),
                                     on_reorder: move |new_order: Vec<String>| {
                                         let updates: Vec<(Uuid, i64)> = new_order
                                             .iter()
@@ -294,7 +292,6 @@ pub fn AddonsPage(app_state: AppState) -> Element {
                                             .collect();
                                         let client = client.clone();
                                         spawn(async move {
-                                            reordering.set(true);
                                             for (id, priority) in updates {
                                                 let _ = client.execute(UpdateAddon {
                                                     id,
@@ -304,7 +301,6 @@ pub fn AddonsPage(app_state: AppState) -> Element {
                                                     },
                                                 }).await;
                                             }
-                                            reordering.set(false);
                                         });
                                     },
                                 }

--- a/crates/remux-dashboard/src/pages/addons.rs
+++ b/crates/remux-dashboard/src/pages/addons.rs
@@ -291,15 +291,24 @@ pub fn AddonsPage(app_state: AppState) -> Element {
                                             })
                                             .collect();
                                         let client = client.clone();
+                                        let mut reorder_error = error;
                                         spawn(async move {
                                             for (id, priority) in updates {
-                                                let _ = client.execute(UpdateAddon {
-                                                    id,
-                                                    payload: UpdateAddonRequest {
-                                                        priority: Some(priority),
-                                                        ..Default::default()
-                                                    },
-                                                }).await;
+                                                if let Err(e) = client
+                                                    .execute(UpdateAddon {
+                                                        id,
+                                                        payload: UpdateAddonRequest {
+                                                            priority: Some(priority),
+                                                            ..Default::default()
+                                                        },
+                                                    })
+                                                    .await
+                                                {
+                                                    reorder_error.set(Some(format!(
+                                                        "Failed to update addon order: {e}"
+                                                    )));
+                                                    return;
+                                                }
                                             }
                                         });
                                     },

--- a/crates/remux-dashboard/src/pages/collections.rs
+++ b/crates/remux-dashboard/src/pages/collections.rs
@@ -193,6 +193,7 @@ pub fn CollectionsPage(app_state: AppState) -> Element {
                                         let app_state = app_state_reorder.clone();
 
                                         spawn(async move {
+                                            loading.set(true);
                                             for (id, so) in updates {
                                                 let _ = app_state.execute(PatchItem {
                                                     item_id: id,
@@ -202,6 +203,7 @@ pub fn CollectionsPage(app_state: AppState) -> Element {
                                                     },
                                                 }).await;
                                             }
+                                            loading.set(false);
 
                                             let v = *refresh.peek() + 1;
                                             refresh.set(v);

--- a/crates/remux-dashboard/src/pages/collections.rs
+++ b/crates/remux-dashboard/src/pages/collections.rs
@@ -41,6 +41,7 @@ impl PartialEq for FormMode {
 #[component]
 pub fn CollectionsPage(app_state: AppState) -> Element {
     let mut collections: Signal<Vec<BaseItemDto>> = use_signal(Vec::new);
+    let mut collection_order: Signal<Vec<String>> = use_signal(Vec::new);
     let mut loading = use_signal(|| true);
     let mut error = use_signal(|| Option::<String>::None);
     let mut refresh = use_signal(|| 0_u32);
@@ -63,6 +64,16 @@ pub fn CollectionsPage(app_state: AppState) -> Element {
                 .await
             {
                 Ok(result) => {
+                    collection_order.set(
+                        result
+                            .items
+                            .iter()
+                            .map(|item| {
+                                item.id
+                                    .to_string()
+                            })
+                            .collect(),
+                    );
                     collections.set(result.items);
                     error.set(None);
                 }
@@ -97,10 +108,6 @@ pub fn CollectionsPage(app_state: AppState) -> Element {
                             let original_order: Vec<String> = collection_items
                                 .iter()
                                 .map(|col| col.id.to_string())
-                                .collect();
-                            let original_sort_orders: HashMap<String, Option<i64>> = collection_items
-                                .iter()
-                                .map(|col| (col.id.to_string(), col.index_number))
                                 .collect();
                             let list_key = original_order.join(":");
                             let items: Vec<Element> = collection_items
@@ -176,19 +183,22 @@ pub fn CollectionsPage(app_state: AppState) -> Element {
                                     items,
                                     aria_label: "Collections",
                                     on_reorder: move |new_order: Vec<String>| {
+                                        let previous_positions: HashMap<String, usize> = collection_order
+                                            .peek()
+                                            .iter()
+                                            .enumerate()
+                                            .map(|(index, id)| (id.clone(), index))
+                                            .collect();
                                         let updates: Vec<(String, i64)> = new_order
                                             .iter()
                                             .enumerate()
-                                            .filter_map(|(i, id)| {
-                                                let new_so = i as i64 * 10;
-
-                                                if original_sort_orders.get(id).copied().flatten() != Some(new_so) {
-                                                    Some((id.clone(), new_so))
-                                                } else {
-                                                    None
-                                                }
+                                            .filter_map(|(index, id)| {
+                                                (previous_positions.get(id).copied() != Some(index))
+                                                    .then(|| (id.clone(), index as i64 * 10))
                                             })
                                             .collect();
+
+                                        collection_order.set(new_order);
 
                                         let app_state = app_state_reorder.clone();
                                         let mut reorder_error = error;

--- a/crates/remux-dashboard/src/pages/collections.rs
+++ b/crates/remux-dashboard/src/pages/collections.rs
@@ -191,16 +191,25 @@ pub fn CollectionsPage(app_state: AppState) -> Element {
                                             .collect();
 
                                         let app_state = app_state_reorder.clone();
+                                        let mut reorder_error = error;
 
                                         spawn(async move {
                                             for (id, so) in updates {
-                                                let _ = app_state.execute(PatchItem {
-                                                    item_id: id,
-                                                    payload: PatchItemPayload {
-                                                        sort_order: Some(so),
-                                                        ..Default::default()
-                                                    },
-                                                }).await;
+                                                if let Err(e) = app_state
+                                                    .execute(PatchItem {
+                                                        item_id: id,
+                                                        payload: PatchItemPayload {
+                                                            sort_order: Some(so),
+                                                            ..Default::default()
+                                                        },
+                                                    })
+                                                    .await
+                                                {
+                                                    reorder_error.set(Some(format!(
+                                                        "Failed to update collection order: {e}"
+                                                    )));
+                                                    return;
+                                                }
                                             }
                                         });
                                     },

--- a/crates/remux-dashboard/src/pages/collections.rs
+++ b/crates/remux-dashboard/src/pages/collections.rs
@@ -42,7 +42,6 @@ impl PartialEq for FormMode {
 pub fn CollectionsPage(app_state: AppState) -> Element {
     let mut collections: Signal<Vec<BaseItemDto>> = use_signal(Vec::new);
     let mut loading = use_signal(|| true);
-    let mut reordering = use_signal(|| false);
     let mut error = use_signal(|| Option::<String>::None);
     let mut refresh = use_signal(|| 0_u32);
     let mut form_mode: Signal<Option<FormMode>> = use_signal(|| None);
@@ -176,7 +175,6 @@ pub fn CollectionsPage(app_state: AppState) -> Element {
                                     key: "{list_key}",
                                     items,
                                     aria_label: "Collections",
-                                    interactive: !*reordering.read(),
                                     on_reorder: move |new_order: Vec<String>| {
                                         let updates: Vec<(String, i64)> = new_order
                                             .iter()
@@ -195,7 +193,6 @@ pub fn CollectionsPage(app_state: AppState) -> Element {
                                         let app_state = app_state_reorder.clone();
 
                                         spawn(async move {
-                                            reordering.set(true);
                                             for (id, so) in updates {
                                                 let _ = app_state.execute(PatchItem {
                                                     item_id: id,
@@ -205,7 +202,6 @@ pub fn CollectionsPage(app_state: AppState) -> Element {
                                                     },
                                                 }).await;
                                             }
-                                            reordering.set(false);
                                         });
                                     },
                                 }

--- a/crates/remux-dashboard/src/pages/collections.rs
+++ b/crates/remux-dashboard/src/pages/collections.rs
@@ -42,6 +42,7 @@ impl PartialEq for FormMode {
 pub fn CollectionsPage(app_state: AppState) -> Element {
     let mut collections: Signal<Vec<BaseItemDto>> = use_signal(Vec::new);
     let mut loading = use_signal(|| true);
+    let mut reordering = use_signal(|| false);
     let mut error = use_signal(|| Option::<String>::None);
     let mut refresh = use_signal(|| 0_u32);
     let mut form_mode: Signal<Option<FormMode>> = use_signal(|| None);
@@ -175,6 +176,7 @@ pub fn CollectionsPage(app_state: AppState) -> Element {
                                     key: "{list_key}",
                                     items,
                                     aria_label: "Collections",
+                                    interactive: !*reordering.read(),
                                     on_reorder: move |new_order: Vec<String>| {
                                         let updates: Vec<(String, i64)> = new_order
                                             .iter()
@@ -193,7 +195,7 @@ pub fn CollectionsPage(app_state: AppState) -> Element {
                                         let app_state = app_state_reorder.clone();
 
                                         spawn(async move {
-                                            loading.set(true);
+                                            reordering.set(true);
                                             for (id, so) in updates {
                                                 let _ = app_state.execute(PatchItem {
                                                     item_id: id,
@@ -203,10 +205,7 @@ pub fn CollectionsPage(app_state: AppState) -> Element {
                                                     },
                                                 }).await;
                                             }
-                                            loading.set(false);
-
-                                            let v = *refresh.peek() + 1;
-                                            refresh.set(v);
+                                            reordering.set(false);
                                         });
                                     },
                                 }


### PR DESCRIPTION
- feat(dashboard): auto-scroll page while dragging list items
  - Near the edge of the top or bottom of the page. Especially helpful on long lists of collections.
- fix(dashboard): show loading state after reordering addons and collections
  - Previously (if the update was slow) you could continue to re-order items and then suddenly the page refresh would cut you short
  
Disclosure: Codex helped me create the edge scroll solution on drag.