### PR TITLE
fix: return language-neutral TMDB backdrops

### DIFF
--- a/crates/remux-sdks/src/tmdb/movie.rs
+++ b/crates/remux-sdks/src/tmdb/movie.rs
@@ -66,6 +66,7 @@ pub struct MovieEndpoint {
     #[serde(skip)]
     pub id: i64,
     pub language: Option<String>,
+    pub include_image_language: Option<String>,
     #[serde(
         skip_serializing_if = "Vec::is_empty",
         serialize_with = "serialize_comma"
@@ -78,8 +79,14 @@ impl MovieEndpoint {
         Self {
             id,
             language,
+            include_image_language: None,
             append_to_response: default_append_to_response(),
         }
+    }
+
+    pub fn with_image_languages(mut self, languages: impl Into<String>) -> Self {
+        self.include_image_language = Some(languages.into());
+        self
     }
 }
 

--- a/crates/remux-sdks/src/tmdb/series.rs
+++ b/crates/remux-sdks/src/tmdb/series.rs
@@ -83,6 +83,7 @@ pub struct SeriesEndpoint {
     #[serde(skip)]
     pub id: i64,
     pub language: Option<String>,
+    pub include_image_language: Option<String>,
     #[serde(
         skip_serializing_if = "Vec::is_empty",
         serialize_with = "serialize_comma"
@@ -95,8 +96,14 @@ impl SeriesEndpoint {
         Self {
             id,
             language,
+            include_image_language: None,
             append_to_response: default_append_to_response(),
         }
+    }
+
+    pub fn with_image_languages(mut self, languages: impl Into<String>) -> Self {
+        self.include_image_language = Some(languages.into());
+        self
     }
 }
 
@@ -187,6 +194,8 @@ pub struct EpisodeEndpoint {
     // #[builder(default = "en")]
     pub language: Option<String>,
 
+    pub include_image_language: Option<String>,
+
     //#[builder(default = "Some(vec![\"images\".to_string(), \"external_ids\".to_string()])")]
     #[serde(serialize_with = "serialize_comma_opt")]
     pub append_to_response: Option<Vec<String>>,
@@ -204,8 +213,14 @@ impl EpisodeEndpoint {
             season_number,
             episode_number,
             language,
+            include_image_language: None,
             append_to_response: Some(super::default_append_to_response()),
         }
+    }
+
+    pub fn with_image_languages(mut self, languages: impl Into<String>) -> Self {
+        self.include_image_language = Some(languages.into());
+        self
     }
 }
 

--- a/crates/remux-server/src/addons/betterposters.rs
+++ b/crates/remux-server/src/addons/betterposters.rs
@@ -294,7 +294,7 @@ impl super::MetaAddon for BetterPostersAddon {
         &self,
         _media: &db::Media,
         _ctx: &AppContext,
-        _image_type: Option<crate::api::ImageType>,
+        _options: super::ImageFetchOptions,
     ) -> Result<Vec<crate::api::RemoteImageInfo>> {
         Ok(vec![])
     }

--- a/crates/remux-server/src/addons/betterposters.rs
+++ b/crates/remux-server/src/addons/betterposters.rs
@@ -294,6 +294,7 @@ impl super::MetaAddon for BetterPostersAddon {
         &self,
         _media: &db::Media,
         _ctx: &AppContext,
+        _image_type: Option<crate::api::ImageType>,
     ) -> Result<Vec<crate::api::RemoteImageInfo>> {
         Ok(vec![])
     }

--- a/crates/remux-server/src/addons/mod.rs
+++ b/crates/remux-server/src/addons/mod.rs
@@ -802,6 +802,7 @@ pub trait MetaAddon: Send + Sync {
         &self,
         media: &db::Media,
         ctx: &AppContext,
+        image_type: Option<api::ImageType>,
     ) -> Result<Vec<crate::api::RemoteImageInfo>> {
         Ok(vec![])
     }
@@ -2572,6 +2573,7 @@ impl AddonService {
         &self,
         media: &db::Media,
         ctx: &AppContext,
+        image_type: Option<api::ImageType>,
     ) -> Result<Vec<crate::api::RemoteImageInfo>> {
         let addons = self
             .addons_for::<dyn MetaAddon>(media, &ctx.db, None)
@@ -2583,7 +2585,7 @@ impl AddonService {
                 .meta
                 .as_ref()
                 .unwrap()
-                .images_fetch(media, ctx)
+                .images_fetch(media, ctx, image_type.clone())
                 .await
             {
                 Ok(images) => out.extend(images),

--- a/crates/remux-server/src/addons/mod.rs
+++ b/crates/remux-server/src/addons/mod.rs
@@ -781,6 +781,12 @@ pub trait CatalogAddon: Send + Sync {
     ) -> Result<Option<Pin<Box<dyn Stream<Item = db::Media> + Send>>>>;
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct ImageFetchOptions {
+    pub image_type: Option<api::ImageType>,
+    pub include_all_languages: bool,
+}
+
 #[async_trait]
 pub trait MetaAddon: Send + Sync {
     async fn supports(&self, media: &db::Media) -> bool;
@@ -802,7 +808,7 @@ pub trait MetaAddon: Send + Sync {
         &self,
         media: &db::Media,
         ctx: &AppContext,
-        image_type: Option<api::ImageType>,
+        options: ImageFetchOptions,
     ) -> Result<Vec<crate::api::RemoteImageInfo>> {
         Ok(vec![])
     }
@@ -2573,7 +2579,7 @@ impl AddonService {
         &self,
         media: &db::Media,
         ctx: &AppContext,
-        image_type: Option<api::ImageType>,
+        options: ImageFetchOptions,
     ) -> Result<Vec<crate::api::RemoteImageInfo>> {
         let addons = self
             .addons_for::<dyn MetaAddon>(media, &ctx.db, None)
@@ -2585,7 +2591,7 @@ impl AddonService {
                 .meta
                 .as_ref()
                 .unwrap()
-                .images_fetch(media, ctx, image_type.clone())
+                .images_fetch(media, ctx, options.clone())
                 .await
             {
                 Ok(images) => out.extend(images),

--- a/crates/remux-server/src/addons/tmdb.rs
+++ b/crates/remux-server/src/addons/tmdb.rs
@@ -180,9 +180,9 @@ impl MetaAddon for TmdbAddon {
         &self,
         media: &db::Media,
         ctx: &AppContext,
-        image_type: Option<crate::api::ImageType>,
+        options: super::ImageFetchOptions,
     ) -> Result<Vec<crate::api::RemoteImageInfo>> {
-        tmdb_remote_images(ctx, media, image_type).await
+        tmdb_remote_images(ctx, media, options).await
     }
 }
 
@@ -1994,8 +1994,19 @@ async fn search_tmdb_series(
 
 fn tmdb_remote_image_languages(
     image_type: Option<&api::ImageType>,
+    include_all_languages: bool,
 ) -> Option<&'static str> {
-    matches!(image_type, Some(api::ImageType::Backdrop)).then_some("null")
+    (!include_all_languages && matches!(image_type, Some(api::ImageType::Backdrop)))
+        .then_some("null")
+}
+
+fn tmdb_remote_metadata_language(
+    preferred_language: Option<&str>,
+    include_all_languages: bool,
+) -> Option<String> {
+    (!include_all_languages)
+        .then(|| preferred_language.map(str::to_string))
+        .flatten()
 }
 
 fn map_remote_image(
@@ -2072,7 +2083,7 @@ fn extend_from_tmdb_images(
 async fn tmdb_remote_images(
     ctx: &AppContext,
     media: &db::Media,
-    image_type: Option<api::ImageType>,
+    options: super::ImageFetchOptions,
 ) -> Result<Vec<api::RemoteImageInfo>> {
     let config = crate::db::Settings::get_config(&ctx.db).await?;
     let api_key = config.get_tmdb_key();
@@ -2084,8 +2095,19 @@ async fn tmdb_remote_images(
         &ctx.config
             .tmdb_base_url,
     )?;
-    let image_languages = tmdb_remote_image_languages(image_type.as_ref());
+    let image_languages = tmdb_remote_image_languages(
+        options
+            .image_type
+            .as_ref(),
+        options.include_all_languages,
+    );
     let language_neutral_backdrops = image_languages.is_some();
+    let preferred_language = tmdb_remote_metadata_language(
+        config
+            .preferred_metadata_language
+            .as_deref(),
+        options.include_all_languages,
+    );
 
     let mut out = Vec::new();
 
@@ -2110,12 +2132,8 @@ async fn tmdb_remote_images(
                 None
             };
             if let Some(tmdb_id) = tmdb_id {
-                let mut endpoint = sdks::tmdb::MovieEndpoint::new(
-                    tmdb_id,
-                    config
-                        .preferred_metadata_language
-                        .clone(),
-                );
+                let mut endpoint =
+                    sdks::tmdb::MovieEndpoint::new(tmdb_id, preferred_language.clone());
                 if let Some(languages) = image_languages {
                     endpoint = endpoint.with_image_languages(languages);
                 }
@@ -2199,9 +2217,7 @@ async fn tmdb_remote_images(
             if let Some(tmdb_id) = tmdb_id {
                 let mut endpoint = sdks::tmdb::SeriesEndpoint::new(
                     tmdb_id,
-                    config
-                        .preferred_metadata_language
-                        .clone(),
+                    preferred_language.clone(),
                 );
                 if let Some(languages) = image_languages {
                     endpoint = endpoint.with_image_languages(languages);
@@ -2228,9 +2244,7 @@ async fn tmdb_remote_images(
                     tmdb_id,
                     s_n,
                     e_n,
-                    config
-                        .preferred_metadata_language
-                        .clone(),
+                    preferred_language,
                 );
                 if let Some(languages) = image_languages {
                     endpoint = endpoint.with_image_languages(languages);
@@ -2364,19 +2378,41 @@ mod tests {
             })
             .count();
         assert_eq!(primary_count, 2);
+
+        let mut all_languages = Vec::new();
+        extend_from_tmdb_images(&mut all_languages, &images, false);
+        assert_eq!(
+            all_languages
+                .iter()
+                .filter(|image| image
+                    .type_
+                    .as_deref()
+                    == Some("Backdrop"))
+                .count(),
+            2
+        );
     }
 
     #[test]
-    fn remote_image_queries_only_request_neutral_images_for_backdrops() {
+    fn remote_image_queries_respect_include_all_languages() {
         assert_eq!(
-            tmdb_remote_image_languages(Some(&api::ImageType::Backdrop)),
+            tmdb_remote_image_languages(Some(&api::ImageType::Backdrop), false),
             Some("null")
         );
         assert_eq!(
-            tmdb_remote_image_languages(Some(&api::ImageType::Primary)),
+            tmdb_remote_image_languages(Some(&api::ImageType::Primary), false),
             None
         );
-        assert_eq!(tmdb_remote_image_languages(None), None);
+        assert_eq!(
+            tmdb_remote_image_languages(Some(&api::ImageType::Backdrop), true),
+            None
+        );
+        assert_eq!(tmdb_remote_image_languages(None, false), None);
+        assert_eq!(
+            tmdb_remote_metadata_language(Some("nl-NL"), false),
+            Some("nl-NL".to_string())
+        );
+        assert_eq!(tmdb_remote_metadata_language(Some("nl-NL"), true), None);
 
         let backdrop_query =
             sdks::tmdb::MovieEndpoint::new(1, Some("nl-NL".to_string()))

--- a/crates/remux-server/src/addons/tmdb.rs
+++ b/crates/remux-server/src/addons/tmdb.rs
@@ -402,6 +402,7 @@ impl MetricsAddon for TmdbAddon {
                 .execute(sdks::tmdb::MovieEndpoint {
                     id: tmdb_id,
                     language: None,
+                    include_image_language: None,
                     append_to_response: vec![],
                 })
                 .await
@@ -412,6 +413,7 @@ impl MetricsAddon for TmdbAddon {
                 .execute(sdks::tmdb::SeriesEndpoint {
                     id: tmdb_id,
                     language: None,
+                    include_image_language: None,
                     append_to_response: vec![],
                 })
                 .await
@@ -1989,6 +1991,74 @@ async fn search_tmdb_series(
 // Remote images
 // ---------------------------------------------------------------------------
 
+fn map_remote_image(
+    type_label: &str,
+    entry: &sdks::tmdb::ImageEntry,
+) -> api::RemoteImageInfo {
+    let url = format!("https://image.tmdb.org/t/p/original{}", entry.file_path);
+    let thumb = format!("https://image.tmdb.org/t/p/w300{}", entry.file_path);
+    api::RemoteImageInfo {
+        provider_name: Some("TheMovieDb".to_string()),
+        url: Some(url),
+        thumbnail_url: Some(thumb),
+        type_: Some(type_label.to_string()),
+        width: entry.width,
+        height: entry.height,
+    }
+}
+
+fn extend_from_tmdb_images(
+    out: &mut Vec<api::RemoteImageInfo>,
+    images: &sdks::tmdb::Images,
+) {
+    out.extend(
+        images
+            .backdrops
+            .iter()
+            .filter(|entry| {
+                entry
+                    .iso_639_1
+                    .is_none()
+            })
+            .map(|entry| map_remote_image("Backdrop", entry)),
+    );
+    out.extend(
+        images
+            .posters
+            .iter()
+            .map(|entry| map_remote_image("Primary", entry)),
+    );
+    out.extend(
+        images
+            .logos
+            .iter()
+            .map(|entry| map_remote_image("Logo", entry)),
+    );
+    out.extend(
+        images
+            .stills
+            .iter()
+            .filter(|entry| {
+                entry
+                    .iso_639_1
+                    .is_none()
+            })
+            .map(|entry| map_remote_image("Backdrop", entry)),
+    );
+    out.extend(
+        images
+            .stills
+            .iter()
+            .map(|entry| map_remote_image("Screenshot", entry)),
+    );
+    out.extend(
+        images
+            .stills
+            .iter()
+            .map(|entry| map_remote_image("Thumb", entry)),
+    );
+}
+
 async fn tmdb_remote_images(
     ctx: &AppContext,
     media: &db::Media,
@@ -2003,64 +2073,6 @@ async fn tmdb_remote_images(
         &ctx.config
             .tmdb_base_url,
     )?;
-
-    fn map_image(
-        type_label: &str,
-        entry: &sdks::tmdb::ImageEntry,
-    ) -> api::RemoteImageInfo {
-        let url = format!("https://image.tmdb.org/t/p/original{}", entry.file_path);
-        let thumb = format!("https://image.tmdb.org/t/p/w300{}", entry.file_path);
-        api::RemoteImageInfo {
-            provider_name: Some("TheMovieDb".to_string()),
-            url: Some(url),
-            thumbnail_url: Some(thumb),
-            type_: Some(type_label.to_string()),
-            width: entry.width,
-            height: entry.height,
-        }
-    }
-
-    fn extend_from_images(
-        out: &mut Vec<api::RemoteImageInfo>,
-        images: &sdks::tmdb::Images,
-    ) {
-        out.extend(
-            images
-                .backdrops
-                .iter()
-                .map(|e| map_image("Backdrop", e)),
-        );
-        out.extend(
-            images
-                .posters
-                .iter()
-                .map(|e| map_image("Primary", e)),
-        );
-        out.extend(
-            images
-                .logos
-                .iter()
-                .map(|e| map_image("Logo", e)),
-        );
-        out.extend(
-            images
-                .stills
-                .iter()
-                .map(|e| map_image("Backdrop", e)),
-        );
-        out.extend(
-            images
-                .stills
-                .iter()
-                .map(|e| map_image("Screenshot", e)),
-        );
-        out.extend(
-            images
-                .stills
-                .iter()
-                .map(|e| map_image("Thumb", e)),
-        );
-    }
 
     let mut out = Vec::new();
 
@@ -2093,11 +2105,12 @@ async fn tmdb_remote_images(
                                 .preferred_metadata_language
                                 .clone(),
                         )
+                        .with_image_languages("null")
                         .with_cache(Duration::from_secs(360)),
                     )
                     .await?;
                 if let Some(images) = &movie.images {
-                    extend_from_images(&mut out, images);
+                    extend_from_tmdb_images(&mut out, images);
                 }
                 if out
                     .iter()
@@ -2175,11 +2188,12 @@ async fn tmdb_remote_images(
                                 .preferred_metadata_language
                                 .clone(),
                         )
+                        .with_image_languages("null")
                         .with_cache(Duration::from_secs(360)),
                     )
                     .await?;
                 if let Some(images) = &tv.images {
-                    extend_from_images(&mut out, images);
+                    extend_from_tmdb_images(&mut out, images);
                 }
             }
         }
@@ -2199,6 +2213,7 @@ async fn tmdb_remote_images(
                                 .preferred_metadata_language
                                 .clone(),
                         )
+                        .with_image_languages("null")
                         .with_cache(Duration::from_secs(360)),
                     )
                     .await?;
@@ -2209,7 +2224,7 @@ async fn tmdb_remote_images(
                             .as_ref()
                     })
                 {
-                    extend_from_images(&mut out, images);
+                    extend_from_tmdb_images(&mut out, images);
                 }
                 if out
                     .iter()
@@ -2260,4 +2275,79 @@ async fn tmdb_remote_images(
     }
 
     Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use remux_sdks::Endpoint;
+
+    fn image_entry(path: &str, language: Option<&str>) -> sdks::tmdb::ImageEntry {
+        sdks::tmdb::ImageEntry {
+            file_path: path.to_string(),
+            iso_639_1: language.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn remote_backdrops_only_include_language_neutral_images() {
+        let images = sdks::tmdb::Images {
+            backdrops: vec![
+                image_entry("/neutral.jpg", None),
+                image_entry("/localized.jpg", Some("en")),
+            ],
+            posters: vec![image_entry("/poster.jpg", Some("en"))],
+            ..Default::default()
+        };
+        let mut remote_images = Vec::new();
+
+        extend_from_tmdb_images(&mut remote_images, &images);
+
+        let backdrop_urls = remote_images
+            .iter()
+            .filter(|image| {
+                image
+                    .type_
+                    .as_deref()
+                    == Some("Backdrop")
+            })
+            .filter_map(|image| {
+                image
+                    .url
+                    .as_deref()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            backdrop_urls,
+            ["https://image.tmdb.org/t/p/original/neutral.jpg"]
+        );
+        assert!(
+            remote_images
+                .iter()
+                .any(|image| image
+                    .type_
+                    .as_deref()
+                    == Some("Primary"))
+        );
+    }
+
+    #[test]
+    fn remote_image_queries_request_language_neutral_images() {
+        let movie_query = sdks::tmdb::MovieEndpoint::new(1, Some("nl-NL".to_string()))
+            .with_image_languages("null")
+            .query();
+        let series_query =
+            sdks::tmdb::SeriesEndpoint::new(1, Some("nl-NL".to_string()))
+                .with_image_languages("null")
+                .query();
+        let episode_query =
+            sdks::tmdb::EpisodeEndpoint::new(1, 1, 1, Some("nl-NL".to_string()))
+                .with_image_languages("null")
+                .query();
+
+        for query in [movie_query, series_query, episode_query] {
+            assert!(query.contains(&("include_image_language".into(), "null".into())));
+        }
+    }
 }

--- a/crates/remux-server/src/addons/tmdb.rs
+++ b/crates/remux-server/src/addons/tmdb.rs
@@ -180,8 +180,9 @@ impl MetaAddon for TmdbAddon {
         &self,
         media: &db::Media,
         ctx: &AppContext,
+        image_type: Option<crate::api::ImageType>,
     ) -> Result<Vec<crate::api::RemoteImageInfo>> {
-        tmdb_remote_images(ctx, media).await
+        tmdb_remote_images(ctx, media, image_type).await
     }
 }
 
@@ -1991,8 +1992,10 @@ async fn search_tmdb_series(
 // Remote images
 // ---------------------------------------------------------------------------
 
-fn tmdb_image_languages_with_neutral(preferred_language: Option<&str>) -> String {
-    format!("{},null", preferred_language.unwrap_or("en"))
+fn tmdb_remote_image_languages(
+    image_type: Option<&api::ImageType>,
+) -> Option<&'static str> {
+    matches!(image_type, Some(api::ImageType::Backdrop)).then_some("null")
 }
 
 fn map_remote_image(
@@ -2014,15 +2017,17 @@ fn map_remote_image(
 fn extend_from_tmdb_images(
     out: &mut Vec<api::RemoteImageInfo>,
     images: &sdks::tmdb::Images,
+    language_neutral_backdrops: bool,
 ) {
     out.extend(
         images
             .backdrops
             .iter()
             .filter(|entry| {
-                entry
-                    .iso_639_1
-                    .is_none()
+                !language_neutral_backdrops
+                    || entry
+                        .iso_639_1
+                        .is_none()
             })
             .map(|entry| map_remote_image("Backdrop", entry)),
     );
@@ -2030,22 +2035,12 @@ fn extend_from_tmdb_images(
         images
             .posters
             .iter()
-            .filter(|entry| {
-                entry
-                    .iso_639_1
-                    .is_some()
-            })
             .map(|entry| map_remote_image("Primary", entry)),
     );
     out.extend(
         images
             .logos
             .iter()
-            .filter(|entry| {
-                entry
-                    .iso_639_1
-                    .is_some()
-            })
             .map(|entry| map_remote_image("Logo", entry)),
     );
     out.extend(
@@ -2053,9 +2048,10 @@ fn extend_from_tmdb_images(
             .stills
             .iter()
             .filter(|entry| {
-                entry
-                    .iso_639_1
-                    .is_none()
+                !language_neutral_backdrops
+                    || entry
+                        .iso_639_1
+                        .is_none()
             })
             .map(|entry| map_remote_image("Backdrop", entry)),
     );
@@ -2076,6 +2072,7 @@ fn extend_from_tmdb_images(
 async fn tmdb_remote_images(
     ctx: &AppContext,
     media: &db::Media,
+    image_type: Option<api::ImageType>,
 ) -> Result<Vec<api::RemoteImageInfo>> {
     let config = crate::db::Settings::get_config(&ctx.db).await?;
     let api_key = config.get_tmdb_key();
@@ -2087,6 +2084,8 @@ async fn tmdb_remote_images(
         &ctx.config
             .tmdb_base_url,
     )?;
+    let image_languages = tmdb_remote_image_languages(image_type.as_ref());
+    let language_neutral_backdrops = image_languages.is_some();
 
     let mut out = Vec::new();
 
@@ -2111,24 +2110,24 @@ async fn tmdb_remote_images(
                 None
             };
             if let Some(tmdb_id) = tmdb_id {
+                let mut endpoint = sdks::tmdb::MovieEndpoint::new(
+                    tmdb_id,
+                    config
+                        .preferred_metadata_language
+                        .clone(),
+                );
+                if let Some(languages) = image_languages {
+                    endpoint = endpoint.with_image_languages(languages);
+                }
                 let movie = client
-                    .execute(
-                        sdks::tmdb::MovieEndpoint::new(
-                            tmdb_id,
-                            config
-                                .preferred_metadata_language
-                                .clone(),
-                        )
-                        .with_image_languages(tmdb_image_languages_with_neutral(
-                            config
-                                .preferred_metadata_language
-                                .as_deref(),
-                        ))
-                        .with_cache(Duration::from_secs(360)),
-                    )
+                    .execute(endpoint.with_cache(Duration::from_secs(360)))
                     .await?;
                 if let Some(images) = &movie.images {
-                    extend_from_tmdb_images(&mut out, images);
+                    extend_from_tmdb_images(
+                        &mut out,
+                        images,
+                        language_neutral_backdrops,
+                    );
                 }
                 if out
                     .iter()
@@ -2198,24 +2197,24 @@ async fn tmdb_remote_images(
                 None
             };
             if let Some(tmdb_id) = tmdb_id {
+                let mut endpoint = sdks::tmdb::SeriesEndpoint::new(
+                    tmdb_id,
+                    config
+                        .preferred_metadata_language
+                        .clone(),
+                );
+                if let Some(languages) = image_languages {
+                    endpoint = endpoint.with_image_languages(languages);
+                }
                 let tv = client
-                    .execute(
-                        sdks::tmdb::SeriesEndpoint::new(
-                            tmdb_id,
-                            config
-                                .preferred_metadata_language
-                                .clone(),
-                        )
-                        .with_image_languages(tmdb_image_languages_with_neutral(
-                            config
-                                .preferred_metadata_language
-                                .as_deref(),
-                        ))
-                        .with_cache(Duration::from_secs(360)),
-                    )
+                    .execute(endpoint.with_cache(Duration::from_secs(360)))
                     .await?;
                 if let Some(images) = &tv.images {
-                    extend_from_tmdb_images(&mut out, images);
+                    extend_from_tmdb_images(
+                        &mut out,
+                        images,
+                        language_neutral_backdrops,
+                    );
                 }
             }
         }
@@ -2225,23 +2224,19 @@ async fn tmdb_remote_images(
             if let (Some(tmdb_id), Some(s_n), Some(e_n)) =
                 (series_tmdb_id, media.parent_idx, media.idx)
             {
+                let mut endpoint = sdks::tmdb::EpisodeEndpoint::new(
+                    tmdb_id,
+                    s_n,
+                    e_n,
+                    config
+                        .preferred_metadata_language
+                        .clone(),
+                );
+                if let Some(languages) = image_languages {
+                    endpoint = endpoint.with_image_languages(languages);
+                }
                 let ep = client
-                    .execute(
-                        sdks::tmdb::EpisodeEndpoint::new(
-                            tmdb_id,
-                            s_n,
-                            e_n,
-                            config
-                                .preferred_metadata_language
-                                .clone(),
-                        )
-                        .with_image_languages(tmdb_image_languages_with_neutral(
-                            config
-                                .preferred_metadata_language
-                                .as_deref(),
-                        ))
-                        .with_cache(Duration::from_secs(360)),
-                    )
+                    .execute(endpoint.with_cache(Duration::from_secs(360)))
                     .await?;
                 if let Some(images) = ep
                     .as_ref()
@@ -2250,7 +2245,11 @@ async fn tmdb_remote_images(
                             .as_ref()
                     })
                 {
-                    extend_from_tmdb_images(&mut out, images);
+                    extend_from_tmdb_images(
+                        &mut out,
+                        images,
+                        language_neutral_backdrops,
+                    );
                 }
                 if out
                     .iter()
@@ -2335,7 +2334,7 @@ mod tests {
         };
         let mut remote_images = Vec::new();
 
-        extend_from_tmdb_images(&mut remote_images, &images);
+        extend_from_tmdb_images(&mut remote_images, &images, true);
 
         let backdrop_urls = remote_images
             .iter()
@@ -2355,48 +2354,44 @@ mod tests {
             backdrop_urls,
             ["https://image.tmdb.org/t/p/original/neutral.jpg"]
         );
-        assert!(
-            remote_images
-                .iter()
-                .any(|image| image
+        let primary_count = remote_images
+            .iter()
+            .filter(|image| {
+                image
                     .type_
                     .as_deref()
-                    == Some("Primary"))
-        );
-        assert!(
-            remote_images
-                .iter()
-                .filter_map(|image| image
-                    .url
-                    .as_deref())
-                .all(|url| !url.contains("neutral-poster")
-                    && !url.contains("neutral-logo"))
-        );
+                    == Some("Primary")
+            })
+            .count();
+        assert_eq!(primary_count, 2);
     }
 
     #[test]
-    fn remote_image_queries_request_language_neutral_images() {
-        let image_languages = tmdb_image_languages_with_neutral(Some("nl-NL"));
-        let movie_query = sdks::tmdb::MovieEndpoint::new(1, Some("nl-NL".to_string()))
-            .with_image_languages(&image_languages)
-            .query();
-        let series_query =
-            sdks::tmdb::SeriesEndpoint::new(1, Some("nl-NL".to_string()))
-                .with_image_languages(&image_languages)
-                .query();
-        let episode_query =
-            sdks::tmdb::EpisodeEndpoint::new(1, 1, 1, Some("nl-NL".to_string()))
-                .with_image_languages(&image_languages)
-                .query();
+    fn remote_image_queries_only_request_neutral_images_for_backdrops() {
+        assert_eq!(
+            tmdb_remote_image_languages(Some(&api::ImageType::Backdrop)),
+            Some("null")
+        );
+        assert_eq!(
+            tmdb_remote_image_languages(Some(&api::ImageType::Primary)),
+            None
+        );
+        assert_eq!(tmdb_remote_image_languages(None), None);
 
-        for query in [movie_query, series_query, episode_query] {
-            assert!(
-                query.contains(&(
-                    "include_image_language".into(),
-                    "nl-NL%2Cnull".into()
-                ))
-            );
-        }
-        assert_eq!(tmdb_image_languages_with_neutral(None), "en,null");
+        let backdrop_query =
+            sdks::tmdb::MovieEndpoint::new(1, Some("nl-NL".to_string()))
+                .with_image_languages("null")
+                .query();
+        let primary_query =
+            sdks::tmdb::MovieEndpoint::new(1, Some("nl-NL".to_string())).query();
+
+        assert!(
+            backdrop_query.contains(&("include_image_language".into(), "null".into()))
+        );
+        assert!(
+            primary_query
+                .iter()
+                .all(|(key, _)| key != "include_image_language")
+        );
     }
 }

--- a/crates/remux-server/src/addons/tmdb.rs
+++ b/crates/remux-server/src/addons/tmdb.rs
@@ -1991,6 +1991,10 @@ async fn search_tmdb_series(
 // Remote images
 // ---------------------------------------------------------------------------
 
+fn tmdb_image_languages_with_neutral(preferred_language: Option<&str>) -> String {
+    format!("{},null", preferred_language.unwrap_or("en"))
+}
+
 fn map_remote_image(
     type_label: &str,
     entry: &sdks::tmdb::ImageEntry,
@@ -2105,7 +2109,11 @@ async fn tmdb_remote_images(
                                 .preferred_metadata_language
                                 .clone(),
                         )
-                        .with_image_languages("null")
+                        .with_image_languages(tmdb_image_languages_with_neutral(
+                            config
+                                .preferred_metadata_language
+                                .as_deref(),
+                        ))
                         .with_cache(Duration::from_secs(360)),
                     )
                     .await?;
@@ -2188,7 +2196,11 @@ async fn tmdb_remote_images(
                                 .preferred_metadata_language
                                 .clone(),
                         )
-                        .with_image_languages("null")
+                        .with_image_languages(tmdb_image_languages_with_neutral(
+                            config
+                                .preferred_metadata_language
+                                .as_deref(),
+                        ))
                         .with_cache(Duration::from_secs(360)),
                     )
                     .await?;
@@ -2213,7 +2225,11 @@ async fn tmdb_remote_images(
                                 .preferred_metadata_language
                                 .clone(),
                         )
-                        .with_image_languages("null")
+                        .with_image_languages(tmdb_image_languages_with_neutral(
+                            config
+                                .preferred_metadata_language
+                                .as_deref(),
+                        ))
                         .with_cache(Duration::from_secs(360)),
                     )
                     .await?;
@@ -2334,20 +2350,27 @@ mod tests {
 
     #[test]
     fn remote_image_queries_request_language_neutral_images() {
+        let image_languages = tmdb_image_languages_with_neutral(Some("nl-NL"));
         let movie_query = sdks::tmdb::MovieEndpoint::new(1, Some("nl-NL".to_string()))
-            .with_image_languages("null")
+            .with_image_languages(&image_languages)
             .query();
         let series_query =
             sdks::tmdb::SeriesEndpoint::new(1, Some("nl-NL".to_string()))
-                .with_image_languages("null")
+                .with_image_languages(&image_languages)
                 .query();
         let episode_query =
             sdks::tmdb::EpisodeEndpoint::new(1, 1, 1, Some("nl-NL".to_string()))
-                .with_image_languages("null")
+                .with_image_languages(&image_languages)
                 .query();
 
         for query in [movie_query, series_query, episode_query] {
-            assert!(query.contains(&("include_image_language".into(), "null".into())));
+            assert!(
+                query.contains(&(
+                    "include_image_language".into(),
+                    "nl-NL%2Cnull".into()
+                ))
+            );
         }
+        assert_eq!(tmdb_image_languages_with_neutral(None), "en,null");
     }
 }

--- a/crates/remux-server/src/addons/tmdb.rs
+++ b/crates/remux-server/src/addons/tmdb.rs
@@ -2030,12 +2030,22 @@ fn extend_from_tmdb_images(
         images
             .posters
             .iter()
+            .filter(|entry| {
+                entry
+                    .iso_639_1
+                    .is_some()
+            })
             .map(|entry| map_remote_image("Primary", entry)),
     );
     out.extend(
         images
             .logos
             .iter()
+            .filter(|entry| {
+                entry
+                    .iso_639_1
+                    .is_some()
+            })
             .map(|entry| map_remote_image("Logo", entry)),
     );
     out.extend(
@@ -2313,7 +2323,14 @@ mod tests {
                 image_entry("/neutral.jpg", None),
                 image_entry("/localized.jpg", Some("en")),
             ],
-            posters: vec![image_entry("/poster.jpg", Some("en"))],
+            posters: vec![
+                image_entry("/localized-poster.jpg", Some("en")),
+                image_entry("/neutral-poster.jpg", None),
+            ],
+            logos: vec![
+                image_entry("/localized-logo.svg", Some("en")),
+                image_entry("/neutral-logo.svg", None),
+            ],
             ..Default::default()
         };
         let mut remote_images = Vec::new();
@@ -2345,6 +2362,15 @@ mod tests {
                     .type_
                     .as_deref()
                     == Some("Primary"))
+        );
+        assert!(
+            remote_images
+                .iter()
+                .filter_map(|image| image
+                    .url
+                    .as_deref())
+                .all(|url| !url.contains("neutral-poster")
+                    && !url.contains("neutral-logo"))
         );
     }
 

--- a/crates/remux-server/src/api/items.rs
+++ b/crates/remux-server/src/api/items.rs
@@ -1404,7 +1404,16 @@ pub async fn items_remote_images(
         match state
             .ctx
             .addons
-            .fetch_images(&media, &state.ctx, requested_image_type)
+            .fetch_images(
+                &media,
+                &state.ctx,
+                crate::addons::ImageFetchOptions {
+                    image_type: requested_image_type,
+                    include_all_languages: q
+                        .include_all_languages
+                        .unwrap_or(false),
+                },
+            )
             .await
         {
             Ok(v) => images.extend(v),
@@ -3456,6 +3465,7 @@ pub async fn media_segments(
 
 #[cfg(test)]
 mod tests {
+    use super::RemoteImagesQuery;
     use chrono::Utc;
     use http::header::HeaderValue;
     use remux_sdks::remux::{
@@ -3472,6 +3482,22 @@ mod tests {
             insert_test_source_of_kind,
         },
     };
+
+    #[test]
+    fn remote_images_query_accepts_include_all_languages() {
+        let query: RemoteImagesQuery = serde_urlencoded::from_str(
+            "type=Primary&startIndex=0&limit=6&IncludeAllLanguages=true",
+        )
+        .unwrap();
+
+        assert_eq!(
+            query
+                .kind
+                .as_deref(),
+            Some("Primary")
+        );
+        assert_eq!(query.include_all_languages, Some(true));
+    }
 
     async fn get_user_id(server: &axum_test::TestServer, auth: &str) -> String {
         let resp: serde_json::Value = server

--- a/crates/remux-server/src/api/items.rs
+++ b/crates/remux-server/src/api/items.rs
@@ -1389,6 +1389,13 @@ pub async fn items_remote_images(
     let provider = q
         .provider
         .as_deref();
+    let requested_image_type = q
+        .kind
+        .as_deref()
+        .and_then(|kind| {
+            kind.parse::<api::ImageType>()
+                .ok()
+        });
     let mut images = Vec::new();
     let mut queried_providers = Vec::new();
 
@@ -1397,7 +1404,7 @@ pub async fn items_remote_images(
         match state
             .ctx
             .addons
-            .fetch_images(&media, &state.ctx)
+            .fetch_images(&media, &state.ctx, requested_image_type)
             .await
         {
             Ok(v) => images.extend(v),

--- a/crates/remux-server/src/services/resolve.rs
+++ b/crates/remux-server/src/services/resolve.rs
@@ -61,6 +61,7 @@ fn series_ids_endpoint(tmdb_id: i64) -> sdks::tmdb::SeriesEndpoint {
     sdks::tmdb::SeriesEndpoint {
         id: tmdb_id,
         language: None,
+        include_image_language: None,
         append_to_response: vec!["external_ids".to_string()],
     }
 }
@@ -69,6 +70,7 @@ fn movie_ids_endpoint(tmdb_id: i64) -> sdks::tmdb::MovieEndpoint {
     sdks::tmdb::MovieEndpoint {
         id: tmdb_id,
         language: None,
+        include_image_language: None,
         append_to_response: vec!["external_ids".to_string()],
     }
 }
@@ -365,6 +367,7 @@ impl MediaResolveService {
                     season_number: season,
                     episode_number: episode,
                     language: None,
+                    include_image_language: None,
                     append_to_response: Some(vec!["external_ids".to_string()]),
                 }
                 .with_cache(


### PR DESCRIPTION
## Summary
- ask TMDB appended image requests to include no-language artwork
- filter remote Backdrop results to language-neutral images only
- preserve existing poster, logo, screenshot, and thumbnail behavior
- add regression coverage for the TMDB query and returned image selection

## Validation
- cargo fmt --all
- cargo check -p remux-server
- cargo check -p remux-server --tests
- cargo test -p remux-server remote_

Closes #430