### PR TITLE
feat: move healthcheck to dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -79,4 +79,7 @@ COPY jellyfin-web ./jellyfin-web
 
 EXPOSE 3000
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD curl -fsS http://127.0.0.1:3000/health || exit 1
+
 CMD ["./remux-server"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,7 @@ ENV DATABASE_URL=sqlite:///data/db.sqlite?mode=rwc
 ENV LOG_FILE=/data/logs/remux.jsonl
 ENV TORRENT_DATA_DIR=/data/torrents
 ENV DATA_DIR=/data
+ENV PORT=3000
 ENV FFMPEG_PATH=/usr/lib/jellyfin-ffmpeg/ffmpeg
 ENV FFPROBE_PATH=/usr/lib/jellyfin-ffmpeg/ffprobe
 ENV PATH="/usr/lib/jellyfin-ffmpeg:${PATH}"
@@ -80,6 +81,6 @@ COPY jellyfin-web ./jellyfin-web
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
-    CMD curl -fsS http://127.0.0.1:3000/health || exit 1
+    CMD curl -fsS "http://127.0.0.1:${PORT}/health"
 
 CMD ["./remux-server"]

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -6,11 +6,6 @@ services:
 
     ports:
       - "3001:3000"
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
-      interval: 30s
-      timeout: 5s
-      retries: 3
     #command: ["bash", "-c", "tail -f /dev/null"]
     #command: ["bash", "-lc", "ls -la ."]
     #command: ["/app/remux-server"]


### PR DESCRIPTION
Move health check to the Dockerfile instead of the docker-compose file. This makes it implicit, i.e. no need for user to define a healthcheck themselves in the docker-compose.