### PR TITLE
feat: honor AnyProviderIdEquals for TMDB/IMDb/TVDB lookups

### DIFF
--- a/crates/remux-sdks/src/remux/mod.rs
+++ b/crates/remux-sdks/src/remux/mod.rs
@@ -1,8 +1,10 @@
 pub mod codecs;
+pub mod provider_ids;
 pub use codecs::{
     AudioCodec, AudioContainer, DlnaProfileType, SubtitleCodec, TranscodingProtocol,
     VideoCodec, VideoContainer,
 };
+pub use provider_ids::AnyProviderIds;
 
 use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
 use http::{HeaderValue, Method};
@@ -1274,6 +1276,14 @@ pub struct GetItemsQuery {
     pub start_index: Option<u32>,
     pub limit: Option<u32>,
     pub search_term: Option<String>,
+    /// Emby/Jellyfin `AnyProviderIdEquals` — `Tmdb.123,Imdb.tt456,Tvdb.789`.
+    #[serde(
+        deserialize_with = "deserialize_separated_str",
+        serialize_with = "serialize_comma_opt",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub any_provider_id_equals: Option<Vec<String>>,
     pub parent_id: Option<Uuid>,
     pub season_id: Option<Uuid>,
     /// Internal server-side constraint. This is not a Jellyfin query parameter.
@@ -1507,6 +1517,15 @@ impl GetItemsQuery {
         //}
 
         requested
+    }
+
+    /// `None` when the client did not send `AnyProviderIdEquals`.
+    /// `Some` (possibly empty) when it did, so callers can return no rows
+    /// instead of ignoring a malformed filter.
+    pub fn any_provider_ids(&self) -> Option<AnyProviderIds> {
+        self.any_provider_id_equals
+            .as_ref()
+            .map(|tokens| AnyProviderIds::parse(tokens))
     }
 }
 
@@ -6606,6 +6625,24 @@ pub struct RefreshItemQuery {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn get_items_query_deserializes_any_provider_id_equals() {
+        let q: GetItemsQuery = serde_json::from_value(serde_json::json!({
+            "AnyProviderIdEquals": "Tmdb.27205,Imdb.tt1375666"
+        }))
+        .unwrap();
+        assert_eq!(
+            q.any_provider_id_equals
+                .as_deref(),
+            Some(["Tmdb.27205".to_string(), "Imdb.tt1375666".to_string()].as_slice())
+        );
+        let ids = q
+            .any_provider_ids()
+            .unwrap();
+        assert_eq!(ids.tmdb, vec![27205]);
+        assert_eq!(ids.imdb, vec!["tt1375666".to_string()]);
+    }
 
     #[test]
     fn user_policy_does_not_advertise_unimplemented_sync_play() {

--- a/crates/remux-sdks/src/remux/mod.rs
+++ b/crates/remux-sdks/src/remux/mod.rs
@@ -1276,7 +1276,7 @@ pub struct GetItemsQuery {
     pub start_index: Option<u32>,
     pub limit: Option<u32>,
     pub search_term: Option<String>,
-    /// Emby/Jellyfin `AnyProviderIdEquals` — `Tmdb.123,Imdb.tt456,Tvdb.789`.
+    /// Emby `AnyProviderIdEquals` — `Tmdb.123,Imdb.tt456,Tvdb.789`.
     #[serde(
         deserialize_with = "deserialize_separated_str",
         serialize_with = "serialize_comma_opt",
@@ -1519,7 +1519,7 @@ impl GetItemsQuery {
         requested
     }
 
-    /// `None` when the client did not send `AnyProviderIdEquals`.
+    /// `None` when the client did not send Emby `AnyProviderIdEquals`.
     /// `Some` (possibly empty) when it did, so callers can return no rows
     /// instead of ignoring a malformed filter.
     pub fn any_provider_ids(&self) -> Option<AnyProviderIds> {

--- a/crates/remux-sdks/src/remux/provider_ids.rs
+++ b/crates/remux-sdks/src/remux/provider_ids.rs
@@ -1,0 +1,147 @@
+/// Parsed Emby/Jellyfin `AnyProviderIdEquals` tokens.
+///
+/// Clients such as Infuse, UHF, and EPlayer look up library items by
+/// `Tmdb.{id}`, `Imdb.tt…`, and `Tvdb.{id}`. Matching is OR across tokens.
+#[derive(
+    Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize,
+)]
+pub struct AnyProviderIds {
+    pub tmdb: Vec<i64>,
+    pub imdb: Vec<String>,
+    pub tvdb: Vec<i64>,
+}
+
+impl AnyProviderIds {
+    pub fn parse(tokens: &[String]) -> Self {
+        let mut ids = Self::default();
+        for token in tokens {
+            ids.push_token(token);
+        }
+        ids
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.tmdb
+            .is_empty()
+            && self
+                .imdb
+                .is_empty()
+            && self
+                .tvdb
+                .is_empty()
+    }
+
+    fn push_token(&mut self, token: &str) {
+        let token = token.trim();
+        if token.is_empty() {
+            return;
+        }
+        let Some((provider, value)) = token
+            .split_once('.')
+            .or_else(|| token.split_once(':'))
+        else {
+            return;
+        };
+        let provider = provider
+            .trim()
+            .to_ascii_lowercase();
+        let value = value.trim();
+        if value.is_empty() {
+            return;
+        }
+        match provider.as_str() {
+            "tmdb" | "themoviedb" | "tmdbid" => {
+                if let Ok(n) = value.parse::<i64>() {
+                    if n > 0
+                        && !self
+                            .tmdb
+                            .contains(&n)
+                    {
+                        self.tmdb
+                            .push(n);
+                    }
+                }
+            }
+            "imdb" | "imdbid" => {
+                if !self
+                    .imdb
+                    .iter()
+                    .any(|existing| existing.eq_ignore_ascii_case(value))
+                {
+                    self.imdb
+                        .push(value.to_string());
+                }
+            }
+            "tvdb" | "thetvdb" | "tvdbid" => {
+                if let Ok(n) = value.parse::<i64>() {
+                    if n > 0
+                        && !self
+                            .tvdb
+                            .contains(&n)
+                    {
+                        self.tvdb
+                            .push(n);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_emby_style_tmdb_imdb_tvdb_tokens() {
+        let ids = AnyProviderIds::parse(&[
+            "Tmdb.27205".to_string(),
+            "Imdb.tt1375666".to_string(),
+            "Tvdb.81189".to_string(),
+        ]);
+        assert_eq!(
+            ids,
+            AnyProviderIds {
+                tmdb: vec![27205],
+                imdb: vec!["tt1375666".to_string()],
+                tvdb: vec![81189],
+            }
+        );
+    }
+
+    #[test]
+    fn accepts_colon_separator_and_provider_aliases() {
+        let ids = AnyProviderIds::parse(&[
+            "themoviedb:550".to_string(),
+            "imdbid.tt0137523".to_string(),
+            "TheTvdb.81189".to_string(),
+        ]);
+        assert_eq!(ids.tmdb, vec![550]);
+        assert_eq!(ids.imdb, vec!["tt0137523".to_string()]);
+        assert_eq!(ids.tvdb, vec![81189]);
+    }
+
+    #[test]
+    fn ignores_unknown_providers_and_empty_values() {
+        let ids = AnyProviderIds::parse(&[
+            "Tmdb.".to_string(),
+            "Kitsu.123".to_string(),
+            "not-a-provider-id".to_string(),
+            "".to_string(),
+        ]);
+        assert!(ids.is_empty());
+    }
+
+    #[test]
+    fn deduplicates_repeated_tokens() {
+        let ids = AnyProviderIds::parse(&[
+            "Tmdb.550".to_string(),
+            "tmdb:550".to_string(),
+            "Imdb.tt0137523".to_string(),
+            "imdb.tt0137523".to_string(),
+        ]);
+        assert_eq!(ids.tmdb, vec![550]);
+        assert_eq!(ids.imdb, vec!["tt0137523".to_string()]);
+    }
+}

--- a/crates/remux-sdks/src/remux/provider_ids.rs
+++ b/crates/remux-sdks/src/remux/provider_ids.rs
@@ -1,4 +1,6 @@
-/// Parsed Emby/Jellyfin `AnyProviderIdEquals` tokens.
+use std::str::FromStr;
+
+/// Parsed Emby `AnyProviderIdEquals` tokens.
 ///
 /// Clients such as Infuse, UHF, and EPlayer look up library items by
 /// `Tmdb.{id}`, `Imdb.tt…`, and `Tvdb.{id}`. Matching is OR across tokens.
@@ -9,6 +11,17 @@ pub struct AnyProviderIds {
     pub tmdb: Vec<i64>,
     pub imdb: Vec<String>,
     pub tvdb: Vec<i64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum_macros::EnumString)]
+#[strum(serialize_all = "lowercase", ascii_case_insensitive)]
+enum ProviderAlias {
+    #[strum(serialize = "tmdb", serialize = "themoviedb", serialize = "tmdbid")]
+    Tmdb,
+    #[strum(serialize = "imdb", serialize = "imdbid")]
+    Imdb,
+    #[strum(serialize = "tvdb", serialize = "thetvdb", serialize = "tvdbid")]
+    Tvdb,
 }
 
 impl AnyProviderIds {
@@ -42,15 +55,15 @@ impl AnyProviderIds {
         else {
             return;
         };
-        let provider = provider
-            .trim()
-            .to_ascii_lowercase();
         let value = value.trim();
         if value.is_empty() {
             return;
         }
-        match provider.as_str() {
-            "tmdb" | "themoviedb" | "tmdbid" => {
+        let Ok(kind) = ProviderAlias::from_str(provider.trim()) else {
+            return;
+        };
+        match kind {
+            ProviderAlias::Tmdb => {
                 if let Ok(n) = value.parse::<i64>() {
                     if n > 0
                         && !self
@@ -62,7 +75,7 @@ impl AnyProviderIds {
                     }
                 }
             }
-            "imdb" | "imdbid" => {
+            ProviderAlias::Imdb => {
                 if !self
                     .imdb
                     .iter()
@@ -72,7 +85,7 @@ impl AnyProviderIds {
                         .push(value.to_string());
                 }
             }
-            "tvdb" | "thetvdb" | "tvdbid" => {
+            ProviderAlias::Tvdb => {
                 if let Ok(n) = value.parse::<i64>() {
                     if n > 0
                         && !self
@@ -84,7 +97,6 @@ impl AnyProviderIds {
                     }
                 }
             }
-            _ => {}
         }
     }
 }

--- a/crates/remux-server/src/api/items.rs
+++ b/crates/remux-server/src/api/items.rs
@@ -5664,9 +5664,10 @@ mod tests {
     }
 
     fn item_ids(body: &serde_json::Value) -> Vec<String> {
-        body["Items"]
-            .as_array()
-            .unwrap_or(&vec![])
+        let Some(items) = body["Items"].as_array() else {
+            return Vec::new();
+        };
+        items
             .iter()
             .filter_map(|item| {
                 item["Id"]

--- a/crates/remux-server/src/api/items.rs
+++ b/crates/remux-server/src/api/items.rs
@@ -5623,4 +5623,226 @@ mod tests {
             "season whose series rating exceeds max must be blocked"
         );
     }
+
+    async fn insert_media_with_provider_ids(
+        db: &sqlx::SqlitePool,
+        title: &str,
+        kind: db::MediaKind,
+        imdb: &str,
+        tmdb: Option<i64>,
+        tvdb: Option<i64>,
+    ) -> db::Media {
+        let now = Utc::now().naive_utc();
+        let ext = ExternalIds {
+            imdb: Some(NonEmptyString::try_new(imdb.to_string()).unwrap()),
+            tmdb,
+            tvdb,
+            ..Default::default()
+        };
+        let id = Uuid::from(&MediaIdRaw {
+            kind: kind.clone(),
+            external_ids: ext.clone(),
+            season: None,
+            episode: None,
+        });
+        let released = now - chrono::Duration::days(800);
+        let mut m = db::Media {
+            id,
+            title: title.to_string(),
+            kind,
+            external_ids: ext,
+            created_at: now,
+            updated_at: now,
+            released_at: Some(released),
+            digital_released_at: Some(released),
+            ..Default::default()
+        };
+        m.save(db)
+            .await
+            .expect("insert_media_with_provider_ids failed");
+        m
+    }
+
+    fn item_ids(body: &serde_json::Value) -> Vec<String> {
+        body["Items"]
+            .as_array()
+            .unwrap_or(&vec![])
+            .iter()
+            .filter_map(|item| {
+                item["Id"]
+                    .as_str()
+                    .map(|id| id.to_ascii_lowercase())
+            })
+            .collect()
+    }
+
+    fn jellyfin_id(id: Uuid) -> String {
+        id.to_string()
+            .replace('-', "")
+            .to_ascii_lowercase()
+    }
+
+    #[tokio::test]
+    async fn any_provider_id_equals_finds_movie_by_tmdb() {
+        let (server, guard, token) = authenticated_server().await;
+        let auth = auth_header_with_token(&token);
+        let db = &guard
+            .0
+            .db;
+
+        let movie = insert_media_with_provider_ids(
+            db,
+            "Inception",
+            db::MediaKind::Movie,
+            "tt1375666",
+            Some(27205),
+            None,
+        )
+        .await;
+        let stored = db::Media::get_by_id(db, &movie.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            stored
+                .external_ids
+                .tmdb,
+            Some(27205)
+        );
+        let _other = insert_media_with_provider_ids(
+            db,
+            "The Matrix",
+            db::MediaKind::Movie,
+            "tt0133093",
+            Some(603),
+            None,
+        )
+        .await;
+
+        let user_id = get_user_id(&server, &auth).await;
+        let resp = server
+            .get(&format!("/users/{user_id}/items"))
+            .add_header(
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth).unwrap(),
+            )
+            .add_query_params(&[
+                ("anyProviderIdEquals", "Tmdb.27205"),
+                ("includeItemTypes", "Movie"),
+                ("recursive", "true"),
+                ("fields", "ProviderIds"),
+            ])
+            .await;
+
+        resp.assert_status_ok();
+        let body: serde_json::Value = resp.json();
+        assert_eq!(
+            body["TotalRecordCount"]
+                .as_i64()
+                .unwrap_or(0),
+            1,
+            "http body: {body}"
+        );
+        assert_eq!(item_ids(&body), vec![jellyfin_id(movie.id)]);
+        assert_eq!(
+            body["Items"][0]["ProviderIds"]["Tmdb"].as_str(),
+            Some("27205")
+        );
+    }
+
+    #[tokio::test]
+    async fn any_provider_id_equals_matches_any_listed_provider() {
+        let (server, guard, token) = authenticated_server().await;
+        let auth = auth_header_with_token(&token);
+        let db = &guard
+            .0
+            .db;
+
+        let movie = insert_media_with_provider_ids(
+            db,
+            "Inception",
+            db::MediaKind::Movie,
+            "tt1375666",
+            Some(27205),
+            None,
+        )
+        .await;
+        let series = insert_media_with_provider_ids(
+            db,
+            "The Wire",
+            db::MediaKind::Series,
+            "tt0306414",
+            Some(1438),
+            Some(79126),
+        )
+        .await;
+
+        let user_id = get_user_id(&server, &auth).await;
+        let resp = server
+            .get("/items")
+            .add_header(
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth).unwrap(),
+            )
+            .add_query_params(&[
+                ("AnyProviderIdEquals", "Tmdb.999,Imdb.tt1375666,Tvdb.79126"),
+                ("Recursive", "true"),
+            ])
+            .await;
+
+        resp.assert_status_ok();
+        let body: serde_json::Value = resp.json();
+        let mut ids = item_ids(&body);
+        ids.sort();
+        let mut expected = vec![jellyfin_id(movie.id), jellyfin_id(series.id)];
+        expected.sort();
+        assert_eq!(ids, expected);
+    }
+
+    #[tokio::test]
+    async fn any_provider_id_equals_unknown_id_returns_empty() {
+        let (server, guard, token) = authenticated_server().await;
+        let auth = auth_header_with_token(&token);
+        let db = &guard
+            .0
+            .db;
+        let _movie = insert_media_with_provider_ids(
+            db,
+            "Inception",
+            db::MediaKind::Movie,
+            "tt1375666",
+            Some(27205),
+            None,
+        )
+        .await;
+
+        let user_id = get_user_id(&server, &auth).await;
+        let resp = server
+            .get(&format!("/users/{user_id}/items"))
+            .add_header(
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth).unwrap(),
+            )
+            .add_query_params(&[
+                ("AnyProviderIdEquals", "Tmdb.1"),
+                ("IncludeItemTypes", "Movie"),
+                ("Recursive", "true"),
+            ])
+            .await;
+
+        resp.assert_status_ok();
+        let body: serde_json::Value = resp.json();
+        assert_eq!(
+            body["TotalRecordCount"]
+                .as_i64()
+                .unwrap_or(-1),
+            0
+        );
+        assert!(
+            body["Items"]
+                .as_array()
+                .map(|items| items.is_empty())
+                .unwrap_or(false)
+        );
+    }
 }

--- a/crates/remux-server/src/db/media.rs
+++ b/crates/remux-server/src/db/media.rs
@@ -1318,7 +1318,7 @@ pub struct MediaFilter {
     /// when empty.
     pub exclude_childless: bool,
     pub exclude_ids: Option<Vec<Uuid>>,
-    /// Jellyfin/Emby `AnyProviderIdEquals` — item must match ANY listed provider ID.
+    /// Emby `AnyProviderIdEquals` — item must match ANY listed provider ID.
     pub any_provider_ids: Option<api::AnyProviderIds>,
 }
 

--- a/crates/remux-server/src/db/media.rs
+++ b/crates/remux-server/src/db/media.rs
@@ -1318,6 +1318,8 @@ pub struct MediaFilter {
     /// when empty.
     pub exclude_childless: bool,
     pub exclude_ids: Option<Vec<Uuid>>,
+    /// Jellyfin/Emby `AnyProviderIdEquals` — item must match ANY listed provider ID.
+    pub any_provider_ids: Option<api::AnyProviderIds>,
 }
 
 /// Normalise any country string to an ISO 3166-1 alpha-2 code (e.g. "US").
@@ -3886,6 +3888,44 @@ impl Media {
                     .push_bind(format!("%{}%", s));
             }
 
+            if let Some(ids) = &filter.any_provider_ids {
+                if ids.is_empty() {
+                    qb.push(" AND 0");
+                } else {
+                    qb.push(" AND (");
+                    let mut first = true;
+                    for tmdb in &ids.tmdb {
+                        if !first {
+                            qb.push(" OR ");
+                        }
+                        first = false;
+                        qb.push(
+                            "CAST(json_extract(external_ids, '$.tmdb') AS TEXT) = ",
+                        )
+                        .push_bind(tmdb.to_string());
+                    }
+                    for imdb in &ids.imdb {
+                        if !first {
+                            qb.push(" OR ");
+                        }
+                        first = false;
+                        qb.push("json_extract(external_ids, '$.imdb') = ")
+                            .push_bind(imdb);
+                    }
+                    for tvdb in &ids.tvdb {
+                        if !first {
+                            qb.push(" OR ");
+                        }
+                        first = false;
+                        qb.push(
+                            "CAST(json_extract(external_ids, '$.tvdb') AS TEXT) = ",
+                        )
+                        .push_bind(tvdb.to_string());
+                    }
+                    qb.push(")");
+                }
+            }
+
             if let Some(idx) = &filter.index_number {
                 qb.push(" AND idx = ")
                     .push_bind(idx);
@@ -5689,6 +5729,7 @@ impl Media {
                     && !filter
                         .include_childless
                         .unwrap_or(false),
+                any_provider_ids: filter.any_provider_ids(),
                 ..Default::default()
             },
         )


### PR DESCRIPTION
## Summary

Jellyfin/Emby clients (EPlayer, Infuse, UHF, and others) find library items by provider ID:

```
GET /Users/{userId}/Items?AnyProviderIdEquals=Tmdb.27205,Imdb.tt1375666&IncludeItemTypes=Movie&Recursive=true
```

Remux ignored `AnyProviderIdEquals`, so those clients could not match Remux sources to TMDB-backed titles and showed no playable resources.

This adds the missing filter:

- Parse Emby-style tokens (`Tmdb.123`, `Imdb.tt…`, `Tvdb.789`) plus common aliases (`themoviedb`, `tmdbid`, colon separators)
- Match **any** listed provider ID against `external_ids` (OR)
- Unknown / malformed tokens return an empty list instead of the whole library
- Cover `/Items` and `/Users/{id}/Items`

## Test plan

- [x] `AnyProviderIds` parse tests (Emby tokens, aliases, empty/unknown, dedupe)
- [x] `GetItemsQuery` deserializes `AnyProviderIdEquals`
- [x] `/Users/{id}/Items?AnyProviderIdEquals=Tmdb.27205&IncludeItemTypes=Movie` returns only that movie
- [x] Comma-delimited `Tmdb.999,Imdb.tt1375666,Tvdb.79126` matches any listed ID
- [x] Unknown TMDB ID returns an empty result (does not dump the library)

## AI disclosure

The initial implementation was drafted with Cursor and then reviewed, tested, and edited by me.


Made with [Cursor](https://cursor.com)