### PR TITLE
feat(dashboard): add stream cache setting and task

### DIFF
--- a/crates/remux-dashboard/src/pages/settings.rs
+++ b/crates/remux-dashboard/src/pages/settings.rs
@@ -22,6 +22,7 @@ pub fn ServerSettingsCard(app_state: AppState) -> Element {
     let mut catalog_max_items = use_signal(|| 100_i64);
     let mut meta_concurrency = use_signal(|| 12_i64);
     let mut delivery_concurrency = use_signal(|| 8_i64);
+    let mut stream_cache_ttl_seconds = use_signal(|| 60_i64);
     let mut filter_digital_release = use_signal(|| true);
     let mut digital_release_buffer = use_signal(|| 0_i64);
     let mut subtitle_languages = use_signal(String::new);
@@ -61,6 +62,10 @@ pub fn ServerSettingsCard(app_state: AppState) -> Element {
                     );
                     meta_concurrency.set(cfg.meta_concurrency);
                     delivery_concurrency.set(cfg.delivery_concurrency);
+                    stream_cache_ttl_seconds.set(
+                        cfg.stream_cache_ttl_seconds
+                            .unwrap_or(60),
+                    );
                     filter_digital_release.set(cfg.filter_by_digital_release_date);
                     digital_release_buffer.set(cfg.digital_release_buffer_days);
                     subtitle_languages.set(
@@ -108,6 +113,7 @@ pub fn ServerSettingsCard(app_state: AppState) -> Element {
         let max = *catalog_max_items.peek();
         let concurrency = *meta_concurrency.peek();
         let delivery = *delivery_concurrency.peek();
+        let stream_cache_ttl = *stream_cache_ttl_seconds.peek();
         let filter_dr = *filter_digital_release.peek();
         let dr_buffer = *digital_release_buffer.peek();
         let sub_langs_str = subtitle_languages
@@ -126,6 +132,7 @@ pub fn ServerSettingsCard(app_state: AppState) -> Element {
         cfg.catalog_max_items = Some(max);
         cfg.meta_concurrency = concurrency;
         cfg.delivery_concurrency = delivery;
+        cfg.stream_cache_ttl_seconds = Some(stream_cache_ttl.max(0));
         cfg.filter_by_digital_release_date = filter_dr;
         cfg.digital_release_buffer_days = dr_buffer;
         cfg.subtitle_languages = Some(
@@ -264,6 +271,25 @@ pub fn ServerSettingsCard(app_state: AppState) -> Element {
                             }
                             p { class: "field-hint",
                                 "Number of media trackers whose queued watch activity is sent concurrently. One tracker's events are always sent in order, one at a time, so this only controls how many trackers are worked on at once. Default: 8."
+                            }
+                        }
+
+                        div { class: "field",
+                            label { class: "field-label", r#for: "s-stream-cache-ttl", "Stream Cache TTL (seconds)" }
+                            input {
+                                id: "s-stream-cache-ttl",
+                                r#type: "number",
+                                class: "field-input",
+                                min: "0",
+                                value: "{stream_cache_ttl_seconds}",
+                                oninput: move |e| {
+                                    if let Ok(n) = e.value().parse::<i64>() {
+                                        stream_cache_ttl_seconds.set(n);
+                                    }
+                                },
+                            }
+                            p { class: "field-hint",
+                                "How long a populated stream list is reused before fetching it again. Set to 0 to disable caching. Default: 60 seconds (1 minute)."
                             }
                         }
 

--- a/crates/remux-sdks/src/remux/mod.rs
+++ b/crates/remux-sdks/src/remux/mod.rs
@@ -519,6 +519,9 @@ pub struct ServerConfiguration {
     /// Show streams that don't match any group individually (default true).
     #[default(Some(true))]
     pub stream_groups_show_ungrouped: Option<bool>,
+    /// How long a populated stream list remains fresh, in seconds (default: 60). Zero disables caching.
+    #[default(Some(60_i64))]
+    pub stream_cache_ttl_seconds: Option<i64>,
     /// Enable submitting probe data to remuxdb (default true).
     #[default(Some(true))]
     pub remuxdb_enabled: Option<bool>,

--- a/crates/remux-server/src/addons/mod.rs
+++ b/crates/remux-server/src/addons/mod.rs
@@ -2764,6 +2764,17 @@ fn match_probe_version<'a>(
         })
 }
 
+fn streams_are_fresh(
+    refreshed_at: Option<chrono::NaiveDateTime>,
+    ttl_seconds: i64,
+    now: chrono::NaiveDateTime,
+) -> bool {
+    ttl_seconds > 0
+        && refreshed_at.is_some_and(|refreshed_at| {
+            (now - refreshed_at).num_seconds() < ttl_seconds
+        })
+}
+
 impl AddonService {
     #[tracing::instrument(skip_all, fields(title = %media.title, kind = %media.kind))]
     pub async fn refresh_streams(
@@ -2772,14 +2783,21 @@ impl AddonService {
         ctx: &AppContext,
         user_id: Option<Uuid>,
     ) -> Result<()> {
-        const STREAMS_TTL_SECS: i64 = 60;
         static STREAM_LOCKS: KeyedLock<Uuid> = KeyedLock::new();
+
+        let cfg = db::Settings::get_config_or_default(&ctx.db).await;
+        let stream_cache_ttl_seconds = cfg
+            .stream_cache_ttl_seconds
+            .unwrap_or(60)
+            .max(0);
 
         // Fast path: TTL not expired — skip the lock entirely.
         let is_fresh = |refreshed: Option<chrono::NaiveDateTime>| {
-            refreshed.is_some_and(|r| {
-                (chrono::Utc::now().naive_utc() - r).num_seconds() < STREAMS_TTL_SECS
-            })
+            streams_are_fresh(
+                refreshed,
+                stream_cache_ttl_seconds,
+                chrono::Utc::now().naive_utc(),
+            )
         };
         if is_fresh(media.streams_refreshed_at) {
             return Ok(());
@@ -2841,7 +2859,6 @@ impl AddonService {
             let Some(imdb_id) = imdb_id else {
                 return None;
             };
-            let cfg = db::Settings::get_config_or_default(&ctx.db).await;
             if !cfg
                 .remuxdb_enabled
                 .unwrap_or(true)
@@ -3185,6 +3202,31 @@ pub fn make_media_id(addon_id: Uuid, local_id: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn stream_cache_ttl_defaults_to_one_minute() {
+        assert_eq!(
+            crate::api::ServerConfiguration::default().stream_cache_ttl_seconds,
+            Some(60)
+        );
+    }
+
+    #[test]
+    fn stream_cache_freshness_uses_configured_ttl() {
+        let now = chrono::Utc::now().naive_utc();
+
+        assert!(streams_are_fresh(
+            Some(now - chrono::Duration::seconds(59)),
+            60,
+            now
+        ));
+        assert!(!streams_are_fresh(
+            Some(now - chrono::Duration::seconds(60)),
+            60,
+            now
+        ));
+        assert!(!streams_are_fresh(Some(now), 0, now));
+    }
 
     fn torrent_stream(hash: &str, file_hint: &str, file_idx: usize) -> db::Media {
         db::Media {

--- a/crates/remux-server/src/tasks/clear_stream_cache.rs
+++ b/crates/remux-server/src/tasks/clear_stream_cache.rs
@@ -1,0 +1,169 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use sqlx::SqlitePool;
+use std::sync::Arc;
+use tracing::info;
+
+use super::{ProgressReporter, Task, TaskCategory, TaskService};
+use crate::{AppContext, db};
+
+pub struct ClearStreamCacheTask;
+
+#[async_trait]
+impl Task for ClearStreamCacheTask {
+    fn key(&self) -> &str {
+        "ClearStreamCache"
+    }
+
+    fn name(&self) -> &str {
+        "Clear Stream Cache"
+    }
+
+    fn description(&self) -> &str {
+        "Deletes all cached stream lists. Streams are fetched again when a media item is opened."
+    }
+
+    fn short_description(&self) -> &str {
+        "Deletes all cached stream lists"
+    }
+
+    fn category(&self) -> TaskCategory {
+        TaskCategory::Maintenance
+    }
+
+    async fn run(
+        &self,
+        ctx: AppContext,
+        _tasks: Arc<TaskService>,
+        progress: ProgressReporter,
+    ) -> Result<()> {
+        let (removed, invalidated) = clear_stream_cache(&ctx.db).await?;
+        info!(removed, invalidated, "cleared stream cache");
+        progress.set(100.0);
+        Ok(())
+    }
+}
+
+async fn clear_stream_cache(db: &SqlitePool) -> Result<(u64, u64)> {
+    let mut tx = db
+        .begin()
+        .await?;
+
+    let removed = sqlx::query("DELETE FROM media WHERE kind = ?")
+        .bind(db::MediaKind::Stream)
+        .execute(&mut *tx)
+        .await?
+        .rows_affected();
+    let invalidated = sqlx::query(
+        "UPDATE media SET streams_refreshed_at = NULL WHERE streams_refreshed_at IS NOT NULL",
+    )
+    .execute(&mut *tx)
+    .await?
+    .rows_affected();
+
+    tx.commit()
+        .await?;
+    Ok((removed, invalidated))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    async fn test_db() -> SqlitePool {
+        let db = crate::db::connect("sqlite::memory:", 10_000)
+            .await
+            .unwrap();
+        crate::db::migrate(&db)
+            .await
+            .unwrap();
+        db
+    }
+
+    async fn insert_media(
+        db: &SqlitePool,
+        id: Uuid,
+        kind: db::MediaKind,
+        parent_id: Option<Uuid>,
+        streams_refreshed: bool,
+    ) {
+        let now = Utc::now().naive_utc();
+        sqlx::query(
+            "INSERT INTO media \
+             (id, title, kind, parent_id, created_at, updated_at, streams_refreshed_at) \
+             VALUES (?, 'Test', ?, ?, ?, ?, ?)",
+        )
+        .bind(id)
+        .bind(kind)
+        .bind(parent_id)
+        .bind(now)
+        .bind(now)
+        .bind(streams_refreshed.then_some(now))
+        .execute(db)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn removes_all_streams_and_invalidates_every_parent() {
+        let db = test_db().await;
+        let movie_id = Uuid::new_v4();
+        let episode_id = Uuid::new_v4();
+
+        insert_media(&db, movie_id, db::MediaKind::Movie, None, true).await;
+        insert_media(&db, episode_id, db::MediaKind::Episode, None, true).await;
+        insert_media(
+            &db,
+            Uuid::new_v4(),
+            db::MediaKind::Stream,
+            Some(movie_id),
+            false,
+        )
+        .await;
+        insert_media(
+            &db,
+            Uuid::new_v4(),
+            db::MediaKind::Stream,
+            Some(episode_id),
+            false,
+        )
+        .await;
+
+        let (removed, invalidated) = clear_stream_cache(&db)
+            .await
+            .unwrap();
+
+        assert_eq!(removed, 2);
+        assert_eq!(invalidated, 2);
+        assert_eq!(
+            sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM media WHERE kind = ?")
+                .bind(db::MediaKind::Stream)
+                .fetch_one(&db)
+                .await
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            sqlx::query_scalar::<_, i64>(
+                "SELECT COUNT(*) FROM media WHERE streams_refreshed_at IS NOT NULL",
+            )
+            .fetch_one(&db)
+            .await
+            .unwrap(),
+            0
+        );
+        assert_eq!(
+            sqlx::query_scalar::<_, i64>(
+                "SELECT COUNT(*) FROM media WHERE id IN (?, ?)"
+            )
+            .bind(movie_id)
+            .bind(episode_id)
+            .fetch_one(&db)
+            .await
+            .unwrap(),
+            2
+        );
+    }
+}

--- a/crates/remux-server/src/tasks/mod.rs
+++ b/crates/remux-server/src/tasks/mod.rs
@@ -21,6 +21,7 @@ mod catalog_import_shared;
 mod clean_transcode_folder;
 mod clear_cache;
 mod clear_image_cache;
+mod clear_stream_cache;
 mod jellyfin_import;
 mod purge_iptv;
 mod purge_media;
@@ -38,6 +39,7 @@ pub use crate::common::ProgressReporter;
 use clean_transcode_folder::CleanTranscodeFolderTask;
 use clear_cache::ClearCacheTask;
 use clear_image_cache::ClearImageCacheTask;
+use clear_stream_cache::ClearStreamCacheTask;
 use jellyfin_import::JellyfinImportTask;
 use purge_iptv::PurgeIptvTask;
 use purge_media::PurgeMediaTask;
@@ -296,6 +298,9 @@ impl TaskService {
             .await?;
         service
             .register_task(Arc::new(ClearImageCacheTask))
+            .await?;
+        service
+            .register_task(Arc::new(ClearStreamCacheTask))
             .await?;
         service
             .register_task(Arc::new(CleanTranscodeFolderTask))


### PR DESCRIPTION
See (#436).

* Add stream cache ttl setting (default 60 seconds).
* Add clear all cached streams task.

Disclosure: Codex was used (under supervision).

