### PR TITLE
fix: scope smart collection genres to matching items

### DIFF
--- a/crates/remux-server/src/addons/mod.rs
+++ b/crates/remux-server/src/addons/mod.rs
@@ -203,6 +203,47 @@ pub(crate) async fn save_pending_relations(ctx: &AppContext, items: &[db::Media]
         .await
         .unwrap_or_default();
 
+    // `apply_meta` deliberately omits provider genre relations when Genres is
+    // locked. If another relation type (for example Cast) is still pending,
+    // the replacement logic below must not interpret those omitted genres as
+    // deletions. Resolve the existing right-hand media kinds once and retain
+    // genre links for every item whose Genres field is locked.
+    let genre_locked_ids: std::collections::HashSet<Uuid> = items_with_rels
+        .iter()
+        .filter(|item| item.is_field_locked(&db::MetadataField::Genres))
+        .map(|item| item.id)
+        .collect();
+    let locked_relation_right_ids: Vec<Uuid> = existing
+        .iter()
+        .filter(|relation| genre_locked_ids.contains(&relation.left_media_id))
+        .map(|relation| relation.right_media_id)
+        .collect::<std::collections::HashSet<_>>()
+        .into_iter()
+        .collect();
+    let locked_genre_right_ids: Option<std::collections::HashSet<Uuid>> =
+        if locked_relation_right_ids.is_empty() {
+            Some(std::collections::HashSet::new())
+        } else {
+            match db::Media::get_by_ids(&ctx.db, &locked_relation_right_ids).await {
+                Ok(media) => Some(
+                    media
+                        .into_iter()
+                        .filter(|right| {
+                            matches!(
+                                right.kind,
+                                db::MediaKind::Genre | db::MediaKind::MusicGenre
+                            )
+                        })
+                        .map(|right| right.id)
+                        .collect(),
+                ),
+                Err(e) => {
+                    warn!(error = %e, "failed to resolve locked genre relations; preserving all locked-item relations");
+                    None
+                }
+            }
+        };
+
     type RelKey = (Uuid, Uuid, Option<db::RelationRole>);
 
     let existing_map: std::collections::HashMap<RelKey, &db::MediaRelation> = existing
@@ -218,7 +259,16 @@ pub(crate) async fn save_pending_relations(ctx: &AppContext, items: &[db::Media]
     let to_delete: Vec<Uuid> = existing
         .iter()
         .filter(|r| {
-            !desired_keys.contains(&(r.left_media_id, r.right_media_id, r.role))
+            if desired_keys.contains(&(r.left_media_id, r.right_media_id, r.role)) {
+                return false;
+            }
+            if !genre_locked_ids.contains(&r.left_media_id) {
+                return true;
+            }
+            match &locked_genre_right_ids {
+                Some(genre_ids) => !genre_ids.contains(&r.right_media_id),
+                None => false,
+            }
         })
         .map(|r| r.relation_id)
         .collect();
@@ -3555,6 +3605,75 @@ mod tests {
                 .as_deref(),
             Some("Provider Overview"),
             "unlocked Overview must still be updated"
+        );
+    }
+
+    #[tokio::test]
+    async fn save_pending_relations_preserves_locked_genres() {
+        let (_server, guard) = crate::integration_test::new_test_server()
+            .await
+            .unwrap();
+        let ctx = &guard.0;
+        let item = db::Media {
+            id: Uuid::new_v4(),
+            title: "Locked Genres Series".to_string(),
+            kind: db::MediaKind::Series,
+            locked_fields: vec![db::MetadataField::Genres],
+            ..Default::default()
+        };
+        let genre = db::Media {
+            id: Uuid::new_v4(),
+            title: "Acoustic".to_string(),
+            kind: db::MediaKind::Genre,
+            ..Default::default()
+        };
+        let actor = db::Media {
+            id: Uuid::new_v4(),
+            title: "Actor".to_string(),
+            kind: db::MediaKind::Person,
+            external_ids: db::ExternalIds {
+                tmdb: Some(42),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let item_id = item.id;
+        let genre_id = genre.id;
+        db::Media::upsert(&ctx.db, &[item.clone(), genre.clone(), actor.clone()])
+            .await
+            .unwrap();
+        db::MediaRelation::upsert(
+            &ctx.db,
+            &[db::MediaRelation {
+                left_media_id: item.id,
+                right_media_id: genre.id,
+                ..Default::default()
+            }],
+        )
+        .await
+        .unwrap();
+
+        let refreshed = db::Media {
+            relations: Some(vec![(
+                db::MediaRelation {
+                    left_media_id: item.id,
+                    right_media_id: actor.id,
+                    role: Some(db::RelationRole::Actor),
+                    ..Default::default()
+                },
+                actor,
+            )]),
+            ..item
+        };
+        save_pending_relations(ctx, &[refreshed]).await;
+
+        let relations = db::MediaRelation::get_by_left_ids(&ctx.db, &[item_id])
+            .await
+            .unwrap();
+        assert!(
+            relations
+                .iter()
+                .any(|relation| relation.right_media_id == genre_id)
         );
     }
 

--- a/crates/remux-server/src/api/items.rs
+++ b/crates/remux-server/src/api/items.rs
@@ -2420,7 +2420,7 @@ fn parse_collection_type(s: &str) -> Option<db::CollectionMediaKind> {
 #[get("/genres")]
 pub async fn genres(
     State(state): State<AppState>,
-    _session: auth::AuthSession,
+    session: auth::AuthSession,
     Query(q): Query<api::GetItemsQuery>,
 ) -> Result<impl IntoResponse> {
     let parent = if let Some(pid) = q.parent_id {
@@ -2477,6 +2477,10 @@ pub async fn genres(
     } else {
         vec![db::MediaKind::Genre, db::MediaKind::MusicGenre]
     };
+    let smart_filter = parent
+        .as_ref()
+        .and_then(|p| p.parse_smart_filter())
+        .cloned();
 
     let result = db::Media::get_by_filter(
         &state
@@ -2488,6 +2492,14 @@ pub async fn genres(
             offset: q.start_index,
             total_count: true,
             genre_related_kinds,
+            parent_id: q.parent_id,
+            parent,
+            filter_rules: smart_filter,
+            user_id: Some(
+                session
+                    .user
+                    .id,
+            ),
             sort_by: q
                 .sort_by
                 .unwrap_or_default(),
@@ -3445,6 +3457,19 @@ mod tests {
         }
     }
 
+    fn catalog_filter(catalog_id: Uuid) -> CollectionFilter {
+        CollectionFilter {
+            match_mode: FilterMatchMode::All,
+            groups: vec![FilterGroup {
+                match_mode: FilterMatchMode::All,
+                rules: vec![FilterRule::Catalog {
+                    op: SetOp::In,
+                    catalog_ids: vec![catalog_id],
+                }],
+            }],
+        }
+    }
+
     async fn insert_smart_collection_with_filter(
         db: &sqlx::SqlitePool,
         title: &str,
@@ -3504,6 +3529,178 @@ mod tests {
             .await
             .expect("insert_media failed");
         m
+    }
+
+    async fn add_genre(db: &sqlx::SqlitePool, media_id: Uuid, genre: &str) {
+        let pairs = db::build_genre_relations_from_names(
+            media_id,
+            &[genre.to_string()],
+            db::MediaKind::Genre,
+        );
+        let genres: Vec<_> = pairs
+            .iter()
+            .map(|(_, media)| media.clone())
+            .collect();
+        let relations: Vec<_> = pairs
+            .into_iter()
+            .map(|(relation, _)| relation)
+            .collect();
+        db::Media::upsert(db, &genres)
+            .await
+            .unwrap();
+        db::MediaRelation::upsert(db, &relations)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn genres_for_smart_collection_only_include_matching_items() {
+        let (server, guard, token) = authenticated_server().await;
+        let auth = auth_header_with_token(&token);
+        let db = &guard
+            .0
+            .db;
+        let catalog_id = Uuid::new_v4();
+
+        let collection = insert_smart_collection_with_filter(
+            db,
+            "Music Videos",
+            db::CollectionMediaKind::Series,
+            Some(catalog_filter(catalog_id)),
+        )
+        .await;
+        let included =
+            insert_media(db, "Included Series", db::MediaKind::Series, "tt1000001")
+                .await;
+        let unrelated =
+            insert_media(db, "Unrelated Series", db::MediaKind::Series, "tt1000002")
+                .await;
+        db::MediaRelation::upsert(
+            db,
+            &[db::MediaRelation {
+                left_media_id: catalog_id,
+                right_media_id: included.id,
+                role: Some(db::RelationRole::Catalog),
+                ..Default::default()
+            }],
+        )
+        .await
+        .unwrap();
+        add_genre(db, included.id, "Live").await;
+        add_genre(db, unrelated.id, "Gaming").await;
+
+        let response: serde_json::Value = server
+            .get("/genres")
+            .add_header(
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth).unwrap(),
+            )
+            .add_query_param(
+                "ParentId",
+                collection
+                    .id
+                    .to_string(),
+            )
+            .await
+            .json();
+        let names: Vec<&str> = response["Items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|item| item["Name"].as_str())
+            .collect();
+
+        assert_eq!(names, vec!["Live"]);
+        assert_eq!(response["TotalRecordCount"], 1);
+    }
+
+    #[tokio::test]
+    async fn genres_for_smart_collection_scope_user_rules_to_requester() {
+        let (server, guard, token) = authenticated_server().await;
+        let auth = auth_header_with_token(&token);
+        let db = &guard
+            .0
+            .db;
+        let requester = db::User::get_by_username(db, "test")
+            .await
+            .unwrap()
+            .unwrap();
+        let mut other_user = db::User::new_with_password(
+            String::new(),
+            "other-user".into(),
+            "test",
+            None,
+        )
+        .unwrap();
+        other_user
+            .save(db)
+            .await
+            .unwrap();
+
+        let collection = insert_smart_collection_with_filter(
+            db,
+            "Favorite Videos",
+            db::CollectionMediaKind::Series,
+            Some(CollectionFilter {
+                match_mode: FilterMatchMode::All,
+                groups: vec![FilterGroup {
+                    match_mode: FilterMatchMode::All,
+                    rules: vec![FilterRule::Favorite { value: true }],
+                }],
+            }),
+        )
+        .await;
+        let requester_item =
+            insert_media(db, "Requester Video", db::MediaKind::Series, "tt1000003")
+                .await;
+        let other_user_item =
+            insert_media(db, "Other User Video", db::MediaKind::Series, "tt1000004")
+                .await;
+        add_genre(db, requester_item.id, "Official Video").await;
+        add_genre(db, other_user_item.id, "Tutorials").await;
+
+        let mut requester_state =
+            db::UserMediaState::get_or_new(db, &requester, &requester_item)
+                .await
+                .unwrap();
+        requester_state.favorite = true;
+        requester_state
+            .save(db)
+            .await
+            .unwrap();
+        let mut other_user_state =
+            db::UserMediaState::get_or_new(db, &other_user, &other_user_item)
+                .await
+                .unwrap();
+        other_user_state.favorite = true;
+        other_user_state
+            .save(db)
+            .await
+            .unwrap();
+
+        let response: serde_json::Value = server
+            .get("/genres")
+            .add_header(
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth).unwrap(),
+            )
+            .add_query_param(
+                "ParentId",
+                collection
+                    .id
+                    .to_string(),
+            )
+            .await
+            .json();
+        let names: Vec<&str> = response["Items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|item| item["Name"].as_str())
+            .collect();
+
+        assert_eq!(names, vec!["Official Video"]);
+        assert_eq!(response["TotalRecordCount"], 1);
     }
 
     async fn insert_smart_collection(

--- a/crates/remux-server/src/db/media.rs
+++ b/crates/remux-server/src/db/media.rs
@@ -3644,7 +3644,27 @@ impl Media {
                     for k in related_kinds {
                         sep.push_bind(k);
                     }
-                    qb.push("))");
+                    qb.push(")");
+                    if is_genre_scope_query {
+                        if let Some(ref rules) = filter.filter_rules {
+                            qb.push(
+                                " AND item.id IN (SELECT media.id FROM media WHERE 1 = 1",
+                            );
+                            apply_filter_rules(
+                                qb,
+                                rules,
+                                filter
+                                    .user_id
+                                    .as_ref(),
+                                // Independent subquery: it does not join the
+                                // watched CTE, so the played-true rule must be
+                                // applied inline rather than suppressed.
+                                false,
+                            );
+                            qb.push(")");
+                        }
+                    }
+                    qb.push(")");
                 }
             }
             if let Some(grandparent_id) = &filter.grandparent_id {
@@ -3976,45 +3996,50 @@ impl Media {
                     .push_bind(after);
             }
 
-            if let Some(ref f) = filter.filter_rules {
-                // When the query targets child types (episodes/seasons), the
-                // collection filter rules describe which series qualify — not the
-                // episode rows themselves. Apply them via a grandparent subquery so
-                // only children of matching series are returned.
-                let all_episode_or_season = filter
-                    .kind
-                    .as_ref()
-                    .map(|k| {
-                        !k.is_empty()
-                            && k.iter()
-                                .all(|k| {
-                                    matches!(k, MediaKind::Episode | MediaKind::Season)
-                                })
-                    })
-                    .unwrap_or(false);
+            if !is_genre_scope_query {
+                if let Some(ref f) = filter.filter_rules {
+                    // When the query targets child types (episodes/seasons), the
+                    // collection filter rules describe which series qualify — not the
+                    // episode rows themselves. Apply them via a grandparent subquery so
+                    // only children of matching series are returned.
+                    let all_episode_or_season = filter
+                        .kind
+                        .as_ref()
+                        .map(|k| {
+                            !k.is_empty()
+                                && k.iter()
+                                    .all(|k| {
+                                        matches!(
+                                            k,
+                                            MediaKind::Episode | MediaKind::Season
+                                        )
+                                    })
+                        })
+                        .unwrap_or(false);
 
-                if all_episode_or_season {
-                    if let Some(fragment) = build_filter_rules_fragment(
-                        f,
-                        filter
-                            .user_id
-                            .as_ref(),
-                        false,
-                    ) {
-                        qb.push(format!(
-                            " AND grandparent_id IN \
+                    if all_episode_or_season {
+                        if let Some(fragment) = build_filter_rules_fragment(
+                            f,
+                            filter
+                                .user_id
+                                .as_ref(),
+                            false,
+                        ) {
+                            qb.push(format!(
+                                " AND grandparent_id IN \
                             (SELECT id FROM media WHERE kind = 'series' AND {fragment})"
-                        ));
+                            ));
+                        }
+                    } else {
+                        apply_filter_rules(
+                            qb,
+                            f,
+                            filter
+                                .user_id
+                                .as_ref(),
+                            use_watched_cte,
+                        );
                     }
-                } else {
-                    apply_filter_rules(
-                        qb,
-                        f,
-                        filter
-                            .user_id
-                            .as_ref(),
-                        use_watched_cte,
-                    );
                 }
             }
             if let Some(ref ids) = filter.exclude_ids {


### PR DESCRIPTION
## Summary

- Remux builds Jellyfin genre categories on the fly from metadata on imported items.
- For a smart collection backed by a Stremio catalog, genre choices now come only from items that match that catalog filter instead of the whole Remux library.
- This is the right boundary because the addon provider defines which items belong to its catalog and may curate its supported genre options through the Stremio manifest. Remux's automatic metadata scan does not know that catalog's intent and should not add unrelated categories from other catalogs.
- For example, a YouTube addon could provide a `Music Videos` catalog with `Live`, `Acoustic`, and `Official Video` filters. Genres such as `Gaming` or `Tutorials` from other YouTube catalogs should not appear while filtering `Music Videos`, even if those items exist elsewhere in Remux.
- Metadata refreshes keep existing genres when the `Genres` field is locked.

Stremio documents provider-defined catalog genre options under [`catalogs[].extra`](https://stremio.github.io/stremio-addon-sdk/api/responses/manifest.html#catalog-format).

## Validation

- Smart-collection genre regression test passed.
- Locked-genre refresh regression test passed.
- Rust formatting check passed.
