### PR TITLE
fix: hide empty subcollection groups

### DIFF
--- a/crates/remux-server/benches/common.rs
+++ b/crates/remux-server/benches/common.rs
@@ -149,7 +149,7 @@ async fn seed_all(db: &sqlx::SqlitePool, user_id: Uuid) {
 
 async fn seed_userviews(db: &sqlx::SqlitePool) {
     use remux_server::sdks::remux::{
-        CollectionFilter, FilterGroup, FilterMatchMode, FilterRule,
+        CollectionFilter, FilterGroup, FilterMatchMode, FilterRule, SetOp,
     };
 
     let plain = db::Media {
@@ -182,6 +182,48 @@ async fn seed_userviews(db: &sqlx::SqlitePool) {
     w.save(db)
         .await
         .unwrap();
+
+    // Exercise the #414 visibility path with a realistic set of promoted
+    // group containers whose smart subcollections all resolve to no content.
+    for i in 0..10 {
+        let mut group = db::Media {
+            title: format!("Empty group {i}"),
+            kind: db::MediaKind::Collection,
+            collection_kind: Some(db::CollectionKind::Manual),
+            collection_media_kind: Some(db::CollectionMediaKind::Collection),
+            promoted: true,
+            ..Default::default()
+        };
+        group
+            .save(db)
+            .await
+            .unwrap();
+
+        for j in 0..3 {
+            let mut child = db::Media {
+                title: format!("Empty group {i} child {j}"),
+                kind: db::MediaKind::Collection,
+                collection_kind: Some(db::CollectionKind::Smart),
+                collection_media_kind: Some(db::CollectionMediaKind::Movie),
+                collection_smart_filter: Some(CollectionFilter {
+                    groups: vec![FilterGroup {
+                        rules: vec![FilterRule::Tag {
+                            op: SetOp::In,
+                            values: vec!["bench:missing".to_string()],
+                        }],
+                        match_mode: FilterMatchMode::All,
+                    }],
+                    match_mode: FilterMatchMode::All,
+                }),
+                parent_id: Some(group.id),
+                ..Default::default()
+            };
+            child
+                .save(db)
+                .await
+                .unwrap();
+        }
+    }
 }
 
 async fn seed_series(

--- a/crates/remux-server/benches/userviews.rs
+++ b/crates/remux-server/benches/userviews.rs
@@ -6,7 +6,7 @@ mod common;
 use common::run_bench;
 
 fn userviews(c: &mut Criterion) {
-    c.bench_function("userviews", |b| {
+    c.bench_function("userviews/with-empty-subcollections", |b| {
         run_bench(b, "/userviews");
     });
 }

--- a/crates/remux-server/src/api/items.rs
+++ b/crates/remux-server/src/api/items.rs
@@ -4210,6 +4210,7 @@ mod tests {
             kind: db::MediaKind::Collection,
             collection_kind: Some(db::CollectionKind::Smart),
             collection_media_kind: Some(db::CollectionMediaKind::Movie),
+            collection_smart_filter: Some(tag_filter("provider:NobodyHasThis")),
             promoted: false,
             ..Default::default()
         };
@@ -4282,6 +4283,7 @@ mod tests {
             kind: db::MediaKind::Collection,
             collection_kind: Some(db::CollectionKind::Smart),
             collection_media_kind: Some(db::CollectionMediaKind::Movie),
+            collection_smart_filter: Some(tag_filter("provider:NobodyHasThis")),
             parent_id: Some(nested.id),
             ..Default::default()
         };

--- a/crates/remux-server/src/api/items.rs
+++ b/crates/remux-server/src/api/items.rs
@@ -4182,6 +4182,217 @@ mod tests {
         );
     }
 
+    // Regression #414: a promoted collection-of-collections must disappear
+    // from /UserViews when every child collection is empty.
+    #[tokio::test]
+    async fn userviews_hides_group_container_with_only_empty_subcollections() {
+        let (server, guard, token) = authenticated_server().await;
+        let auth = auth_header_with_token(&token);
+        let db = &guard
+            .0
+            .db;
+
+        let mut group = db::Media {
+            title: "Empty group".to_string(),
+            kind: db::MediaKind::Collection,
+            collection_kind: Some(db::CollectionKind::Manual),
+            collection_media_kind: Some(db::CollectionMediaKind::Collection),
+            promoted: true,
+            ..Default::default()
+        };
+        group
+            .save(db)
+            .await
+            .unwrap();
+
+        let mut child = db::Media {
+            title: "Empty child".to_string(),
+            kind: db::MediaKind::Collection,
+            collection_kind: Some(db::CollectionKind::Smart),
+            collection_media_kind: Some(db::CollectionMediaKind::Movie),
+            promoted: false,
+            ..Default::default()
+        };
+        child
+            .save(db)
+            .await
+            .unwrap();
+        db::Media::set_parent_id(db, &[child.id], Some(group.id))
+            .await
+            .unwrap();
+
+        let body: serde_json::Value = server
+            .get("/userviews")
+            .add_header(
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth).unwrap(),
+            )
+            .await
+            .json();
+        let group_id = group
+            .id
+            .to_string()
+            .replace('-', "");
+
+        assert!(
+            !body["Items"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|item| item["Id"].as_str() == Some(group_id.as_str())),
+            "group container with only empty subcollections must not appear in /UserViews; got: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn userviews_hides_nested_empty_group_containers() {
+        let (server, guard, token) = authenticated_server().await;
+        let auth = auth_header_with_token(&token);
+        let db = &guard
+            .0
+            .db;
+
+        let mut root = db::Media {
+            title: "Empty root group".to_string(),
+            kind: db::MediaKind::Collection,
+            collection_kind: Some(db::CollectionKind::Manual),
+            collection_media_kind: Some(db::CollectionMediaKind::Collection),
+            promoted: true,
+            ..Default::default()
+        };
+        root.save(db)
+            .await
+            .unwrap();
+
+        let mut nested = db::Media {
+            title: "Empty nested group".to_string(),
+            kind: db::MediaKind::Collection,
+            collection_kind: Some(db::CollectionKind::Manual),
+            collection_media_kind: Some(db::CollectionMediaKind::Collection),
+            parent_id: Some(root.id),
+            ..Default::default()
+        };
+        nested
+            .save(db)
+            .await
+            .unwrap();
+
+        let mut leaf = db::Media {
+            title: "Empty nested child".to_string(),
+            kind: db::MediaKind::Collection,
+            collection_kind: Some(db::CollectionKind::Smart),
+            collection_media_kind: Some(db::CollectionMediaKind::Movie),
+            parent_id: Some(nested.id),
+            ..Default::default()
+        };
+        leaf.save(db)
+            .await
+            .unwrap();
+
+        let body: serde_json::Value = server
+            .get("/userviews")
+            .add_header(
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth).unwrap(),
+            )
+            .await
+            .json();
+        let root_id = root
+            .id
+            .to_string()
+            .replace('-', "");
+
+        assert!(
+            !body["Items"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|item| item["Id"].as_str() == Some(root_id.as_str())),
+            "nested empty group containers must not appear in /UserViews; got: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn userviews_keeps_group_container_with_populated_subcollection() {
+        let (server, guard, token) = authenticated_server().await;
+        let auth = auth_header_with_token(&token);
+        let db = &guard
+            .0
+            .db;
+
+        let mut group = db::Media {
+            title: "Populated group".to_string(),
+            kind: db::MediaKind::Collection,
+            collection_kind: Some(db::CollectionKind::Manual),
+            collection_media_kind: Some(db::CollectionMediaKind::Collection),
+            promoted: true,
+            ..Default::default()
+        };
+        group
+            .save(db)
+            .await
+            .unwrap();
+
+        let mut child = db::Media {
+            title: "Populated child".to_string(),
+            kind: db::MediaKind::Collection,
+            collection_kind: Some(db::CollectionKind::Manual),
+            collection_media_kind: Some(db::CollectionMediaKind::Movie),
+            parent_id: Some(group.id),
+            ..Default::default()
+        };
+        child
+            .save(db)
+            .await
+            .unwrap();
+
+        let external_ids = ExternalIds {
+            imdb: Some(NonEmptyString::try_new("tt_issue414".to_string()).unwrap()),
+            ..Default::default()
+        };
+        let mut movie = db::Media {
+            id: Uuid::from(&MediaIdRaw {
+                kind: db::MediaKind::Movie,
+                external_ids: external_ids.clone(),
+                season: None,
+                episode: None,
+            }),
+            title: "Collection member".to_string(),
+            kind: db::MediaKind::Movie,
+            external_ids,
+            ..Default::default()
+        };
+        movie
+            .save(db)
+            .await
+            .unwrap();
+        db::MediaRelation::add_collection_items(db, &child.id, &[movie.id])
+            .await
+            .unwrap();
+
+        let body: serde_json::Value = server
+            .get("/userviews")
+            .add_header(
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth).unwrap(),
+            )
+            .await
+            .json();
+        let group_id = group
+            .id
+            .to_string()
+            .replace('-', "");
+
+        assert!(
+            body["Items"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|item| item["Id"].as_str() == Some(group_id.as_str())),
+            "group container with a populated subcollection must appear in /UserViews; got: {body}"
+        );
+    }
+
     // Regression: GET /Items?parentId=<alias-uuid> used db::Media::get_by_id for the parent
     // lookup, which does a straight WHERE id = $1 and cannot follow alias mappings in the
     // in-memory store. Stremio addons expose series under a virtual alias UUID; children are

--- a/crates/remux-server/src/db/media.rs
+++ b/crates/remux-server/src/db/media.rs
@@ -3241,6 +3241,7 @@ impl Media {
                 &MediaFilter {
                     kind: Some(vec![MediaKind::Collection]),
                     parent_id: Some(parent_id),
+                    include_child_count: true,
                     user_id,
                     policy_filter: policy_filter.clone(),
                     ..Default::default()
@@ -3256,19 +3257,9 @@ impl Media {
                 }
 
                 let visible = match child.collection_kind {
-                    Some(CollectionKind::Smart) => !Box::pin(Self::get_by_filter(
-                        db,
-                        &MediaFilter {
-                            id: Some(vec![child.id]),
-                            exclude_childless: true,
-                            user_id,
-                            policy_filter: policy_filter.clone(),
-                            ..Default::default()
-                        },
-                    ))
-                    .await?
-                    .records
-                    .is_empty(),
+                    Some(CollectionKind::Smart) => child
+                        .child_count
+                        .is_some_and(|count| count > 0),
                     Some(CollectionKind::Manual) => !Box::pin(Self::get_by_filter(
                         db,
                         &MediaFilter {

--- a/crates/remux-server/src/db/media.rs
+++ b/crates/remux-server/src/db/media.rs
@@ -39,7 +39,7 @@ use serde_with::skip_serializing_none;
 use sqlx::{Row, SqlitePool};
 use std::{
     self,
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     env, fs,
     path::Path,
     str::FromStr,
@@ -3212,6 +3212,89 @@ impl Media {
         Ok(out)
     }
 
+    /// Whether a collection-of-collections has a reachable child collection
+    /// that would itself be visible. Group containers hold their children via
+    /// `parent_id`, unlike regular manual collections, which use relations.
+    ///
+    /// Walk groups iteratively to avoid recursion and to guard against a
+    /// malformed parent cycle. The number of promoted groups is small, while
+    /// the leaf checks reuse the normal collection query paths so smart and
+    /// policy filters keep their usual semantics.
+    async fn group_container_has_visible_content(
+        db: &SqlitePool,
+        group_id: Uuid,
+        user_id: Option<Uuid>,
+        policy_filter: Option<remux_sdks::remux::CollectionFilter>,
+    ) -> Result<bool> {
+        let mut pending = vec![group_id];
+        let mut visited = HashSet::new();
+
+        while let Some(parent_id) = pending.pop() {
+            if !visited.insert(parent_id) {
+                continue;
+            }
+
+            let children = Box::pin(Self::get_by_filter(
+                db,
+                &MediaFilter {
+                    kind: Some(vec![MediaKind::Collection]),
+                    parent_id: Some(parent_id),
+                    user_id,
+                    policy_filter: policy_filter.clone(),
+                    ..Default::default()
+                },
+            ))
+            .await?
+            .records;
+
+            for child in children {
+                if child.is_group_container() {
+                    pending.push(child.id);
+                    continue;
+                }
+
+                let visible = match child.collection_kind {
+                    Some(CollectionKind::Smart) => !Box::pin(Self::get_by_filter(
+                        db,
+                        &MediaFilter {
+                            id: Some(vec![child.id]),
+                            exclude_childless: true,
+                            user_id,
+                            policy_filter: policy_filter.clone(),
+                            ..Default::default()
+                        },
+                    ))
+                    .await?
+                    .records
+                    .is_empty(),
+                    Some(CollectionKind::Manual) => !Box::pin(Self::get_by_filter(
+                        db,
+                        &MediaFilter {
+                            parent_id: Some(child.id),
+                            parent: Some(child),
+                            limit: Some(1),
+                            user_id,
+                            policy_filter: policy_filter.clone(),
+                            ..Default::default()
+                        },
+                    ))
+                    .await?
+                    .records
+                    .is_empty(),
+                    // Preserve legacy collections whose storage convention
+                    // predates explicit collection kinds.
+                    None => true,
+                };
+
+                if visible {
+                    return Ok(true);
+                }
+            }
+        }
+
+        Ok(false)
+    }
+
     pub async fn get_by_filter(
         db: &SqlitePool,
         filter: &MediaFilter,
@@ -5202,10 +5285,31 @@ impl Media {
 
         // Drop empty containers when requested. child_count is already populated
         // for all container kinds (including smart/catalog) by the branches above.
-        // Structural "collection of collections" containers always show.
+        // A structural collection-of-collections is visible only when it has a
+        // non-empty descendant collection.
         let sql_total = count?;
 
         if filter.exclude_childless {
+            let mut nonempty_groups = HashSet::new();
+            for group_id in records
+                .iter()
+                .filter(|m| m.is_group_container())
+                .map(|m| m.id)
+            {
+                if Self::group_container_has_visible_content(
+                    db,
+                    group_id,
+                    filter.user_id,
+                    filter
+                        .policy_filter
+                        .clone(),
+                )
+                .await?
+                {
+                    nonempty_groups.insert(group_id);
+                }
+            }
+
             records.retain(|m| {
                 if !matches!(
                     m.kind,
@@ -5214,7 +5318,7 @@ impl Media {
                     return true;
                 }
                 if m.is_group_container() {
-                    return true;
+                    return nonempty_groups.contains(&m.id);
                 }
                 m.child_count
                     .map_or(true, |c| c > 0)


### PR DESCRIPTION
Fixes #414\n\n- Hide promoted group collections when all subcollections are empty\n- Preserve nested groups with visible descendant content\n- Add regression coverage and an expanded UserViews benchmark