### PR TITLE
fix(playback): normalize copied HLS VOD audio

### DIFF
--- a/crates/remux-server/src/api/hls.rs
+++ b/crates/remux-server/src/api/hls.rs
@@ -272,7 +272,18 @@ async fn create_hls_session(
         // live channels, regardless of what the client negotiated. The
         // existing audio_channels logic (None for copy, Some(2) for transcode)
         // then kicks in automatically and produces the correct stereo downmix.
-        let audio_codec = resolve_live_audio_codec(is_live, &audio_codec);
+        let audio_codec = resolve_hls_audio_codec(
+            is_live,
+            resolved_media
+                .probe_data
+                .as_ref()
+                .and_then(|probe| {
+                    probe
+                        .container
+                        .as_deref()
+                }),
+            &audio_codec,
+        );
 
         // Live streams have no fixed duration — skip all runtime lookups.
         let runtime_ticks = if is_live {
@@ -648,14 +659,21 @@ pub async fn variant_hls_video(
     variant_hls_video_inner(state, q).await
 }
 
-/// Returns the audio codec to use for HLS transcoding.
+/// Returns the audio codec to use for browser-facing HLS transcoding.
 ///
 /// Live IPTV sources often carry LATM-encoded AAC (see the large comment block
-/// inside `create_hls_session`). When the client has negotiated `copy` for a
-/// live channel we override it to `aac` so ffmpeg re-encodes to standard ADTS
-/// stereo, which MSE-based players (Safari + hls.js) can actually decode.
-fn resolve_live_audio_codec(is_live: bool, requested: &str) -> String {
-    if is_live && requested == "copy" {
+/// inside `create_hls_session`). HLS VOD sources use the same transport and
+/// can carry that framing as well. When either path would copy audio, encode it
+/// as AAC so ffmpeg emits browser-compatible ADTS audio in the output segments.
+/// Other source containers and explicit client codec choices are unchanged.
+fn resolve_hls_audio_codec(
+    is_live: bool,
+    input_container: Option<&str>,
+    requested: &str,
+) -> String {
+    let input_is_hls =
+        input_container.is_some_and(|container| container.eq_ignore_ascii_case("hls"));
+    if requested == "copy" && (is_live || input_is_hls) {
         "aac".to_string()
     } else {
         requested.to_string()
@@ -1279,11 +1297,35 @@ async fn hls_segment_inner(
 #[cfg(test)]
 mod tests {
     #[test]
+    fn vod_hls_source_reencodes_copied_audio_to_aac() {
+        assert_eq!(
+            super::resolve_hls_audio_codec(false, Some("hls"), "copy"),
+            "aac"
+        );
+        assert_eq!(
+            super::resolve_hls_audio_codec(false, Some("HLS"), "copy"),
+            "aac"
+        );
+    }
+
+    #[test]
+    fn hls_audio_normalization_preserves_compatible_copy_paths() {
+        assert_eq!(
+            super::resolve_hls_audio_codec(false, Some("mp4"), "copy"),
+            "copy"
+        );
+        assert_eq!(super::resolve_hls_audio_codec(false, None, "copy"), "copy");
+        assert_eq!(
+            super::resolve_hls_audio_codec(false, Some("hls"), "ac3"),
+            "ac3"
+        );
+    }
+
+    #[test]
     fn live_channel_forces_aac_over_copy() {
-        assert_eq!(super::resolve_live_audio_codec(true, "copy"), "aac");
-        assert_eq!(super::resolve_live_audio_codec(false, "copy"), "copy");
-        assert_eq!(super::resolve_live_audio_codec(true, "aac"), "aac");
-        assert_eq!(super::resolve_live_audio_codec(true, "ac3"), "ac3");
+        assert_eq!(super::resolve_hls_audio_codec(true, None, "copy"), "aac");
+        assert_eq!(super::resolve_hls_audio_codec(true, None, "aac"), "aac");
+        assert_eq!(super::resolve_hls_audio_codec(true, None, "ac3"), "ac3");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A browser can fail to play an HLS video-on-demand title when the source uses LATM-formatted AAC audio. The failure occurs when Remux copies that audio into its browser-facing HLS output unchanged: the browser expects normal ADTS AAC in those MPEG-TS segments and cannot decode the copied LATM data.

For example, a remote HLS playlist can contain H.264 video and LATM AAC audio. The video is compatible, so a client requests audio copy. Before this change, ffmpeg passed the LATM audio through, and browser playback could fail or have unusable audio.

The fix checks whether the selected source is HLS. If the client requested audio copy for an HLS source, Remux asks ffmpeg to decode and re-encode the audio as standard AAC before serving the HLS segments. This keeps the video untouched while giving the browser the AAC format it expects.

This does not change non-HLS sources or explicit client audio codec selections. Existing live-channel AAC normalization is preserved.

## Testing

- `cargo test -p remux-server api::hls::tests`
