### PR TITLE
fix(sdks): respect Retry-After across concurrent outbound requests

### DIFF
--- a/crates/remux-sdks/Cargo.toml
+++ b/crates/remux-sdks/Cargo.toml
@@ -36,6 +36,9 @@ isolang = { version = "2.4.0", features = ["list_languages", "lowercase_names"] 
 nutype = { version = "0.6", features = ["serde", "regex"] }
 regex = "1"
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1", features = ["time"] }
+
 [dev-dependencies]
 httpmock = "0.7"
 tokio = { version = "1", features = ["macros", "rt", "time"] }

--- a/crates/remux-sdks/src/lib.rs
+++ b/crates/remux-sdks/src/lib.rs
@@ -9,6 +9,8 @@ pub mod stremio;
 pub mod tmdb;
 pub mod trakt;
 
+mod rate_limit;
+
 use bytes::Bytes;
 use http::{Extensions, HeaderMap, HeaderValue, Method, header};
 use itertools::Itertools;
@@ -396,14 +398,16 @@ fn build_mw(retry: Option<Arc<dyn RetryPolicy + Send + Sync>>) -> ClientWithMidd
         MwClientBuilder::new(SHARED_HTTP_CLIENT.clone()).with(InMemoryCacheMiddleware);
     #[cfg(target_arch = "wasm32")]
     let builder = MwClientBuilder::new(SHARED_HTTP_CLIENT.clone());
-    match retry {
-        Some(policy) => builder
-            .with(RetryTransientMiddleware::new_with_policy(DynRetryPolicy(
-                policy,
-            )))
-            .build(),
-        None => builder.build(),
-    }
+    let builder = match retry {
+        Some(policy) => builder.with(RetryTransientMiddleware::new_with_policy(
+            DynRetryPolicy(policy),
+        )),
+        None => builder,
+    };
+    // Added after retry middleware so every retry attempt observes the shared cooldown.
+    #[cfg(not(target_arch = "wasm32"))]
+    let builder = builder.with(rate_limit::RateLimitMiddleware);
+    builder.build()
 }
 
 #[derive(Clone)]
@@ -535,18 +539,9 @@ impl<A: Auth + Clone> RestClient<A> {
             .status()
             .as_u16();
         if status == 429 {
-            let retry_after_secs = resp
-                .headers()
-                .get("Retry-After")
-                .and_then(|v| {
-                    v.to_str()
-                        .ok()
-                })
-                .and_then(|s| {
-                    s.parse::<u64>()
-                        .ok()
-                })
-                .unwrap_or(60);
+            let retry_after_secs =
+                rate_limit::retry_after(resp.headers(), std::time::SystemTime::now())
+                    .as_secs();
             return Err(ClientError::RateLimited { retry_after_secs });
         }
         let text = resp

--- a/crates/remux-sdks/src/rate_limit.rs
+++ b/crates/remux-sdks/src/rate_limit.rs
@@ -1,0 +1,244 @@
+//! Shared HTTP 429 backpressure for all outbound SDK clients.
+
+use http::{HeaderMap, header};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const DEFAULT_RETRY_AFTER: Duration = Duration::from_secs(60);
+
+pub(crate) fn retry_after(headers: &HeaderMap, now: SystemTime) -> Duration {
+    headers
+        .get(header::RETRY_AFTER)
+        .and_then(|value| {
+            value
+                .to_str()
+                .ok()
+        })
+        .and_then(|value| parse_retry_after(value, now))
+        .unwrap_or(DEFAULT_RETRY_AFTER)
+}
+
+fn parse_retry_after(value: &str, now: SystemTime) -> Option<Duration> {
+    let value = value.trim();
+    if let Ok(seconds) = value.parse::<u64>() {
+        return Some(Duration::from_secs(seconds));
+    }
+
+    let retry_at = chrono::DateTime::parse_from_rfc2822(value)
+        .map(|date| date.timestamp())
+        .or_else(|_| {
+            chrono::NaiveDateTime::parse_from_str(value, "%a, %d %b %Y %H:%M:%S GMT")
+                .map(|date| {
+                    date.and_utc()
+                        .timestamp()
+                })
+        })
+        .ok()?;
+    let retry_at = u64::try_from(retry_at).unwrap_or_default();
+    let now = now
+        .duration_since(UNIX_EPOCH)
+        .ok()?
+        .as_secs();
+    Some(Duration::from_secs(retry_at.saturating_sub(now)))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+use {
+    async_trait::async_trait,
+    reqwest_middleware::{Middleware, Next},
+    std::{
+        collections::HashMap,
+        sync::{LazyLock, Mutex},
+        time::Instant,
+    },
+};
+
+#[cfg(not(target_arch = "wasm32"))]
+static RATE_LIMIT_COOLDOWNS: LazyLock<Mutex<HashMap<String, Instant>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+#[cfg(not(target_arch = "wasm32"))]
+fn origin(url: &url::Url) -> String {
+    url.origin()
+        .ascii_serialization()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+async fn wait_for_origin(origin: &str) {
+    loop {
+        let delay = {
+            let now = Instant::now();
+            let mut cooldowns = RATE_LIMIT_COOLDOWNS
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            match cooldowns
+                .get(origin)
+                .copied()
+            {
+                Some(deadline) if deadline > now => Some(deadline.duration_since(now)),
+                Some(_) => {
+                    cooldowns.remove(origin);
+                    None
+                }
+                None => None,
+            }
+        };
+
+        match delay {
+            Some(delay) => tokio::time::sleep(delay).await,
+            None => return,
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn pause_origin(origin: &str, delay: Duration) -> bool {
+    if delay.is_zero() {
+        return false;
+    }
+
+    let now = Instant::now();
+    let Some(deadline) = now.checked_add(delay) else {
+        return false;
+    };
+    let mut cooldowns = RATE_LIMIT_COOLDOWNS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    cooldowns.retain(|_, current| *current > now);
+
+    let extends_cooldown = match cooldowns.get(origin) {
+        Some(current) => deadline > *current,
+        None => true,
+    };
+    if extends_cooldown {
+        cooldowns.insert(origin.to_string(), deadline);
+    }
+    extends_cooldown
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) struct RateLimitMiddleware;
+
+#[cfg(not(target_arch = "wasm32"))]
+#[async_trait]
+impl Middleware for RateLimitMiddleware {
+    async fn handle(
+        &self,
+        req: reqwest::Request,
+        extensions: &mut http::Extensions,
+        next: Next<'_>,
+    ) -> reqwest_middleware::Result<reqwest::Response> {
+        let request_origin = origin(req.url());
+        wait_for_origin(&request_origin).await;
+
+        let response = next
+            .run(req, extensions)
+            .await?;
+        if response.status() == http::StatusCode::TOO_MANY_REQUESTS {
+            let delay = retry_after(response.headers(), SystemTime::now());
+            let response_origin = origin(response.url());
+            let request_extended = pause_origin(&request_origin, delay);
+            let response_extended = response_origin != request_origin
+                && pause_origin(&response_origin, delay);
+
+            if request_extended || response_extended {
+                tracing::warn!(
+                    origin = %response_origin,
+                    retry_after_secs = delay.as_secs(),
+                    "upstream returned 429; pausing requests for origin"
+                );
+            }
+        }
+
+        Ok(response)
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+    use crate::{ClientError, Endpoint, RestClient};
+
+    #[derive(Clone)]
+    struct Probe(&'static str);
+
+    impl Endpoint for Probe {
+        type Output = Vec<String>;
+
+        fn path(&self) -> String {
+            self.0
+                .to_string()
+        }
+    }
+
+    #[test]
+    fn parses_retry_after_delay_seconds() {
+        let now = UNIX_EPOCH + Duration::from_secs(10);
+        assert_eq!(parse_retry_after("42", now), Some(Duration::from_secs(42)));
+    }
+
+    #[test]
+    fn parses_retry_after_http_date() {
+        let now = UNIX_EPOCH + Duration::from_secs(1_445_412_450);
+        assert_eq!(
+            parse_retry_after("Wed, 21 Oct 2015 07:28:00 GMT", now),
+            Some(Duration::from_secs(30))
+        );
+    }
+
+    #[test]
+    fn defaults_to_sixty_seconds_for_missing_or_invalid_header() {
+        let headers = HeaderMap::new();
+        assert_eq!(retry_after(&headers, UNIX_EPOCH), DEFAULT_RETRY_AFTER);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::RETRY_AFTER,
+            "not-a-delay"
+                .parse()
+                .unwrap(),
+        );
+        assert_eq!(retry_after(&headers, UNIX_EPOCH), DEFAULT_RETRY_AFTER);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cooldown_is_shared_between_clients_for_the_same_origin() {
+        let server = httpmock::MockServer::start();
+        let limited = server.mock(|when, then| {
+            when.path("/limited");
+            then.status(429)
+                .header("Retry-After", "1");
+        });
+        let ok = server.mock(|when, then| {
+            when.path("/ok");
+            then.status(200)
+                .json_body(serde_json::json!([]));
+        });
+        let first = RestClient::new(&server.base_url()).unwrap();
+        let second = RestClient::new(&server.base_url()).unwrap();
+
+        let error = first
+            .execute(Probe("/limited"))
+            .await
+            .unwrap_err();
+        match error {
+            ClientError::RateLimited { retry_after_secs } => {
+                assert_eq!(retry_after_secs, 1);
+            }
+            other => panic!("expected rate-limit error, got {other}"),
+        }
+
+        let started = std::time::Instant::now();
+        second
+            .execute(Probe("/ok"))
+            .await
+            .unwrap();
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed >= Duration::from_millis(750),
+            "request was sent before the shared cooldown elapsed: {elapsed:?}"
+        );
+        assert_eq!(limited.hits(), 1);
+        assert_eq!(ok.hits(), 1);
+    }
+}


### PR DESCRIPTION
## Summary

This adds shared, per-origin backpressure after an upstream returns HTTP `429 Too Many Requests`.

- Parse `Retry-After` as either delay-seconds or an HTTP date.
- Fall back to 60 seconds when the header is missing or invalid.
- Share the cooldown across all `RestClient` instances in the process.
- Make each retry attempt observe the shared cooldown by placing the middleware inside the retry middleware.
- Preserve the existing `ClientError::RateLimited` behavior.
- Add regression tests for parsing and for a cooldown shared by two separate clients.

## Operational context

A user ran Remux against an upstream service we operate. We observed roughly **8 requests per second**—about **28,800 requests per hour**—and traffic continued after repeated `429` responses (and after 403's.. about a million blocked by CF). In practice, the Remux-generated traffic hammered our server.

I would appreciate it if Remux could build this shared rate-limit backpressure into its HTTP client, so upstream services do not have to keep absorbing concurrent requests after explicitly asking the client to slow down.

## Current behavior

The SDK recognizes a `429` and returns `ClientError::RateLimited { retry_after_secs }`, but the parsed value is not used to pause other requests. Concurrent workers and separate `RestClient` instances can therefore continue sending requests to the same origin, while retry-enabled clients may also issue additional attempts.

## Behavior after this change

Once any request receives a `429`, new outbound SDK requests to the same scheme/host/port wait until the cooldown expires. A later `429` can extend, but never shorten, the cooldown. Requests already in flight are not cancelled.

This is deliberately reactive rather than a hard-coded requests-per-second limit: the upstream controls the pause through `Retry-After`.

## Validation

- `cargo fmt --all` completed successfully (with existing stable-channel warnings for the repository's nightly-only import setting).
- `cargo test -p remux-sdks`: **66 passed**, plus doc-tests.
- `git diff --check` completed successfully.

## AI-assisted contribution disclosure

This proposal and the initial patch were drafted with ChatGPT.
