### PR TITLE
fix(playback): avoid forcing transcode for direct-playable containers

### DIFF
--- a/crates/remux-server/src/device_profile.rs
+++ b/crates/remux-server/src/device_profile.rs
@@ -128,7 +128,6 @@ impl DeviceProfileExt for DeviceProfile {
         });
 
         check_codec_profiles(self, media_source, &mut reasons);
-        check_subtitle_codec(self, media_source, &mut reasons);
 
         reasons
     }
@@ -175,59 +174,6 @@ fn check_codec_profiles(
             }
             _ => {}
         }
-    }
-}
-
-fn check_subtitle_codec(
-    profile: &DeviceProfile,
-    media_source: &MediaSourceInfo,
-    reasons: &mut TranscodeReasons,
-) {
-    let sub_idx = match media_source.default_subtitle_stream_index {
-        Some(idx) => idx,
-        None => return,
-    };
-    let sub_stream = media_source
-        .media_streams
-        .iter()
-        .find(|s| {
-            s.index == sub_idx && matches!(s.type_, Some(MediaStreamType::Subtitle))
-        });
-    let sub_codec = match sub_stream.and_then(|s| {
-        s.codec
-            .as_deref()
-    }) {
-        Some(c) => c,
-        None => return,
-    };
-
-    // Drop/External/Embed are passthrough-compatible; Encode and Hls require transcoding.
-    let supported = profile
-        .subtitle_profiles
-        .iter()
-        .any(|p| {
-            let format_matches = p
-                .format
-                .as_deref()
-                .map(|f| subtitle_codec_matches_profile(sub_codec, f))
-                .unwrap_or(false);
-            if !format_matches {
-                return false;
-            }
-            matches!(
-                p.method,
-                Some(
-                    SubtitleDeliveryMethod::Drop
-                        | SubtitleDeliveryMethod::External
-                        | SubtitleDeliveryMethod::Embed
-                )
-            )
-        });
-
-    if !supported {
-        reasons.insert(TranscodeReason::SubtitleCodecNotSupported(
-            sub_codec.to_string(),
-        ));
     }
 }
 
@@ -624,6 +570,55 @@ mod tests {
                 "hdmv_pgs_subtitle".to_string()
             )),
             "alias-matched subtitle should remain direct-play eligible: {reasons:?}"
+        );
+    }
+
+    #[test]
+    fn test_direct_play_mkv_with_unsupported_embedded_subtitle_codec() {
+        // Device profile only supports VTT subtitles (like Roku without direct PGS)
+        let profile = DeviceProfile {
+            direct_play_profiles: vec![DirectPlayProfile {
+                container: Some(vec![VideoContainer::Mkv]),
+                video_codec: Some(vec![VideoCodec::H264]),
+                audio_codec: Some(vec![AudioCodec::Aac]),
+                type_: Some(DlnaProfileType::Video),
+            }],
+            subtitle_profiles: vec![SubtitleProfile {
+                format: Some("vtt".to_string()),
+                method: Some(SubtitleDeliveryMethod::External),
+            }],
+            ..Default::default()
+        };
+        let media_source = MediaSourceInfo {
+            container: Some("mkv".to_string()),
+            default_subtitle_stream_index: Some(2),
+            media_streams: vec![
+                MediaStream {
+                    codec: Some("h264".to_string()),
+                    type_: Some(MediaStreamType::Video),
+                    index: 0,
+                    ..Default::default()
+                },
+                MediaStream {
+                    codec: Some("aac".to_string()),
+                    type_: Some(MediaStreamType::Audio),
+                    index: 1,
+                    ..Default::default()
+                },
+                MediaStream {
+                    codec: Some("hdmv_pgs_subtitle".to_string()),
+                    type_: Some(MediaStreamType::Subtitle),
+                    index: 2,
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let reasons = profile.check_direct_play(&media_source);
+        assert!(
+            reasons.is_empty(),
+            "direct play should be permitted for MKV even when embedded subtitle codec is not in profile: {reasons:?}"
         );
     }
 }

--- a/crates/remux-server/src/playback/decision.rs
+++ b/crates/remux-server/src/playback/decision.rs
@@ -795,4 +795,94 @@ mod tests {
         };
         assert_eq!(outcome.container, "ts");
     }
+
+    #[test]
+    fn test_burn_mode_transcodes_only_when_subtitle_actively_selected() {
+        let session =
+            make_session_with_policy(remux_sdks::remux::UserPolicy::default());
+        let mut source = make_video_source("mkv");
+        source.media_streams = vec![
+            api::MediaStream {
+                codec: Some("h264".to_string()),
+                type_: Some(api::MediaStreamType::Video),
+                index: 0,
+                ..Default::default()
+            },
+            api::MediaStream {
+                codec: Some("aac".to_string()),
+                type_: Some(api::MediaStreamType::Audio),
+                index: 1,
+                ..Default::default()
+            },
+            api::MediaStream {
+                codec: Some("hdmv_pgs_subtitle".to_string()),
+                type_: Some(api::MediaStreamType::Subtitle),
+                index: 2,
+                ..Default::default()
+            },
+        ];
+
+        let profile = api::DeviceProfile {
+            direct_play_profiles: vec![remux_sdks::remux::DirectPlayProfile {
+                container: Some(vec![remux_sdks::remux::VideoContainer::Mkv]),
+                video_codec: Some(vec![remux_sdks::remux::VideoCodec::H264]),
+                audio_codec: Some(vec![remux_sdks::remux::AudioCodec::Aac]),
+                type_: Some(remux_sdks::remux::DlnaProfileType::Video),
+            }],
+            subtitle_profiles: vec![remux_sdks::remux::SubtitleProfile {
+                format: Some("vtt".to_string()),
+                method: Some(remux_sdks::remux::SubtitleDeliveryMethod::External),
+            }],
+            ..Default::default()
+        };
+
+        let mut cfg = base_cfg(EncodingOptions::default());
+        cfg.device_profile = Some(profile);
+        cfg.subtitle_mode = EmbeddedSubtitleHandling::Burn;
+
+        // When NO subtitle is selected (None): DirectPlay (no transcode reasons)
+        let reasons = api::TranscodeReasons::default();
+        let query = api::PlaybackInfoQuery::default();
+        let decision =
+            build_transcode_decision(&source, &reasons, None, &query, &session, &cfg);
+        assert!(
+            matches!(decision, TranscodeDecision::DirectPlay),
+            "no subtitle selected in burn mode should remain direct play"
+        );
+
+        // When PGS subtitle (index 2) is actively selected: Transcode with video re-encoding
+        let mut burn_reasons = api::TranscodeReasons::default();
+        burn_reasons.insert(api::TranscodeReason::SubtitleCodecNotSupported(
+            "hdmv_pgs_subtitle".to_string(),
+        ));
+        let decision_sub = build_transcode_decision(
+            &source,
+            &burn_reasons,
+            Some(2),
+            &query,
+            &session,
+            &cfg,
+        );
+        match decision_sub {
+            TranscodeDecision::Transcode(outcome) => {
+                assert!(
+                    outcome
+                        .url
+                        .contains("VideoCodec=h264"),
+                    "PGS burn-in must trigger video transcoding: {}",
+                    outcome.url
+                );
+                assert!(
+                    outcome
+                        .url
+                        .contains("SubtitleMethod=Encode"),
+                    "PGS burn-in must set SubtitleMethod=Encode: {}",
+                    outcome.url
+                );
+            }
+            TranscodeDecision::DirectPlay => {
+                panic!("PGS subtitle selected in burn mode must trigger transcoding");
+            }
+        }
+    }
 }


### PR DESCRIPTION
This PR prevents direct-playable video containers (such as MKV and MP4) from being unnecessarily forced into transcoding when they contain embedded bitmap or unsupported subtitle tracks. Previously, `check_direct_play` rejected media sources whenever an embedded subtitle codec was not explicitly listed in the client device profile's subtitle profiles, triggering video transcoding even if subtitles were turned off. This check has been removed so containers direct play as intended, while preserving transcoding and burn-in behavior when an unsupported embedded subtitle is actively selected with subtitle burn mode enabled.

*Co-authored and verified with Antigravity AI assistant.*
