### PR TITLE
fix(playback): evaluate codec profiles for every direct play candidate

### DIFF
--- a/crates/remux-sdks/src/remux/mod.rs
+++ b/crates/remux-sdks/src/remux/mod.rs
@@ -1968,6 +1968,8 @@ pub enum TranscodeReason {
     SubtitleCodecNotSupported(String),
     VideoRangeTypeNotSupported(String),
     VideoCodecTagNotSupported(String),
+    VideoProfileNotSupported(String),
+    VideoBitDepthNotSupported(String),
     ContainerBitrateExceedsLimit,
 }
 
@@ -1980,6 +1982,8 @@ impl TranscodeReason {
             Self::SubtitleCodecNotSupported(_) => "SubtitleCodecNotSupported",
             Self::VideoRangeTypeNotSupported(_) => "VideoRangeTypeNotSupported",
             Self::VideoCodecTagNotSupported(_) => "VideoCodecTagNotSupported",
+            Self::VideoProfileNotSupported(_) => "VideoProfileNotSupported",
+            Self::VideoBitDepthNotSupported(_) => "VideoBitDepthNotSupported",
             Self::ContainerBitrateExceedsLimit => "ContainerBitrateExceedsLimit",
         }
     }
@@ -1999,6 +2003,12 @@ impl std::fmt::Debug for TranscodeReason {
             }
             Self::VideoCodecTagNotSupported(d) => {
                 write!(f, "VideoCodecTagNotSupported({d})")
+            }
+            Self::VideoProfileNotSupported(d) => {
+                write!(f, "VideoProfileNotSupported({d})")
+            }
+            Self::VideoBitDepthNotSupported(d) => {
+                write!(f, "VideoBitDepthNotSupported({d})")
             }
             Self::ContainerBitrateExceedsLimit => {
                 write!(f, "ContainerBitrateExceedsLimit")
@@ -2091,6 +2101,12 @@ impl TranscodeReasons {
                 }
                 "VideoCodecTagNotSupported" => {
                     Some(TranscodeReason::VideoCodecTagNotSupported(String::new()))
+                }
+                "VideoProfileNotSupported" => {
+                    Some(TranscodeReason::VideoProfileNotSupported(String::new()))
+                }
+                "VideoBitDepthNotSupported" => {
+                    Some(TranscodeReason::VideoBitDepthNotSupported(String::new()))
                 }
                 "ContainerBitrateExceedsLimit" => {
                     Some(TranscodeReason::ContainerBitrateExceedsLimit)

--- a/crates/remux-server/src/device_profile.rs
+++ b/crates/remux-server/src/device_profile.rs
@@ -98,7 +98,14 @@ impl DeviceProfileExt for DeviceProfile {
                     continue;
                 }
             }
-            let reasons = profile.check_reasons(media_source);
+            let mut reasons = profile.check_reasons(media_source);
+            // Codec profile conditions (video profile, bit depth, etc.) are a
+            // further restriction independent of container/codec-name matching —
+            // a profile can't count as a full direct-play match until these pass
+            // too. Checking them only in the "nothing matched" fallback below
+            // would let e.g. Hi10p through as plain "h264" whenever some
+            // direct-play profile already accepts the container and codec name.
+            check_codec_profiles(self, media_source, &mut reasons);
             if reasons.is_empty() {
                 return reasons;
             }
@@ -119,17 +126,14 @@ impl DeviceProfileExt for DeviceProfile {
                 }
             });
         }
-        let mut reasons = best.unwrap_or_else(|| {
+        best.unwrap_or_else(|| {
             let mut r = TranscodeReasons::default();
             r.insert(TranscodeReason::ContainerNotSupported(
                 "no matching profile".into(),
             ));
+            check_codec_profiles(self, media_source, &mut r);
             r
-        });
-
-        check_codec_profiles(self, media_source, &mut reasons);
-
-        reasons
+        })
     }
 }
 
@@ -341,6 +345,10 @@ impl CodecProfileExt for CodecProfile {
                     "VideoCodecTag" => {
                         TranscodeReason::VideoCodecTagNotSupported(detail)
                     }
+                    "VideoProfile" | "Profile" => {
+                        TranscodeReason::VideoProfileNotSupported(detail)
+                    }
+                    "BitDepth" => TranscodeReason::VideoBitDepthNotSupported(detail),
                     _ => TranscodeReason::VideoCodecNotSupported(detail),
                 };
                 reasons.insert(reason);
@@ -499,9 +507,10 @@ impl ProfileConditionExt for ProfileCondition {
 mod tests {
     use super::DeviceProfileExt;
     use remux_sdks::remux::{
-        AudioCodec, DeviceProfile, DirectPlayProfile, DlnaProfileType, MediaSourceInfo,
-        MediaStream, MediaStreamType, SubtitleDeliveryMethod, SubtitleProfile,
-        TranscodeReason, VideoCodec, VideoContainer,
+        AudioCodec, CodecProfile, DeviceProfile, DirectPlayProfile, DlnaProfileType,
+        MediaSourceInfo, MediaStream, MediaStreamType, ProfileCondition,
+        SubtitleDeliveryMethod, SubtitleProfile, TranscodeReason, VideoCodec,
+        VideoContainer,
     };
 
     #[test]
@@ -616,6 +625,76 @@ mod tests {
         assert!(
             reasons.is_empty(),
             "direct play should be permitted for MKV even when embedded subtitle codec is not in profile: {reasons:?}"
+        );
+    }
+
+    /// Mirrors a real Android TV device profile: a `DirectPlayProfile` accepts
+    /// H264 by codec name alone, but a `CodecProfile` further restricts which
+    /// H264 *profiles* are allowed (High/Main/Baseline — no High 10). Hi10p
+    /// anime must be rejected here, not silently direct-played as plain h264.
+    fn hi10p_rejecting_profile() -> DeviceProfile {
+        DeviceProfile {
+            direct_play_profiles: vec![DirectPlayProfile {
+                container: Some(vec![VideoContainer::Mkv]),
+                video_codec: Some(vec![VideoCodec::H264]),
+                audio_codec: Some(vec![AudioCodec::Aac]),
+                type_: Some(DlnaProfileType::Video),
+            }],
+            codec_profiles: vec![CodecProfile {
+                type_: Some(DlnaProfileType::Video),
+                codec: Some(vec!["h264".to_string()]),
+                conditions: vec![ProfileCondition {
+                    condition: Some("EqualsAny".to_string()),
+                    property: Some("VideoProfile".to_string()),
+                    value: Some("high|main|baseline|constrained baseline".to_string()),
+                    is_required: Some(false),
+                }],
+            }],
+            ..Default::default()
+        }
+    }
+
+    fn h264_source(profile: &str) -> MediaSourceInfo {
+        MediaSourceInfo {
+            container: Some(VideoContainer::Mkv),
+            media_streams: vec![
+                MediaStream {
+                    codec: Some("h264".to_string()),
+                    type_: Some(MediaStreamType::Video),
+                    index: 0,
+                    profile: Some(profile.to_string()),
+                    ..Default::default()
+                },
+                MediaStream {
+                    codec: Some("aac".to_string()),
+                    type_: Some(MediaStreamType::Audio),
+                    index: 1,
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn hi10p_h264_is_rejected_despite_matching_codec_name() {
+        let reasons =
+            hi10p_rejecting_profile().check_direct_play(&h264_source("High 10"));
+        assert!(
+            reasons.contains(&TranscodeReason::VideoProfileNotSupported(String::new())),
+            "Hi10p (High 10 profile) must be rejected even though the container \
+             and codec name alone would pass direct play: {reasons:?}"
+        );
+    }
+
+    #[test]
+    fn plain_high_profile_h264_still_direct_plays() {
+        // Regression guard: the CodecProfile check must not reject ordinary
+        // H264 content that actually is in an allowed profile.
+        let reasons = hi10p_rejecting_profile().check_direct_play(&h264_source("High"));
+        assert!(
+            reasons.is_empty(),
+            "plain High-profile H264 should remain direct-play eligible: {reasons:?}"
         );
     }
 }

--- a/crates/remux-server/src/playback/decision.rs
+++ b/crates/remux-server/src/playback/decision.rs
@@ -189,6 +189,12 @@ fn build_video_transcode(
         || reasons.contains(&api::TranscodeReason::ContainerBitrateExceedsLimit)
         || reasons.contains(&api::TranscodeReason::VideoRangeTypeNotSupported(
             String::new(),
+        ))
+        || reasons.contains(&api::TranscodeReason::VideoProfileNotSupported(
+            String::new(),
+        ))
+        || reasons.contains(&api::TranscodeReason::VideoBitDepthNotSupported(
+            String::new(),
         ));
 
     // When video re-encoding is not allowed (server setting or user policy),
@@ -796,6 +802,39 @@ mod tests {
             panic!("expected transcode outcome for container remux");
         };
         assert_eq!(outcome.container, "ts");
+    }
+
+    #[test]
+    fn video_profile_not_supported_forces_a_real_video_transcode() {
+        // Detecting the reason is not enough — build_video_transcode must also
+        // act on it, or a device-profile rejection (e.g. Hi10p) would still
+        // direct-play as VideoCodec=copy despite being reported as unsupported.
+        let session =
+            make_session_with_policy(remux_sdks::remux::UserPolicy::default());
+        let source = make_video_source(VideoContainer::Mkv);
+        let mut reasons = api::TranscodeReasons::default();
+        reasons.insert(api::TranscodeReason::VideoProfileNotSupported(
+            "High 10".to_string(),
+        ));
+        let TranscodeDecision::Transcode(outcome) = build_transcode_decision(
+            &source,
+            &reasons,
+            None,
+            &force_transcode_query(),
+            &session,
+            &base_cfg(EncodingOptions::default()),
+        ) else {
+            panic!(
+                "VideoProfileNotSupported must trigger a transcode, not direct play"
+            );
+        };
+        assert!(
+            outcome
+                .url
+                .contains("VideoCodec=h264"),
+            "VideoProfileNotSupported must force real video re-encoding, not copy: {}",
+            outcome.url
+        );
     }
 
     #[test]


### PR DESCRIPTION
Hi @lostb1t big fan of your work. I ran into an issue where most of anime streams would not play on my nvidia shield box. I asked claude what was going on and below is basically what it AI Slopped. From what I understand right now remux does not evaluate "bitness" of the video before sending it to the client, so if client cannot play 10-bit videos it will just shuts down. Unfortunately I do not know rust, so I cannot evaluate how correct is the fix below, but it did fix the streams not playing

Leaving ai slop below in case it might be useful

`check_direct_play` only called `check_codec_profiles` — the function that evaluates `VideoProfile` and `BitDepth` conditions — in the branch taken when no `DirectPlayProfile` matched on container and codec name alone. Any profile that matched coarsely returned success immediately, so the codec-profile conditions were never consulted.

10-bit H.264 (Hi10p) passes the coarse check trivially: the codec is still "h264". A client whose profile explicitly lists only `high|main|baseline|constrained baseline` for `VideoProfile` was therefore told to direct play content its decoder cannot handle, and the server logged `transcode_reasons=None`. The rejecting logic already existed in `CodecProfileExt::check_reasons`, and `stream_property_value` already handled both `BitDepth` and `VideoProfile`/`Profile` — it was simply unreachable.

Move `check_codec_profiles` inside the per-profile loop so every candidate is checked before it is accepted as a full match.

Also add the two reasons Jellyfin's API actually reports, which were previously bucketed under the generic `VideoCodecNotSupported`: `TranscodeReason::VideoProfileNotSupported` and `::VideoBitDepthNotSupported`. Both are wired into `needs_video_transcode`, since detecting a reason does not by itself make `build_video_transcode` act on it.