### PR TITLE
fix(remuxdb): submit HTTP debrid probes with preserved torrent identity

### DIFF
--- a/crates/remux-server/src/addons/mod.rs
+++ b/crates/remux-server/src/addons/mod.rs
@@ -35,9 +35,7 @@ use libc;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
-use crate::{
-    AppContext, api, common::ProgressReporter, db, sdks, stream::StreamDescriptor,
-};
+use crate::{AppContext, api, common::ProgressReporter, db, sdks};
 pub use addon::{Addon, CatalogState, set_user_addon_override, user_addon_override};
 use remux_sdks::remuxdb;
 
@@ -2818,19 +2816,7 @@ fn match_probe_version<'a>(
 
     // Torrent: match by info_hash + file_idx. Covers both raw Torrent descriptors and
     // debrid Http streams where the hash comes from AIOStreams streamData.
-    let (hash, hash_file_idx) = match si.descriptor {
-        StreamDescriptor::Torrent {
-            ref info_hash,
-            file_idx,
-            ..
-        } => (Some(info_hash.as_str()), file_idx.map(|i| i as i32)),
-        _ => (
-            si.torrent_info_hash
-                .as_deref(),
-            si.torrent_file_idx,
-        ),
-    };
-    if let Some(hash) = hash {
+    if let Some((hash, hash_file_idx)) = si.torrent_identity() {
         if let Some(v) = versions
             .iter()
             .find(|v| {

--- a/crates/remux-server/src/services/stream_service.rs
+++ b/crates/remux-server/src/services/stream_service.rs
@@ -1,7 +1,6 @@
 use crate::{
     AppContext, api, db,
     playback::probe::{probe_stream, resolve_stream_root},
-    stream::StreamDescriptor,
 };
 use remux_sdks::{
     remux::{MediaStreamType, StreamFilter, VideoRangeType},
@@ -724,13 +723,9 @@ fn media_info_from_probe(
         .as_ref()
     {
         Some(si) => {
-            let (hash, idx) = match &si.descriptor {
-                StreamDescriptor::Torrent {
-                    info_hash,
-                    file_idx,
-                    ..
-                } => (Some(info_hash.clone()), file_idx.map(|i| i as i32)),
-                _ => (None, None),
+            let (hash, idx) = match si.torrent_identity() {
+                Some((hash, idx)) => (Some(hash.to_owned()), idx),
+                None => (None, None),
             };
             let nzb = si
                 .usenet_guid
@@ -874,4 +869,143 @@ fn media_info_from_probe(
         external_ids,
         tracks,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::stream::{StreamDescriptor, StreamInfo};
+
+    const DEBRID_HASH: &str = "63259f55cd5c31826321286ae1fde40c931dee1d";
+    const DESCRIPTOR_HASH: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    /// Minimal successful probe: only `size` is required by `media_info_from_probe`.
+    fn probe_with_size(size: i64) -> api::MediaSourceInfo {
+        api::MediaSourceInfo {
+            size: Some(size),
+            ..Default::default()
+        }
+    }
+
+    fn stream_media(info: StreamInfo) -> db::Media {
+        db::Media {
+            title: "Example".to_string(),
+            stream_info: Some(info),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn media_info_from_probe_preserves_torrent_identity_for_http_debrid_stream() {
+        let stream = stream_media(StreamInfo {
+            descriptor: StreamDescriptor::http("https://debrid.example/playback/123"),
+            torrent_info_hash: Some(DEBRID_HASH.to_string()),
+            torrent_file_idx: Some(4),
+            filename: Some("Example.2026.2160p.mkv".to_string()),
+            ..Default::default()
+        });
+        let payload = media_info_from_probe(
+            &probe_with_size(12_340_295_313),
+            &stream,
+            None,
+        )
+        .expect("HTTP debrid stream with preserved torrent identity must be submitted");
+        assert_eq!(
+            payload
+                .torrent_info_hash
+                .as_deref(),
+            Some(DEBRID_HASH)
+        );
+        assert_eq!(payload.torrent_file_idx, Some(4));
+        assert!(
+            payload
+                .nzb
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn media_info_from_probe_prefers_torrent_descriptor_identity() {
+        let stream = stream_media(StreamInfo {
+            descriptor: StreamDescriptor::Torrent {
+                info_hash: DESCRIPTOR_HASH.to_string(),
+                file_hint: None,
+                file_idx: Some(7),
+                trackers: vec![],
+            },
+            torrent_info_hash: Some(DEBRID_HASH.to_string()),
+            torrent_file_idx: Some(4),
+            ..Default::default()
+        });
+        let payload =
+            media_info_from_probe(&probe_with_size(1), &stream, None).unwrap();
+        assert_eq!(
+            payload
+                .torrent_info_hash
+                .as_deref(),
+            Some(DESCRIPTOR_HASH)
+        );
+        assert_eq!(payload.torrent_file_idx, Some(7));
+    }
+
+    #[test]
+    fn media_info_from_probe_http_debrid_without_file_idx_still_submits() {
+        let stream = stream_media(StreamInfo {
+            descriptor: StreamDescriptor::http("https://debrid.example/playback/123"),
+            torrent_info_hash: Some(DEBRID_HASH.to_string()),
+            torrent_file_idx: None,
+            ..Default::default()
+        });
+        let payload =
+            media_info_from_probe(&probe_with_size(1), &stream, None).unwrap();
+        assert_eq!(
+            payload
+                .torrent_info_hash
+                .as_deref(),
+            Some(DEBRID_HASH)
+        );
+        assert_eq!(payload.torrent_file_idx, None);
+    }
+
+    #[test]
+    fn media_info_from_probe_nzb_only_stream_submits_without_torrent_identity() {
+        let stream = stream_media(StreamInfo {
+            descriptor: StreamDescriptor::http("https://usenet.example/file"),
+            usenet_guid: Some("guid-123".to_string()),
+            usenet_indexer: Some("NZBgeek".to_string()),
+            filename: Some("Example.2026.1080p.mkv".to_string()),
+            ..Default::default()
+        });
+        let payload = media_info_from_probe(&probe_with_size(1), &stream, None)
+            .expect("usenet stream must still be submitted");
+        let nzb = payload
+            .nzb
+            .expect("nzb submission populated");
+        assert_eq!(nzb.indexer, "NZBgeek");
+        assert_eq!(nzb.indexer_guid, "guid-123");
+        assert_eq!(
+            nzb.title
+                .as_deref(),
+            Some("Example.2026.1080p.mkv")
+        );
+        assert!(
+            payload
+                .torrent_info_hash
+                .is_none()
+        );
+        assert!(
+            payload
+                .torrent_file_idx
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn media_info_from_probe_skips_http_stream_without_any_identity() {
+        let stream = stream_media(StreamInfo {
+            descriptor: StreamDescriptor::http("https://cdn.example/file.mkv"),
+            ..Default::default()
+        });
+        assert!(media_info_from_probe(&probe_with_size(1), &stream, None).is_none());
+    }
 }

--- a/crates/remux-server/src/stream.rs
+++ b/crates/remux-server/src/stream.rs
@@ -266,7 +266,7 @@ pub struct StreamInfo {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stream_addon: Option<String>,
     /// Torrent info-hash for the source release (from AIOStreams streamData).
-    /// Stored independently of the descriptor so debrid Http streams can match by hash.
+    /// Stored independently of the descriptor so debrid Http streams can match and submit by hash.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub torrent_info_hash: Option<String>,
     /// File index within the torrent (from AIOStreams streamData).
@@ -281,6 +281,26 @@ pub struct StreamInfo {
 impl StreamInfo {
     pub fn is_p2p(&self) -> bool {
         matches!(self.descriptor, StreamDescriptor::Torrent { .. })
+    }
+
+    /// Torrent identity used for RemuxDB lookup and submission.
+    ///
+    /// A `Torrent` descriptor is authoritative. Any other transport (notably a
+    /// debrid `Http` stream) falls back to the identity preserved from
+    /// AIOStreams `streamData.torrent`. `None` when the stream has no torrent
+    /// identity at all.
+    pub fn torrent_identity(&self) -> Option<(&str, Option<i32>)> {
+        match &self.descriptor {
+            StreamDescriptor::Torrent {
+                info_hash,
+                file_idx,
+                ..
+            } => Some((info_hash.as_str(), file_idx.map(|i| i as i32))),
+            _ => self
+                .torrent_info_hash
+                .as_deref()
+                .map(|hash| (hash, self.torrent_file_idx)),
+        }
     }
 
     pub fn resolution_tag(&self) -> Option<String> {

--- a/crates/remux-server/src/stream.rs
+++ b/crates/remux-server/src/stream.rs
@@ -295,7 +295,11 @@ impl StreamInfo {
                 info_hash,
                 file_idx,
                 ..
-            } => Some((info_hash.as_str(), file_idx.map(|i| i as i32))),
+            } => Some((
+                info_hash.as_str(),
+                // Indices beyond i32 can't be represented in RemuxDB; treat as unknown.
+                file_idx.and_then(|i| i32::try_from(i).ok()),
+            )),
             _ => self
                 .torrent_info_hash
                 .as_deref()


### PR DESCRIPTION
## What

AIOStreams debrid streams play over HTTP but expose the original torrent via `streamData.torrent.{infoHash,fileIdx}`. Remux already keeps that in `StreamInfo.torrent_info_hash` / `torrent_file_idx` (separate from the descriptor, so the stream stays HTTP), and `match_probe_version` already uses it to *look up* RemuxDB versions for HTTP streams.

The *submission* side didn't: `media_info_from_probe` only read the hash from `StreamDescriptor::Torrent`, so for an HTTP/debrid stream it ended up with no hash, hit the `info_hash.is_none() && nzb.is_none()` guard, and the freshly probed data was never sent to RemuxDB at all.

## Fix

- New `StreamInfo::torrent_identity()`: `Torrent` descriptor wins, otherwise fall back to the preserved `streamData.torrent` identity.
- Both `match_probe_version` (lookup) and `media_info_from_probe` (submission) now go through it, so they can't drift apart again.

Transport is untouched: the stream stays `StreamDescriptor::Http`, ffprobe still hits the debrid URL, nothing becomes P2P.

## Tests

Unit tests on `media_info_from_probe`:
- HTTP + preserved hash + fileIdx → submitted with both
- HTTP + hash, no fileIdx → still submitted
- raw `Torrent` descriptor beats the metadata hash
- NZB-only stream unchanged
- HTTP with no identity at all → still skipped

The first two fail on `main`. `cargo test -p remux-server -- --test-threads=1` and `cargo fmt --all -- --check` pass locally (serial run because on a 16-thread box the parallel server-booting tests exhaust the 10-port librqbit range `6881..6891`; unrelated to this change).
