### PR TITLE
fix(playback): support extensionless HLS segments

### DIFF
--- a/crates/remux-server/src/playback/engine.rs
+++ b/crates/remux-server/src/playback/engine.rs
@@ -475,6 +475,33 @@ fn is_hdr(range_type: Option<&VideoRangeType>) -> bool {
     )
 }
 
+fn is_hls_input_url(input_url: &str) -> bool {
+    let Ok(url) = url::Url::parse(input_url) else {
+        return false;
+    };
+    let path = url
+        .path()
+        .to_ascii_lowercase();
+    path.ends_with(".m3u8")
+        || (path.ends_with("/hls")
+            && url
+                .query_pairs()
+                .any(|(name, _)| name.eq_ignore_ascii_case("url")))
+}
+
+fn add_hls_extension_compat_args(args: &mut Vec<String>, input_url: &str) {
+    if is_hls_input_url(input_url) {
+        args.extend([
+            "-allowed_extensions".into(),
+            "ALL".into(),
+            "-allowed_segment_extensions".into(),
+            "ALL".into(),
+            "-extension_picky".into(),
+            "0".into(),
+        ]);
+    }
+}
+
 /// Build the ffmpeg CLI args for an HLS transcode.
 pub(crate) fn build_hls_args(params: &TranscodeParams) -> Vec<String> {
     let accel = params
@@ -612,6 +639,8 @@ pub(crate) fn build_hls_args(params: &TranscodeParams) -> Vec<String> {
             "5000000".into(),
         ]);
     }
+
+    add_hls_extension_compat_args(&mut args, &params.input_url);
 
     args.extend([
         "-copyts".into(),
@@ -2186,6 +2215,10 @@ mod tests {
         assert_eq!(arg_after(&args, "-c:v"), Some("copy"));
         assert_eq!(arg_after(&args, "-c:a"), Some("aac"));
         assert_eq!(arg_after(&args, "-f"), Some("hls"));
+        assert!(
+            !args_contains(&args, "-allowed_extensions"),
+            "ordinary file inputs must retain ffmpeg's default extension policy"
+        );
         // Default TS segments — no fmp4 flag
         assert!(!args_contains(&args, "-hls_segment_type"));
         // Playlist and segment paths
@@ -2197,6 +2230,20 @@ mod tests {
             args.iter()
                 .any(|a| a.contains("segment_") && a.ends_with(".ts"))
         );
+    }
+
+    #[test]
+    fn hls_proxy_input_allows_extensionless_segments() {
+        let args = build_hls_args(&TranscodeParams {
+            input_url:
+                "https://relay.example/hls?url=https%3A%2F%2Forigin.example%2Fplaylist"
+                    .into(),
+            ..default_hls(PathBuf::from("/tmp/test_extensionless_hls"))
+        });
+
+        assert_eq!(arg_after(&args, "-allowed_extensions"), Some("ALL"));
+        assert_eq!(arg_after(&args, "-allowed_segment_extensions"), Some("ALL"));
+        assert_eq!(arg_after(&args, "-extension_picky"), Some("0"));
     }
 
     #[test]

--- a/crates/remux-server/src/playback/probe.rs
+++ b/crates/remux-server/src/playback/probe.rs
@@ -16,6 +16,71 @@ fn ffprobe_bin() -> String {
     std::env::var("FFPROBE_PATH").unwrap_or_else(|_| "ffprobe".into())
 }
 
+fn should_retry_with_relaxed_hls_extensions(stderr: &str) -> bool {
+    stderr.contains("allowed_segment_extensions")
+        || stderr.contains("mismatches allowed extensions")
+}
+
+fn ffprobe_args(url: &str, allow_nonstandard_hls_extensions: bool) -> Vec<String> {
+    let mut args = vec![
+        "-v".into(),
+        "error".into(),
+        "-print_format".into(),
+        "json".into(),
+        "-show_chapters".into(),
+        "-show_streams".into(),
+        "-show_format".into(),
+    ];
+    if allow_nonstandard_hls_extensions {
+        args.extend([
+            "-allowed_extensions".into(),
+            "ALL".into(),
+            "-allowed_segment_extensions".into(),
+            "ALL".into(),
+            "-extension_picky".into(),
+            "0".into(),
+        ]);
+    }
+    args.push(url.into());
+    args
+}
+
+#[cfg(test)]
+mod extension_retry_tests {
+    #[test]
+    fn retries_hls_probe_when_extension_validation_rejects_a_proxy_segment() {
+        let stderr =
+            "[hls] URL https://relay.example/hls is not in allowed_segment_extensions";
+
+        assert!(super::should_retry_with_relaxed_hls_extensions(stderr));
+    }
+
+    #[test]
+    fn does_not_retry_unrelated_probe_errors() {
+        assert!(!super::should_retry_with_relaxed_hls_extensions(
+            "Connection timed out"
+        ));
+    }
+
+    #[test]
+    fn retry_uses_hls_extension_compatibility_options() {
+        let args = super::ffprobe_args("https://relay.example/hls?url=playlist", true);
+
+        assert!(
+            args.windows(2)
+                .any(|pair| { pair == ["-allowed_extensions", "ALL"] })
+        );
+        assert!(
+            args.windows(2)
+                .any(|pair| { pair == ["-allowed_segment_extensions", "ALL"] })
+        );
+        assert!(
+            args.windows(2)
+                .any(|pair| { pair == ["-extension_picky", "0"] })
+        );
+    }
+}
+
 fn nonzero<T: Default + PartialOrd>(v: T) -> Option<T> {
     if v > T::default() { Some(v) } else { None }
 }
@@ -465,20 +530,25 @@ fn apply_video_bitrate_fallback(
 pub fn probe_media(url: &str) -> Result<(api::MediaSourceInfo, MediaSegments)> {
     debug!(url, "probing media");
 
-    let output = std::process::Command::new(ffprobe_bin())
-        .args([
-            "-v",
-            "error",
-            "-print_format",
-            "json",
-            "-show_chapters",
-            "-show_streams",
-            "-show_format",
-            url,
-        ])
+    let mut output = std::process::Command::new(ffprobe_bin())
+        .args(ffprobe_args(url, false))
         .hide_console()
         .output()
         .map_err(|e| anyhow!("Failed to run ffprobe: {}", e))?;
+
+    if !output
+        .status
+        .success()
+        && should_retry_with_relaxed_hls_extensions(&String::from_utf8_lossy(
+            &output.stderr,
+        ))
+    {
+        output = std::process::Command::new(ffprobe_bin())
+            .args(ffprobe_args(url, true))
+            .hide_console()
+            .output()
+            .map_err(|e| anyhow!("Failed to rerun ffprobe: {}", e))?;
+    }
 
     if !output
         .status


### PR DESCRIPTION
## Summary

Some HLS relays expose playlist segments through extensionless URLs. For example, a `/hls?url=...` relay can return a valid playlist whose segment URLs do not end in `.ts`; ffprobe then rejects the source before playback starts.

This retries only that extension-validation failure with ffprobe's HLS compatibility options and passes the same options to ffmpeg for direct HLS and relay-style HLS inputs. Ordinary file inputs retain ffmpeg's default extension policy.

## Testing

- `cargo test -p remux-server hls_`
