### PR TITLE
refactor: name external ID providers explicitly

### DIFF
--- a/crates/remux-sdks/src/remux/mod.rs
+++ b/crates/remux-sdks/src/remux/mod.rs
@@ -4,7 +4,7 @@ pub use codecs::{
     AudioCodec, AudioContainer, DlnaProfileType, SubtitleCodec, TranscodingProtocol,
     VideoCodec, VideoContainer,
 };
-pub use provider_ids::AnyProviderIds;
+pub use provider_ids::{AnyProviderIds, ExternalIdProvider};
 
 use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
 use http::{HeaderValue, Method};

--- a/crates/remux-sdks/src/remux/provider_ids.rs
+++ b/crates/remux-sdks/src/remux/provider_ids.rs
@@ -13,9 +13,12 @@ pub struct AnyProviderIds {
     pub tvdb: Vec<i64>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, strum_macros::EnumString)]
+/// The external-ID namespace named by an Emby `AnyProviderIdEquals` token.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, strum_macros::EnumString, strum_macros::Display,
+)]
 #[strum(serialize_all = "lowercase", ascii_case_insensitive)]
-enum ProviderAlias {
+enum ExternalIdProvider {
     #[strum(serialize = "tmdb", serialize = "themoviedb", serialize = "tmdbid")]
     Tmdb,
     #[strum(serialize = "imdb", serialize = "imdbid")]
@@ -59,11 +62,11 @@ impl AnyProviderIds {
         if value.is_empty() {
             return;
         }
-        let Ok(kind) = ProviderAlias::from_str(provider.trim()) else {
+        let Ok(kind) = ExternalIdProvider::from_str(provider.trim()) else {
             return;
         };
         match kind {
-            ProviderAlias::Tmdb => {
+            ExternalIdProvider::Tmdb => {
                 if let Ok(n) = value.parse::<i64>() {
                     if n > 0
                         && !self
@@ -75,7 +78,7 @@ impl AnyProviderIds {
                     }
                 }
             }
-            ProviderAlias::Imdb => {
+            ExternalIdProvider::Imdb => {
                 if !self
                     .imdb
                     .iter()
@@ -85,7 +88,7 @@ impl AnyProviderIds {
                         .push(value.to_string());
                 }
             }
-            ProviderAlias::Tvdb => {
+            ExternalIdProvider::Tvdb => {
                 if let Ok(n) = value.parse::<i64>() {
                     if n > 0
                         && !self

--- a/crates/remux-sdks/src/remux/provider_ids.rs
+++ b/crates/remux-sdks/src/remux/provider_ids.rs
@@ -18,7 +18,7 @@ pub struct AnyProviderIds {
     Debug, Clone, Copy, PartialEq, Eq, strum_macros::EnumString, strum_macros::Display,
 )]
 #[strum(serialize_all = "lowercase", ascii_case_insensitive)]
-enum ExternalIdProvider {
+pub enum ExternalIdProvider {
     #[strum(serialize = "tmdb", serialize = "themoviedb", serialize = "tmdbid")]
     Tmdb,
     #[strum(serialize = "imdb", serialize = "imdbid")]


### PR DESCRIPTION
Renames the private AnyProviderIdEquals parser enum from ProviderAlias to ExternalIdProvider and derives Display alongside EnumString.\n\nTests: cargo test -p remux-sdks provider_ids