### PR TITLE
fix(items): return MediaSources when an item is fetched by MediaSourc…

### DIFF
--- a/crates/remux-server/src/api/models.rs
+++ b/crates/remux-server/src/api/models.rs
@@ -1034,10 +1034,13 @@ pub fn db_media_to_item(media: db::Media, hide_sources: bool) -> BaseItemDto {
     item.external_urls = external_urls;
 
     // several dlients require at least one stream
+    // `Stream` is here because Android TV refetches an item by MediaSource id
+    // when switching versions; without it that response has no MediaSources.
     if !hide_sources
         && (media.kind == db::MediaKind::Movie
             || media.kind == db::MediaKind::Episode
-            || media.kind == db::MediaKind::Track)
+            || media.kind == db::MediaKind::Track
+            || media.kind == db::MediaKind::Stream)
     {
         item.can_download = Some(true);
         item.media_sources = match media
@@ -1210,4 +1213,34 @@ pub struct RemoteSubtitleInfo {
     pub is_hash_match: Option<bool>,
     pub ai_translated: Option<bool>,
     pub machine_translated: Option<bool>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression: `GET /Items/{id}` on a MediaSource id — what Android TV
+    /// requests when switching versions — omitted `MediaSources` entirely,
+    /// which the client dereferences unguarded and crashes on.
+    #[test]
+    fn db_media_to_item_emits_media_sources_for_a_stream_row() {
+        let row = db::Media {
+            kind: db::MediaKind::Stream,
+            title: "1080p WEB-DL".into(),
+            ..Default::default()
+        };
+        // What `item_for_user` does for a Stream: the row is its own source.
+        let mut media = row.clone();
+        media.sources = Some(vec![row]);
+
+        let item = db_media_to_item(media, false);
+        let sources = item
+            .media_sources
+            .expect("a Stream row must carry MediaSources, not omit the field");
+        assert_eq!(
+            sources.len(),
+            1,
+            "clients select MediaSources[0] with no PlaybackInfo round-trip"
+        );
+    }
 }


### PR DESCRIPTION
Hi, while testing HEVC playback fix on my shield ran into an issue when picking alternative media source results in client crash. Below is claude's explanation of what's happening after reading server logs and org.jellyfin.androidtv client logs uploaded after crash. I verified crash does not happen after adding this

Android TV refetches an item by MediaSource id when the user picks a different version, and `item_for_user` already answers that: it resolves the Stream row and sets `sources` to the row itself.

`db_media_to_item` then discarded that work. Its `MediaSources` block is gated on `Movie | Episode | Track`, so for a `Stream` row the field was never populated and `skip_serializing_none` omitted it from the response entirely. `GET /Items/{mediaSourceId}` returned 200 with `Type: "Video"` and no `MediaSources` at all.

A client that reads `MediaSources` off that response with no `PlaybackInfo` round-trip therefore gets null. Jellyfin for Android TV dereferences it unguarded in `PlaybackController.buildExoPlayerOptions` and crashes:

    java.lang.NullPointerException: Attempt to invoke virtual method
    'java.util.List org.jellyfin.sdk.model.api.MediaSourceInfo.getMediaStreams()'
    on a null object reference

The app relaunches, retries the same item and crashes again, so playback never recovers.

Add `Stream` to the gate so the sources `item_for_user` resolved are actually serialised.

Fuller log just in case:

```
java.lang.NullPointerException: Attempt to invoke virtual method 'java.util.List org.jellyfin.sdk.model.api.MediaSourceInfo.getMediaStreams()' on a null object reference
	at org.jellyfin.androidtv.ui.playback.PlaybackController.buildExoPlayerOptions(PlaybackController.java:521)
	at org.jellyfin.androidtv.ui.playback.PlaybackController.play(PlaybackController.java:486)
	at org.jellyfin.androidtv.ui.playback.PlaybackController.play(PlaybackController.java:392)
	at org.jellyfin.androidtv.ui.playback.CustomPlaybackOverlayFragment.onActivityCreated(CustomPlaybackOverlayFragment.java:300)
	... (Fragment/Handler/Looper/ActivityThread frames, standard Android crash unwind)
```