### PR TITLE
fix(db): keep the external IDs a row's stable UUID was derived from

### DIFF
--- a/crates/remux-server/src/addons/tmdb.rs
+++ b/crates/remux-server/src/addons/tmdb.rs
@@ -1309,19 +1309,18 @@ async fn fetch_tmdb_meta(
                         .with_cache(Duration::from_secs(360)),
                     )
                     .await?;
-                let external_ids = db::ExternalIds {
+                let mut external_ids = db::ExternalIds {
                     tmdb: Some(movie_details.id),
                     imdb: movie_details
                         .imdb_id
                         .as_deref()
-                        .and_then(|s| db::NonEmptyString::try_new(s.to_string()).ok())
-                        .or_else(|| {
-                            ids.imdb
-                                .clone()
-                        }),
-                    tvdb: ids.tvdb,
+                        .and_then(|s| db::NonEmptyString::try_new(s.to_string()).ok()),
                     ..Default::default()
                 };
+                // Keep the IDs the row already has. TMDB knows nothing about
+                // kitsu/custom_stremio_id, and a Kitsu import's stable UUID is
+                // derived from them — dropping them fails validate on upsert.
+                external_ids.merge(ids, false);
                 let logo = movie_details
                     .images
                     .as_ref()
@@ -1510,7 +1509,7 @@ async fn fetch_tmdb_meta(
                 let tmdb_ext = tv_details
                     .external_ids
                     .as_ref();
-                let external_ids = db::ExternalIds {
+                let mut external_ids = db::ExternalIds {
                     tmdb: Some(tv_details.id),
                     imdb: tmdb_ext
                         .and_then(|e| {
@@ -1521,6 +1520,10 @@ async fn fetch_tmdb_meta(
                     tvdb: tmdb_ext.and_then(|e| e.tvdb_id),
                     ..Default::default()
                 };
+                // Keep the IDs the row already has. TMDB knows nothing about
+                // kitsu/custom_stremio_id, and a Kitsu import's stable UUID is
+                // derived from them — dropping them fails validate on upsert.
+                external_ids.merge(ids, false);
                 let country = tv_details
                     .origin_country
                     .into_iter()

--- a/crates/remux-server/src/db/media.rs
+++ b/crates/remux-server/src/db/media.rs
@@ -2205,9 +2205,7 @@ impl Media {
                 )));
             }
             let expected = Uuid::from(&raw);
-            if expected != self.id
-                && !Self::ext_id_uuid_candidates(self).contains(&self.id)
-            {
+            if expected != self.id && !Self::ext_id_uuid_all(self).contains(&self.id) {
                 return Err(MediaError::ValidationError(format!(
                     "{:?} '{}' UUID mismatch: id={} expected={}",
                     self.kind, self.title, self.id, expected
@@ -2805,6 +2803,16 @@ impl Media {
     /// external IDs. The item's own current UUID is excluded so only *different*
     /// rows can match.
     pub fn ext_id_uuid_candidates(item: &Self) -> Vec<Uuid> {
+        let mut candidates = Self::ext_id_uuid_all(item);
+        candidates.retain(|u| *u != item.id);
+        candidates
+    }
+
+    /// As `ext_id_uuid_candidates`, but keeps the row's current UUID. `validate`
+    /// needs the unfiltered set: a row whose canonical ID changed after it was
+    /// written (Kitsu anime that later gains an IMDB ID) still owns the UUID it
+    /// was stored under.
+    fn ext_id_uuid_all(item: &Self) -> Vec<Uuid> {
         use crate::common::stable_media_uuid;
         let kind = &item.kind;
         let ext = &item.external_ids;
@@ -2900,7 +2908,6 @@ impl Media {
             }
             _ => {}
         }
-        candidates.retain(|u| *u != item.id);
         candidates
     }
 
@@ -8393,6 +8400,53 @@ mod tests {
                 "kitsu:555"
             ]
         );
+    }
+
+    /// Regression: a Kitsu-imported series derives its UUID from
+    /// `custom_stremio_id`, often its only identity. TMDB enrichment rebuilt
+    /// `ExternalIds` from scratch, so `validate` then rejected the row and the
+    /// series vanished from its library.
+    #[test]
+    fn kitsu_series_still_validates_after_tmdb_enrichment() {
+        let mut media = Media {
+            kind: MediaKind::Series,
+            title: "Daemons of the Shadow Realm".to_string(),
+            external_ids: ExternalIds::from_stremio_id("kitsu:50023"),
+            ..Default::default()
+        };
+        media.id = Uuid::from(&media.media_id_raw());
+        assert_eq!(
+            media
+                .id
+                .to_string(),
+            "cffb332d-0f99-5725-968d-26d2d5cc0e8c",
+            "a kitsu-only series is keyed on its Stremio ID"
+        );
+        media
+            .validate()
+            .expect("freshly imported kitsu series must be valid");
+
+        // Everything TMDB contributes; it knows nothing about kitsu.
+        let tmdb_ids = ExternalIds {
+            tmdb: Some(260463),
+            imdb: NonEmptyString::try_new("tt37532356".to_string()).ok(),
+            tvdb: Some(452711),
+            ..Default::default()
+        };
+        media
+            .external_ids
+            .merge(&tmdb_ids, false);
+
+        assert_eq!(
+            media
+                .external_ids
+                .kitsu,
+            Some(50023),
+            "enrichment must not drop the ID the UUID was derived from"
+        );
+        media
+            .validate()
+            .expect("enrichment must not invalidate the row it just enriched");
     }
 
     #[test]


### PR DESCRIPTION
Hello, my animes were dropped from importing if they had both imdb and kitsu ids but were imported from kitsu. Example log below:


```
ERROR remux_server::db::media:2513: skipping media item with invalid UUID error=Invalid media: Series '<title>' UUID mismatch: id=<incoming_id> expected=<computed_id>
27 series hit this in one refresh pass (09:52:57–09:55:49). Sample of the raw lines:


09:52:57 ERROR remux_server::db::media:2513: skipping media item with invalid UUID error=Invalid media: Series 'Witch Hat Atelier' UUID mismatch: id=6735948c-c6d1-5621-8efa-39ad6eb17b31 expected=faea4489-1e26-569d-a91b-21f234ed1fb4
09:52:57 ERROR remux_server::db::media:2513: skipping media item with invalid UUID error=Invalid media: Series 'LIAR GAME' UUID mismatch: id=83e617c6-10e8-5d28-8189-4fa6e8f5c7aa expected=ef69b9bd-830c-5d8b-8628-c7e2130a20ff
09:52:57 ERROR remux_server::db::media:2513: skipping media item with invalid UUID error=Invalid media: Series 'Welcome to Demon School! Iruma-kun' UUID mismatch: id=9bb84cd5-0d17-53b2-a201-e82dc9220090 expected=41144797-c8c7-500a-ac25-3578e5328c79
09:52:57 ERROR remux_server::db::media:2513: skipping media item with invalid UUID error=Invalid media: Series 'The Classroom of a Black Cat and a Witch' UUID mismatch: id=87090520-916e-56c7-85c0-2b70a18b01cb expected=089bface-1e4f-543b-81ba-ab5cfd126728
09:52:57 ERROR remux_server::db::media:2513: skipping media item with invalid UUID error=Invalid media: Series 'The Ramparts of Ice' UUID mismatch: id=9e93ae73-4415-529f-a4a3-0c0671220cf1 expected=1af94c9f-a7c5-5447-8548-4f214da28cbb
09:54:56 ERROR remux_server::db::media:2513: skipping media item with invalid UUID error=Invalid media: Series 'Onegai AiPri' UUID mismatch: id=c35e9f11-f1bb-5897-a90d-60c760ad806d expected=a7431fae-9685-55d6-8093-19853e8d43b6
09:55:02 ERROR remux_server::db::media:2513: skipping media item with invalid UUID error=Invalid media: Series 'Zhe Tian' UUID mismatch: id=cd87c2b5-1a23-5d75-b0e8-d55dea5a1b00 expected=84a9478b-346a-5674-9743-4763de85048a
09:55:06 ERROR remux_server::db::media:2513: skipping media item with invalid UUID error=Invalid media: Series 'Daemons of the Shadow Realm' UUID mismatch: id=cffb332d-0f99-5725-968d-26d2d5cc0e8c expected=095e510e-4f81-5646-80a6-af8b10293991
09:55:46 ERROR remux_server::db::media:2513: skipping media item with invalid UUID error=Invalid media: Series 'Mushen Ji' UUID mismatch: id=f5511827-7b56-5215-8a62-96816b479bc3 expected=30563d24-a4b9-50b8-9d6a-0c8f55a083a8
09:55:49 ERROR remux_server::db::media:2513: skipping media item with invalid UUID error=Invalid media: Series 'MAO' UUID mismatch: id=f903a590-9bf2-591f-a2d6-3c85bdb36443 expected=be648687-2736-5dd2-8495-681c2f7090c0
```

Claude's explanation and fix:

A Series imported from a Kitsu catalog is keyed on custom_stremio_id ("kitsu:N"). Identity priority is imdb ▸ custom_stremio_id ▸ tmdb ▸ tvdb ▸ kitsu, and anime is frequently absent from IMDB at import time, so the row is stored under uuid5("series:kitsu:N").

The rejection happens when that stops being true. Once TMDB enrichment supplies an
IMDB ID:
1. refresh_meta recomputes media.id to the IMDB-derived UUID. So far id and expected agree.
2. find_existing_id_by_ext then locates the stored kitsu-keyed row and adopts its UUID back onto the item — correctly, since that is the row we mean to update. The item now carries a kitsu-derived id alongside an IMDB-derived canonical. This is the state validate sees, and nothing about it is wrong.
3. validate is meant to allow exactly this: it tries to accept an ID still derivable from the item's own external IDs, via ext_id_uuid_candidates. But that helper ends with candidates.retain(|u| *u != item.id) — it strips the item's own UUID by design, because its real job is finding *other* rows to deduplicate against. contains(&self.id) was therefore always false, the escape hatch was dead code, and validate rejected every row whose canonical ID had changed since it was written.
4. Media::upsert filters the item out, logs the line above, and returns Ok(()). The caller cannot tell the write was discarded.

Impact: nothing is deleted. The row keeps its previous metadata and its library membership. But refreshed_at is set in memory by refresh_meta and persisted only by the upsert, so it is never recorded — every later pass re-fetches, re-rejects and re-logs the same items. They stay frozen at their import-time metadata indefinitely.

Fix: split the derivation into ext_id_uuid_all (unfiltered, used by validate) and keep ext_id_uuid_candidates self-excluding for its existing callers (find_existing_id_by_ext, the UserMediaState lookups). validate now accepts a row whose UUID is derivable from any identity it actually owns, not only the current top-priority one; the check is gated to Movie | Series, so nothing else is affected. The regression test reproduces the 'Daemons of the Shadow Realm' line with its production UUIDs: uuid5("series:kitsu:50023") = cffb332d-0f99-5725-968d-26d2d5cc0e8c, and the logged expected 095e510e-4f81-5646-80a6-af8b10293991 = uuid5("series:tt37532356").

Also in this change, but not a cause of the above: fetch_tmdb_meta rebuilt ExternalIds from scratch with ..Default::default(), so the patch it returns describes only what TMDB knows. Patches reach the row through merge_media → ExternalIds::merge → merge_option, which never clears a Some, so kitsu, custom_stremio_id and custom_stremio_type survive today. It is corrected anyway: any caller consuming the patch standalone would lose them, and for movies the explicit merge subsumes the manual imdb/tvdb fallbacks the branch was doing by hand.