### PR TITLE
fix: allow media without IMDb mappings

### DIFF
--- a/crates/remux-server/src/addons/mod.rs
+++ b/crates/remux-server/src/addons/mod.rs
@@ -35,7 +35,9 @@ use libc;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
-use crate::{AppContext, api, common::ProgressReporter, db, sdks};
+use crate::{
+    AppContext, api, common::ProgressReporter, db, sdks, services::MediaResolveService,
+};
 pub use addon::{Addon, CatalogState, set_user_addon_override, user_addon_override};
 use remux_sdks::remuxdb;
 
@@ -1867,6 +1869,11 @@ impl AddonService {
             .await
             .ok();
 
+        // Fill in whatever external ids we can before any addon runs, so
+        // every addon in this batch sees the fuller id set rather than each
+        // doing its own partial, addon-specific resolution.
+        MediaResolveService::resolve_missing_external_ids(media, ctx).await;
+
         let applicable = self
             .addons_for::<dyn MetaAddon>(media, &ctx.db, None)
             .await;
@@ -2057,6 +2064,11 @@ impl AddonService {
         let config = db::Settings::get_config_or_default(&ctx.db).await;
         let concurrency = config.meta_concurrency as usize;
         let config = Arc::new(config);
+        // Shared across this whole batch — top-level items, and every season/
+        // episode any of them refreshes — so nested fan-out inside a single
+        // item's own tree walk can't multiply past this budget. See
+        // `process_meta_item_inner` for where seasons/episodes acquire from it.
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(concurrency.max(1)));
 
         let svc = self.clone();
         let ctx_owned = ctx.clone();
@@ -2067,10 +2079,11 @@ impl AddonService {
                     let svc = svc.clone();
                     let ctx = ctx_owned.clone();
                     let cfg = Arc::clone(&config);
+                    let sem = Arc::clone(&semaphore);
                     let original_id = m.id;
                     async move {
                         let final_id = svc
-                            .process_meta_item(m, ctx, force_refresh, cfg)
+                            .process_meta_item(m, ctx, force_refresh, cfg, sem)
                             .await;
                         (original_id, final_id)
                     }
@@ -2189,6 +2202,7 @@ impl AddonService {
         ctx: AppContext,
         force_refresh: bool,
         config: Arc<api::ServerConfiguration>,
+        semaphore: Arc<tokio::sync::Semaphore>,
     ) -> Uuid {
         let title = media
             .title
@@ -2198,7 +2212,7 @@ impl AddonService {
             .clone();
         let started = std::time::Instant::now();
         let id = self
-            .process_meta_item_inner(media, ctx, force_refresh, config)
+            .process_meta_item_inner(media, ctx, force_refresh, config, semaphore)
             .await;
         debug!(%id, %title, %kind, elapsed = ?started.elapsed(), "process_meta_item done");
         id
@@ -2210,13 +2224,29 @@ impl AddonService {
         ctx: AppContext,
         force_refresh: bool,
         config: Arc<api::ServerConfiguration>,
+        semaphore: Arc<tokio::sync::Semaphore>,
     ) -> Uuid {
+        use futures::StreamExt;
+
+        // Bounds how many season/episode tasks are polled concurrently within
+        // this one item's own tree walk; actual network concurrency is capped
+        // by `semaphore` regardless, so this only needs to be "large enough
+        // to not artificially serialize" — reusing the same configured value
+        // keeps it consistent with the outer batch's own concurrency knob.
+        let concurrency = config
+            .meta_concurrency
+            .max(1) as usize;
+
         let original_id = media.id;
 
-        if let Err(e) = self
-            .refresh_meta(&mut media, &ctx, force_refresh, &config)
-            .await
-        {
+        let root_refresh_result = {
+            let _permit = semaphore
+                .acquire()
+                .await;
+            self.refresh_meta(&mut media, &ctx, force_refresh, &config)
+                .await
+        };
+        if let Err(e) = root_refresh_result {
             warn!(id = %media.id, error = %e, "failed to refresh metadata, keeping as-is");
             if let Err(e) = db::Media::upsert(&ctx.db, &[media.clone()]).await {
                 error!(id = %media.id, error = %e, "failed to upsert media");
@@ -2348,65 +2378,83 @@ impl AddonService {
         })
         .collect();
 
-        let mut level1: Vec<db::Media> = Vec::with_capacity(raw_level1.len());
-        for mut child in raw_level1 {
-            child.parent_id = Some(actual_root_id);
-            child.grandparent = Some(Box::new(gp_stub.clone()));
+        // Seasons/albums fan out concurrently — each one's own `refresh_meta`
+        // still throttles through `semaphore` (shared for the whole batch),
+        // so this can't multiply past the configured budget the way an
+        // independent per-level concurrency cap would.
+        let level1: Vec<db::Media> = futures::stream::iter(raw_level1)
+            .map(|mut child| {
+                let svc = self.clone();
+                let ctx = ctx.clone();
+                let config = Arc::clone(&config);
+                let semaphore = Arc::clone(&semaphore);
+                let gp_stub = gp_stub.clone();
+                let existing_l1 = &existing_l1;
+                async move {
+                    child.parent_id = Some(actual_root_id);
+                    child.grandparent = Some(Box::new(gp_stub));
 
-            // Adopt the existing DB UUID (and refreshed_at) for this (kind, idx)
-            // position if found. The new child UUID may differ from what's stored
-            // (due to UUID scheme changes or root remapping) — adopting the stored
-            // UUID avoids duplicate rows and keeps grandchild parent_id references
-            // intact. `refreshed_at` must also be adopted: this `child` was just
-            // freshly parsed from the addon's raw response, which has no concept
-            // of it, so leaving it unset makes `child_refresh_force` below treat
-            // an already-refreshed child as brand new every single pass.
-            if let Some(idx) = child.idx {
-                let key = (
-                    child
-                        .kind
-                        .to_string(),
-                    idx,
-                );
-                if let Some(&(existing_id, existing_refreshed_at)) =
-                    existing_l1.get(&key)
-                {
-                    child.refreshed_at = existing_refreshed_at;
-                    if existing_id != child.id {
-                        // When the root was remapped, cascade any references to the new
-                        // child UUID (which was never in the DB) before adopting.
-                        if root_was_remapped {
-                            if let Err(e) = db::Media::cascade_update_parent_refs(
-                                &ctx.db,
-                                child.id,
-                                existing_id,
-                            )
-                            .await
-                            {
-                                warn!(old = %child.id, new = %existing_id, error = %e,
-                                    "cascade for level-1 child failed");
+                    // Adopt the existing DB UUID (and refreshed_at) for this (kind, idx)
+                    // position if found. The new child UUID may differ from what's stored
+                    // (due to UUID scheme changes or root remapping) — adopting the stored
+                    // UUID avoids duplicate rows and keeps grandchild parent_id references
+                    // intact. `refreshed_at` must also be adopted: this `child` was just
+                    // freshly parsed from the addon's raw response, which has no concept
+                    // of it, so leaving it unset makes `child_refresh_force` below treat
+                    // an already-refreshed child as brand new every single pass.
+                    if let Some(idx) = child.idx {
+                        let key = (
+                            child
+                                .kind
+                                .to_string(),
+                            idx,
+                        );
+                        if let Some(&(existing_id, existing_refreshed_at)) =
+                            existing_l1.get(&key)
+                        {
+                            child.refreshed_at = existing_refreshed_at;
+                            if existing_id != child.id {
+                                // When the root was remapped, cascade any references to the new
+                                // child UUID (which was never in the DB) before adopting.
+                                if root_was_remapped {
+                                    if let Err(e) = db::Media::cascade_update_parent_refs(
+                                        &ctx.db,
+                                        child.id,
+                                        existing_id,
+                                    )
+                                    .await
+                                    {
+                                        warn!(old = %child.id, new = %existing_id, error = %e,
+                                            "cascade for level-1 child failed");
+                                    }
+                                }
+                                child.id = existing_id;
                             }
                         }
-                        child.id = existing_id;
                     }
-                }
-            }
 
-            let in_active_window = is_continuing
-                && matches!(child.kind, db::MediaKind::Episode)
-                && episode_in_active_window(&child);
-            if let Some(effective_force) =
-                child_refresh_force(force_refresh, in_active_window, &child)
-            {
-                if let Err(e) = self
-                    .refresh_meta(&mut child, &ctx, effective_force, &config)
-                    .await
-                {
-                    warn!(id = %child.id, error = %e, "failed to refresh level-1 child meta");
+                    let in_active_window = is_continuing
+                        && matches!(child.kind, db::MediaKind::Episode)
+                        && episode_in_active_window(&child);
+                    if let Some(effective_force) =
+                        child_refresh_force(force_refresh, in_active_window, &child)
+                    {
+                        let _permit = semaphore
+                            .acquire()
+                            .await;
+                        if let Err(e) = svc
+                            .refresh_meta(&mut child, &ctx, effective_force, &config)
+                            .await
+                        {
+                            warn!(id = %child.id, error = %e, "failed to refresh level-1 child meta");
+                        }
+                    }
+                    child
                 }
-            }
-            level1.push(child);
-        }
+            })
+            .buffer_unordered(concurrency)
+            .collect()
+            .await;
 
         let mut level1_ok: Vec<&db::Media> = Vec::with_capacity(level1.len());
         for chunk in level1.chunks(db::CHUNK_SIZE) {
@@ -2421,70 +2469,86 @@ impl AddonService {
             }
         }
 
-        // Level 2: grandchildren (Episodes, Tracks, etc.) — one fetch+upsert per child.
-        // Only process children whose level-1 upsert succeeded to avoid orphaned rows.
-        for child in &level1_ok {
-            let actual_child_id = child.id;
-            let raw_level2 = self
-                .get_direct_children(child, &ctx)
-                .await;
-            if raw_level2.is_empty() {
-                continue;
-            }
+        // Level 2: grandchildren (Episodes, Tracks, etc.) — one fetch+upsert
+        // per level-1 child. Only process children whose level-1 upsert
+        // succeeded to avoid orphaned rows. Different seasons' episode
+        // batches fan out concurrently for the same reason level 1 does;
+        // `semaphore` still bounds the real cost regardless.
+        futures::stream::iter(level1_ok)
+            .for_each_concurrent(concurrency, |child| {
+                let svc = self.clone();
+                let ctx = ctx.clone();
+                let config = Arc::clone(&config);
+                let semaphore = Arc::clone(&semaphore);
+                let gp_stub = gp_stub.clone();
+                let existing_l2 = &existing_l2;
+                async move {
+                    let actual_child_id = child.id;
+                    let raw_level2 = svc
+                        .get_direct_children(child, &ctx)
+                        .await;
+                    if raw_level2.is_empty() {
+                        return;
+                    }
 
-            let mut level2: Vec<db::Media> = Vec::with_capacity(raw_level2.len());
-            for mut gc in raw_level2 {
-                gc.parent_id = Some(actual_child_id);
-                gc.grandparent_id = Some(actual_root_id);
-                gc.grandparent = Some(Box::new(gp_stub.clone()));
+                    let mut level2: Vec<db::Media> = Vec::with_capacity(raw_level2.len());
+                    for mut gc in raw_level2 {
+                        gc.parent_id = Some(actual_child_id);
+                        gc.grandparent_id = Some(actual_root_id);
+                        gc.grandparent = Some(Box::new(gp_stub.clone()));
 
-                // Adopt existing UUID + refreshed_at from the pre-loaded grandchild
-                // map. `gc` is freshly parsed from the addon's raw response, which
-                // has no concept of refreshed_at — without adopting it here too,
-                // child_refresh_force below always treats this episode as never
-                // refreshed, refetching it on every single pass.
-                if let Some(idx) = gc.idx {
-                    let key = (
-                        actual_child_id,
-                        gc.kind
-                            .to_string(),
-                        idx,
-                    );
-                    if let Some(&(existing_id, existing_refreshed_at)) =
-                        existing_l2.get(&key)
-                    {
-                        gc.id = existing_id;
-                        gc.refreshed_at = existing_refreshed_at;
+                        // Adopt existing UUID + refreshed_at from the pre-loaded grandchild
+                        // map. `gc` is freshly parsed from the addon's raw response, which
+                        // has no concept of refreshed_at — without adopting it here too,
+                        // child_refresh_force below always treats this episode as never
+                        // refreshed, refetching it on every single pass.
+                        if let Some(idx) = gc.idx {
+                            let key = (
+                                actual_child_id,
+                                gc.kind
+                                    .to_string(),
+                                idx,
+                            );
+                            if let Some(&(existing_id, existing_refreshed_at)) =
+                                existing_l2.get(&key)
+                            {
+                                gc.id = existing_id;
+                                gc.refreshed_at = existing_refreshed_at;
+                            }
+                        }
+
+                        let in_active_window = is_continuing
+                            && matches!(gc.kind, db::MediaKind::Episode)
+                            && episode_in_active_window(&gc);
+                        if let Some(effective_force) =
+                            child_refresh_force(force_refresh, in_active_window, &gc)
+                        {
+                            let _permit = semaphore
+                                .acquire()
+                                .await;
+                            if let Err(e) = svc
+                                .refresh_meta(&mut gc, &ctx, effective_force, &config)
+                                .await
+                            {
+                                warn!(id = %gc.id, error = %e, "failed to refresh level-2 child meta");
+                            }
+                        }
+                        level2.push(gc);
+                    }
+
+                    for chunk in level2.chunks(db::CHUNK_SIZE) {
+                        if let Err(e) = db::Media::upsert(&ctx.db, chunk).await {
+                            error!(error = %e, "failed to upsert level-2 children");
+                        } else {
+                            db::UserMediaState::remap_orphaned_for(&ctx.db, chunk).await;
+                            save_pending_relations(&ctx, chunk).await;
+                            save_pending_tags(&ctx, chunk).await;
+                            save_pending_popularity(&ctx, chunk).await;
+                        }
                     }
                 }
-
-                let in_active_window = is_continuing
-                    && matches!(gc.kind, db::MediaKind::Episode)
-                    && episode_in_active_window(&gc);
-                if let Some(effective_force) =
-                    child_refresh_force(force_refresh, in_active_window, &gc)
-                {
-                    if let Err(e) = self
-                        .refresh_meta(&mut gc, &ctx, effective_force, &config)
-                        .await
-                    {
-                        warn!(id = %gc.id, error = %e, "failed to refresh level-2 child meta");
-                    }
-                }
-                level2.push(gc);
-            }
-
-            for chunk in level2.chunks(db::CHUNK_SIZE) {
-                if let Err(e) = db::Media::upsert(&ctx.db, chunk).await {
-                    error!(error = %e, "failed to upsert level-2 children");
-                } else {
-                    db::UserMediaState::remap_orphaned_for(&ctx.db, chunk).await;
-                    save_pending_relations(&ctx, chunk).await;
-                    save_pending_tags(&ctx, chunk).await;
-                    save_pending_popularity(&ctx, chunk).await;
-                }
-            }
-        }
+            })
+            .await;
 
         self.notify_series_done(&media);
         actual_root_id

--- a/crates/remux-server/src/addons/mod.rs
+++ b/crates/remux-server/src/addons/mod.rs
@@ -2062,13 +2062,18 @@ impl AddonService {
         use futures::StreamExt;
 
         let config = db::Settings::get_config_or_default(&ctx.db).await;
-        let concurrency = config.meta_concurrency as usize;
+        // Clamp before casting: a persisted/API-set 0 or negative value would
+        // otherwise stall `buffer_unordered` (0) or wrap around to near
+        // `usize::MAX` (negative), not just fail to throttle.
+        let concurrency = config
+            .meta_concurrency
+            .max(1) as usize;
         let config = Arc::new(config);
         // Shared across this whole batch — top-level items, and every season/
         // episode any of them refreshes — so nested fan-out inside a single
         // item's own tree walk can't multiply past this budget. See
         // `process_meta_item_inner` for where seasons/episodes acquire from it.
-        let semaphore = Arc::new(tokio::sync::Semaphore::new(concurrency.max(1)));
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(concurrency));
 
         let svc = self.clone();
         let ctx_owned = ctx.clone();
@@ -2242,7 +2247,8 @@ impl AddonService {
         let root_refresh_result = {
             let _permit = semaphore
                 .acquire()
-                .await;
+                .await
+                .expect("semaphore is never closed");
             self.refresh_meta(&mut media, &ctx, force_refresh, &config)
                 .await
         };
@@ -2441,7 +2447,8 @@ impl AddonService {
                     {
                         let _permit = semaphore
                             .acquire()
-                            .await;
+                            .await
+                            .expect("semaphore is never closed");
                         if let Err(e) = svc
                             .refresh_meta(&mut child, &ctx, effective_force, &config)
                             .await
@@ -2525,7 +2532,8 @@ impl AddonService {
                         {
                             let _permit = semaphore
                                 .acquire()
-                                .await;
+                                .await
+                                .expect("semaphore is never closed");
                             if let Err(e) = svc
                                 .refresh_meta(&mut gc, &ctx, effective_force, &config)
                                 .await

--- a/crates/remux-server/src/addons/opendal.rs
+++ b/crates/remux-server/src/addons/opendal.rs
@@ -1194,7 +1194,18 @@ async fn scan_addon(
                                         .map(Into::into)
                                 }
                             } else {
-                                resolve_imdb(tmdb, &clean_title, None, true).await
+                                if let Some(client) = tmdb {
+                                    MediaResolveService::resolve_imdb_from_search(
+                                        client,
+                                        &clean_title,
+                                        None,
+                                        true,
+                                    )
+                                    .await
+                                    .map(Into::into)
+                                } else {
+                                    None
+                                }
                             };
                             (imdb_id, season, episode, year, clean_title)
                         }
@@ -1226,7 +1237,18 @@ async fn scan_addon(
                                         .map(Into::into)
                                 }
                             } else {
-                                resolve_imdb(tmdb, &clean_title, year, false).await
+                                if let Some(client) = tmdb {
+                                    MediaResolveService::resolve_imdb_from_search(
+                                        client,
+                                        &clean_title,
+                                        year,
+                                        false,
+                                    )
+                                    .await
+                                    .map(Into::into)
+                                } else {
+                                    None
+                                }
                             };
                             (imdb_id, None, None, year, clean_title)
                         }
@@ -1478,7 +1500,18 @@ async fn scan_addon(
                                 .map(Into::into)
                         }
                     } else {
-                        resolve_imdb(tmdb, &clean_title, None, true).await
+                        if let Some(client) = tmdb {
+                            MediaResolveService::resolve_imdb_from_search(
+                                client,
+                                &clean_title,
+                                None,
+                                true,
+                            )
+                            .await
+                            .map(Into::into)
+                        } else {
+                            None
+                        }
                     };
 
                     if imdb_id.is_none() {
@@ -1519,7 +1552,18 @@ async fn scan_addon(
                                 .map(Into::into)
                         }
                     } else {
-                        resolve_imdb(tmdb, &clean_title, year, false).await
+                        if let Some(client) = tmdb {
+                            MediaResolveService::resolve_imdb_from_search(
+                                client,
+                                &clean_title,
+                                year,
+                                false,
+                            )
+                            .await
+                            .map(Into::into)
+                        } else {
+                            None
+                        }
                     };
 
                     if imdb_id.is_none() {
@@ -1619,77 +1663,6 @@ async fn fetch_existing_imdb(
     .fetch_optional(&ctx.db)
     .await?
     .flatten())
-}
-
-async fn resolve_imdb(
-    tmdb: &Option<sdks::RestClient<sdks::BearerAuth>>,
-    title: &str,
-    year: Option<i64>,
-    is_tv: bool,
-) -> Option<String> {
-    let client = tmdb.as_ref()?;
-    if title.is_empty() {
-        return None;
-    }
-
-    if is_tv {
-        let resp = client
-            .execute(
-                sdks::tmdb::SearchTvEndpoint {
-                    query: title.to_string(),
-                }
-                .with_cache(Duration::from_secs(86400)),
-            )
-            .await
-            .ok()?;
-        let tmdb_id = resp
-            .results
-            .into_iter()
-            .next()?
-            .id;
-
-        let series = client
-            .execute(
-                sdks::tmdb::SeriesEndpoint::new(tmdb_id, None)
-                    .with_cache(Duration::from_secs(86400)),
-            )
-            .await
-            .ok()?;
-
-        series
-            .external_ids
-            .as_ref()
-            .and_then(|e| {
-                e.imdb_id
-                    .clone()
-            })
-    } else {
-        let resp = client
-            .execute(
-                sdks::tmdb::SearchMovieEndpoint {
-                    query: title.to_string(),
-                    year,
-                }
-                .with_cache(Duration::from_secs(86400)),
-            )
-            .await
-            .ok()?;
-        let tmdb_id = resp
-            .results
-            .into_iter()
-            .next()?
-            .id;
-
-        let movie = client
-            .execute(
-                sdks::tmdb::MovieEndpoint::new(tmdb_id, None)
-                    .with_cache(Duration::from_secs(86400)),
-            )
-            .await
-            .ok()?;
-
-        movie.imdb_id
-    }
 }
 
 async fn prune_stale_paths(
@@ -3082,13 +3055,14 @@ mod tests {
         });
         mock_tv_series(&server, 157842, "tt21249100");
 
-        let result = resolve_imdb(
-            &tmdb_test_client(&server.base_url()),
+        let result: Option<String> = MediaResolveService::resolve_imdb_from_search(
+            &tmdb_test_client(&server.base_url()).unwrap(),
             "Black Summoner",
             Some(2022),
             true,
         )
-        .await;
+        .await
+        .map(Into::into);
         assert_eq!(
             result.as_deref(),
             Some("tt21249100"),
@@ -3109,13 +3083,14 @@ mod tests {
         });
         mock_tv_series(&server, 30984, "tt0434665");
 
-        let result = resolve_imdb(
-            &tmdb_test_client(&server.base_url()),
+        let result: Option<String> = MediaResolveService::resolve_imdb_from_search(
+            &tmdb_test_client(&server.base_url()).unwrap(),
             "Bleach",
             Some(2004),
             true,
         )
-        .await;
+        .await
+        .map(Into::into);
         assert_eq!(result.as_deref(), Some("tt0434665"), "Bleach title search");
     }
 
@@ -3132,13 +3107,14 @@ mod tests {
         });
         mock_tv_series(&server, 43270, "tt1890725");
 
-        let result = resolve_imdb(
-            &tmdb_test_client(&server.base_url()),
+        let result: Option<String> = MediaResolveService::resolve_imdb_from_search(
+            &tmdb_test_client(&server.base_url()).unwrap(),
             "Blood-C",
             Some(2011),
             true,
         )
-        .await;
+        .await
+        .map(Into::into);
         assert_eq!(result.as_deref(), Some("tt1890725"), "Blood-C title search");
     }
 

--- a/crates/remux-server/src/addons/tmdb.rs
+++ b/crates/remux-server/src/addons/tmdb.rs
@@ -1271,25 +1271,11 @@ async fn fetch_tmdb_meta(
 
     match media.kind {
         db::MediaKind::Movie => {
-            // Use the TMDB ID directly if known; otherwise discover it via /find.
-            let tmdb_movie_id: Option<i64> = if let Some(id) = ids.tmdb {
-                Some(id)
-            } else {
-                match MediaResolveService::tmdb_search_key(ids, None).await {
-                    Some((external_id, external_source)) => {
-                        MediaResolveService::find_tmdb_id_by(
-                            external_id,
-                            external_source,
-                            false,
-                            &client,
-                        )
-                        .await
-                        .ok()
-                        .flatten()
-                    }
-                    None => return Ok(None),
-                }
-            };
+            // `resolve_missing_external_ids` (called at the top of
+            // `refresh_meta`, before any addon runs) already resolves a
+            // tmdb id from whatever else is known, if one is resolvable at
+            // all — nothing left to discover here.
+            let tmdb_movie_id: Option<i64> = ids.tmdb;
 
             if let Some(tmdb_id) = tmdb_movie_id {
                 let movie_details = client
@@ -1474,25 +1460,11 @@ async fn fetch_tmdb_meta(
             }
         }
         db::MediaKind::Series => {
-            // Use the TMDB ID directly if known; otherwise discover it via /find.
-            let tmdb_series_id: Option<i64> = if let Some(id) = ids.tmdb {
-                Some(id)
-            } else {
-                match MediaResolveService::tmdb_search_key(ids, None).await {
-                    Some((external_id, external_source)) => {
-                        MediaResolveService::find_tmdb_id_by(
-                            external_id,
-                            external_source,
-                            true,
-                            &client,
-                        )
-                        .await
-                        .ok()
-                        .flatten()
-                    }
-                    None => return Ok(None),
-                }
-            };
+            // `resolve_missing_external_ids` (called at the top of
+            // `refresh_meta`, before any addon runs) already resolves a
+            // tmdb id from whatever else is known, if one is resolvable at
+            // all — nothing left to discover here.
+            let tmdb_series_id: Option<i64> = ids.tmdb;
 
             if let Some(tmdb_id) = tmdb_series_id {
                 let tv_details = client
@@ -2472,82 +2444,6 @@ mod tests {
                 Some("tt1234567")
             );
         }
-    }
-
-    #[tokio::test]
-    async fn catalog_streams_do_not_resolve_imdb() {
-        let server = httpmock::MockServer::start();
-        let body = serde_json::json!({"page": 1, "total_pages": 1, "total_results": 1,
-            "results": [{"id": 446301, "name": "Series", "title": "Movie"}]});
-        let discover = server.mock(|when, then| {
-            when.path_contains("/discover/");
-            then.status(200)
-                .json_body(body.clone());
-        });
-        let trending = server.mock(|when, then| {
-            when.path_contains("/trending/");
-            then.status(200)
-                .json_body(body.clone());
-        });
-        let lookup = server.mock(|when, then| {
-            when.path_contains("/446301");
-            then.status(404);
-        });
-        let (_app, guard) =
-            crate::integration_test::new_test_server_with_config(crate::Config {
-                database_url: Some("sqlite::memory:".into()),
-                torrent_http_port: None,
-                disable_dht: true,
-                tmdb_base_url: server.base_url(),
-                ..Default::default()
-            })
-            .await
-            .unwrap();
-        let addon = TmdbAddon {
-            popularity_max: Mutex::new(None),
-        };
-        for catalog in [
-            "popular_movies",
-            "popular_tv",
-            "top_rated_movies",
-            "top_rated_tv",
-            "trending_movies_week",
-            "trending_tv_week",
-        ] {
-            let stream = addon
-                .catalog_stream(&guard.0, catalog)
-                .await
-                .unwrap()
-                .unwrap();
-            let items: Vec<_> = stream
-                .collect()
-                .await;
-            assert_eq!(items.len(), 1, "{catalog}");
-            assert_eq!(
-                items[0]
-                    .external_ids
-                    .tmdb,
-                Some(446301)
-            );
-            assert!(
-                items[0]
-                    .external_ids
-                    .imdb
-                    .is_none()
-            );
-            assert_eq!(
-                items[0].id,
-                common::stable_media_uuid(&items[0].kind, "tmdb:446301")
-            );
-        }
-        // Background startup tasks can also request catalog pages.
-        assert!(discover.hits() >= 4);
-        assert!(trending.hits() >= 2);
-        assert_eq!(
-            lookup.hits(),
-            0,
-            "IMDb resolution belongs to metadata refresh"
-        );
     }
 
     fn image_entry(path: &str, language: Option<&str>) -> sdks::tmdb::ImageEntry {

--- a/crates/remux-server/src/addons/tmdb.rs
+++ b/crates/remux-server/src/addons/tmdb.rs
@@ -301,62 +301,43 @@ impl CatalogAddon for TmdbAddon {
         )?;
 
         let stream: Pin<Box<dyn Stream<Item = db::Media> + Send>> = match local_id {
-            "popular_movies" => Box::pin(with_optional_imdb(
-                discover_movie_stream(
-                    client.clone(),
-                    sdks::tmdb::DiscoverQuery {
-                        sort_by: Some("popularity.desc".into()),
-                        ..Default::default()
-                    },
-                ),
+            "popular_movies" => Box::pin(discover_movie_stream(
                 client,
-                false,
+                sdks::tmdb::DiscoverQuery {
+                    sort_by: Some("popularity.desc".into()),
+                    ..Default::default()
+                },
             )),
-            "popular_tv" => Box::pin(with_optional_imdb(
-                discover_tv_stream(
-                    client.clone(),
-                    sdks::tmdb::DiscoverQuery {
-                        sort_by: Some("popularity.desc".into()),
-                        ..Default::default()
-                    },
-                ),
+            "popular_tv" => Box::pin(discover_tv_stream(
                 client,
-                true,
+                sdks::tmdb::DiscoverQuery {
+                    sort_by: Some("popularity.desc".into()),
+                    ..Default::default()
+                },
             )),
-            "top_rated_movies" => Box::pin(with_optional_imdb(
-                discover_movie_stream(
-                    client.clone(),
-                    sdks::tmdb::DiscoverQuery {
-                        sort_by: Some("vote_average.desc".into()),
-                        vote_count_gte: Some(300),
-                        ..Default::default()
-                    },
-                ),
+            "top_rated_movies" => Box::pin(discover_movie_stream(
                 client,
-                false,
+                sdks::tmdb::DiscoverQuery {
+                    sort_by: Some("vote_average.desc".into()),
+                    vote_count_gte: Some(300),
+                    ..Default::default()
+                },
             )),
-            "top_rated_tv" => Box::pin(with_optional_imdb(
-                discover_tv_stream(
-                    client.clone(),
-                    sdks::tmdb::DiscoverQuery {
-                        sort_by: Some("vote_average.desc".into()),
-                        vote_count_gte: Some(300),
-                        ..Default::default()
-                    },
-                ),
+            "top_rated_tv" => Box::pin(discover_tv_stream(
                 client,
-                true,
+                sdks::tmdb::DiscoverQuery {
+                    sort_by: Some("vote_average.desc".into()),
+                    vote_count_gte: Some(300),
+                    ..Default::default()
+                },
             )),
-            "trending_movies_week" => Box::pin(with_optional_imdb(
-                trending_movie_stream(client.clone(), sdks::tmdb::TrendingWindow::Week),
+            "trending_movies_week" => Box::pin(trending_movie_stream(
                 client,
-                false,
+                sdks::tmdb::TrendingWindow::Week,
             )),
-            "trending_tv_week" => Box::pin(with_optional_imdb(
-                trending_tv_stream(client.clone(), sdks::tmdb::TrendingWindow::Week),
-                client,
-                true,
-            )),
+            "trending_tv_week" => {
+                Box::pin(trending_tv_stream(client, sdks::tmdb::TrendingWindow::Week))
+            }
             _ => return Ok(None),
         };
 
@@ -485,35 +466,6 @@ fn series_result_to_stub(s: sdks::tmdb::SeriesSearchResult) -> db::Media {
         media.set_image(db::ImageKind::Primary, url);
     }
     media
-}
-
-/// Wraps a catalog stub stream and resolves the IMDB ID for each item inline,
-/// recomputing the stable UUID when an IMDb ID is found. Otherwise retain
-/// the stub's TMDB identity so missing mappings do not hide catalog items.
-fn with_optional_imdb(
-    stream: impl Stream<Item = db::Media> + Send + 'static,
-    client: sdks::RestClient<sdks::BearerAuth>,
-    is_tv: bool,
-) -> impl Stream<Item = db::Media> + Send {
-    stream
-        .map(move |mut stub| {
-            let c = client.clone();
-            async move {
-                if let Some(imdb) = MediaResolveService::resolve_imdb_from_ids(
-                    &stub.external_ids,
-                    is_tv,
-                    &c,
-                )
-                .await
-                {
-                    stub.id = common::stable_media_uuid(&stub.kind, imdb.as_str());
-                    stub.external_ids
-                        .imdb = Some(imdb);
-                }
-                stub
-            }
-        })
-        .buffer_unordered(10)
 }
 
 fn discover_movie_stream(
@@ -2523,79 +2475,79 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn catalog_keeps_tmdb_identity_without_imdb() {
+    async fn catalog_streams_do_not_resolve_imdb() {
         let server = httpmock::MockServer::start();
-        let missing = server.mock(|when, then| {
-            when.path("/tv/446101");
-            then.status(200).json_body(serde_json::json!({"id": 446101, "external_ids": {"imdb_id": null}}));
+        let body = serde_json::json!({"page": 1, "total_pages": 1, "total_results": 1,
+            "results": [{"id": 446301, "name": "Series", "title": "Movie"}]});
+        let discover = server.mock(|when, then| {
+            when.path_contains("/discover/");
+            then.status(200)
+                .json_body(body.clone());
         });
-        let found = server.mock(|when, then| {
-            when.path("/tv/446102");
-            then.status(200).json_body(serde_json::json!({"id": 446102, "external_ids": {"imdb_id": "tt446102"}}));
+        let trending = server.mock(|when, then| {
+            when.path_contains("/trending/");
+            then.status(200)
+                .json_body(body.clone());
         });
-        let failed = server.mock(|when, then| {
-            when.path("/tv/446103");
+        let lookup = server.mock(|when, then| {
+            when.path_contains("/446301");
             then.status(404);
         });
-        let stubs = [446101, 446102, 446103].map(|id| db::Media {
-            id: common::stable_media_uuid(
-                &db::MediaKind::Series,
-                &format!("tmdb:{id}"),
-            ),
-            kind: db::MediaKind::Series,
-            external_ids: db::ExternalIds {
-                tmdb: Some(id),
+        let (_app, guard) =
+            crate::integration_test::new_test_server_with_config(crate::Config {
+                database_url: Some("sqlite::memory:".into()),
+                torrent_http_port: None,
+                disable_dht: true,
+                tmdb_base_url: server.base_url(),
                 ..Default::default()
-            },
-            ..Default::default()
-        });
-        let client = sdks::RestClient::new(&server.base_url())
-            .unwrap()
-            .with_auth(sdks::BearerAuth {
-                token: String::new(),
-            });
-        let items: Vec<_> =
-            with_optional_imdb(futures::stream::iter(stubs.clone()), client, true)
+            })
+            .await
+            .unwrap();
+        let addon = TmdbAddon {
+            popularity_max: Mutex::new(None),
+        };
+        for catalog in [
+            "popular_movies",
+            "popular_tv",
+            "top_rated_movies",
+            "top_rated_tv",
+            "trending_movies_week",
+            "trending_tv_week",
+        ] {
+            let stream = addon
+                .catalog_stream(&guard.0, catalog)
+                .await
+                .unwrap()
+                .unwrap();
+            let items: Vec<_> = stream
                 .collect()
                 .await;
-        assert_eq!(items.len(), 3);
-        for stub in stubs {
-            let item = items
-                .iter()
-                .find(|item| {
-                    item.external_ids
-                        .tmdb
-                        == stub
-                            .external_ids
-                            .tmdb
-                })
-                .unwrap();
-            if stub
-                .external_ids
-                .tmdb
-                == Some(446102)
-            {
-                assert_eq!(
-                    item.id,
-                    common::stable_media_uuid(&db::MediaKind::Series, "tt446102")
-                );
-                assert!(
-                    item.external_ids
-                        .imdb
-                        .is_some()
-                );
-            } else {
-                assert_eq!(item.id, stub.id);
-                assert!(
-                    item.external_ids
-                        .imdb
-                        .is_none()
-                );
-            }
+            assert_eq!(items.len(), 1, "{catalog}");
+            assert_eq!(
+                items[0]
+                    .external_ids
+                    .tmdb,
+                Some(446301)
+            );
+            assert!(
+                items[0]
+                    .external_ids
+                    .imdb
+                    .is_none()
+            );
+            assert_eq!(
+                items[0].id,
+                common::stable_media_uuid(&items[0].kind, "tmdb:446301")
+            );
         }
-        missing.assert();
-        found.assert();
-        failed.assert();
+        // Background startup tasks can also request catalog pages.
+        assert!(discover.hits() >= 4);
+        assert!(trending.hits() >= 2);
+        assert_eq!(
+            lookup.hits(),
+            0,
+            "IMDb resolution belongs to metadata refresh"
+        );
     }
 
     fn image_entry(path: &str, language: Option<&str>) -> sdks::tmdb::ImageEntry {

--- a/crates/remux-server/src/addons/tmdb.rs
+++ b/crates/remux-server/src/addons/tmdb.rs
@@ -301,7 +301,7 @@ impl CatalogAddon for TmdbAddon {
         )?;
 
         let stream: Pin<Box<dyn Stream<Item = db::Media> + Send>> = match local_id {
-            "popular_movies" => Box::pin(with_imdb_resolved(
+            "popular_movies" => Box::pin(with_optional_imdb(
                 discover_movie_stream(
                     client.clone(),
                     sdks::tmdb::DiscoverQuery {
@@ -312,7 +312,7 @@ impl CatalogAddon for TmdbAddon {
                 client,
                 false,
             )),
-            "popular_tv" => Box::pin(with_imdb_resolved(
+            "popular_tv" => Box::pin(with_optional_imdb(
                 discover_tv_stream(
                     client.clone(),
                     sdks::tmdb::DiscoverQuery {
@@ -323,7 +323,7 @@ impl CatalogAddon for TmdbAddon {
                 client,
                 true,
             )),
-            "top_rated_movies" => Box::pin(with_imdb_resolved(
+            "top_rated_movies" => Box::pin(with_optional_imdb(
                 discover_movie_stream(
                     client.clone(),
                     sdks::tmdb::DiscoverQuery {
@@ -335,7 +335,7 @@ impl CatalogAddon for TmdbAddon {
                 client,
                 false,
             )),
-            "top_rated_tv" => Box::pin(with_imdb_resolved(
+            "top_rated_tv" => Box::pin(with_optional_imdb(
                 discover_tv_stream(
                     client.clone(),
                     sdks::tmdb::DiscoverQuery {
@@ -347,12 +347,12 @@ impl CatalogAddon for TmdbAddon {
                 client,
                 true,
             )),
-            "trending_movies_week" => Box::pin(with_imdb_resolved(
+            "trending_movies_week" => Box::pin(with_optional_imdb(
                 trending_movie_stream(client.clone(), sdks::tmdb::TrendingWindow::Week),
                 client,
                 false,
             )),
-            "trending_tv_week" => Box::pin(with_imdb_resolved(
+            "trending_tv_week" => Box::pin(with_optional_imdb(
                 trending_tv_stream(client.clone(), sdks::tmdb::TrendingWindow::Week),
                 client,
                 true,
@@ -488,9 +488,9 @@ fn series_result_to_stub(s: sdks::tmdb::SeriesSearchResult) -> db::Media {
 }
 
 /// Wraps a catalog stub stream and resolves the IMDB ID for each item inline,
-/// recomputing the stable UUID from the IMDB ID. Items that cannot be resolved
-/// are dropped (no IMDB ID = no canonical identity).
-fn with_imdb_resolved(
+/// recomputing the stable UUID when an IMDb ID is found. Otherwise retain
+/// the stub's TMDB identity so missing mappings do not hide catalog items.
+fn with_optional_imdb(
     stream: impl Stream<Item = db::Media> + Send + 'static,
     client: sdks::RestClient<sdks::BearerAuth>,
     is_tv: bool,
@@ -499,20 +499,21 @@ fn with_imdb_resolved(
         .map(move |mut stub| {
             let c = client.clone();
             async move {
-                let imdb = MediaResolveService::resolve_imdb_from_ids(
+                if let Some(imdb) = MediaResolveService::resolve_imdb_from_ids(
                     &stub.external_ids,
                     is_tv,
                     &c,
                 )
-                .await?;
-                stub.id = common::stable_media_uuid(&stub.kind, imdb.as_str());
-                stub.external_ids
-                    .imdb = Some(imdb);
-                Some(stub)
+                .await
+                {
+                    stub.id = common::stable_media_uuid(&stub.kind, imdb.as_str());
+                    stub.external_ids
+                        .imdb = Some(imdb);
+                }
+                stub
             }
         })
         .buffer_unordered(10)
-        .filter_map(futures::future::ready)
 }
 
 fn discover_movie_stream(
@@ -2519,6 +2520,82 @@ mod tests {
                 Some("tt1234567")
             );
         }
+    }
+
+    #[tokio::test]
+    async fn catalog_keeps_tmdb_identity_without_imdb() {
+        let server = httpmock::MockServer::start();
+        let missing = server.mock(|when, then| {
+            when.path("/tv/446101");
+            then.status(200).json_body(serde_json::json!({"id": 446101, "external_ids": {"imdb_id": null}}));
+        });
+        let found = server.mock(|when, then| {
+            when.path("/tv/446102");
+            then.status(200).json_body(serde_json::json!({"id": 446102, "external_ids": {"imdb_id": "tt446102"}}));
+        });
+        let failed = server.mock(|when, then| {
+            when.path("/tv/446103");
+            then.status(404);
+        });
+        let stubs = [446101, 446102, 446103].map(|id| db::Media {
+            id: common::stable_media_uuid(
+                &db::MediaKind::Series,
+                &format!("tmdb:{id}"),
+            ),
+            kind: db::MediaKind::Series,
+            external_ids: db::ExternalIds {
+                tmdb: Some(id),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let client = sdks::RestClient::new(&server.base_url())
+            .unwrap()
+            .with_auth(sdks::BearerAuth {
+                token: String::new(),
+            });
+        let items: Vec<_> =
+            with_optional_imdb(futures::stream::iter(stubs.clone()), client, true)
+                .collect()
+                .await;
+        assert_eq!(items.len(), 3);
+        for stub in stubs {
+            let item = items
+                .iter()
+                .find(|item| {
+                    item.external_ids
+                        .tmdb
+                        == stub
+                            .external_ids
+                            .tmdb
+                })
+                .unwrap();
+            if stub
+                .external_ids
+                .tmdb
+                == Some(446102)
+            {
+                assert_eq!(
+                    item.id,
+                    common::stable_media_uuid(&db::MediaKind::Series, "tt446102")
+                );
+                assert!(
+                    item.external_ids
+                        .imdb
+                        .is_some()
+                );
+            } else {
+                assert_eq!(item.id, stub.id);
+                assert!(
+                    item.external_ids
+                        .imdb
+                        .is_none()
+                );
+            }
+        }
+        missing.assert();
+        found.assert();
+        failed.assert();
     }
 
     fn image_entry(path: &str, language: Option<&str>) -> sdks::tmdb::ImageEntry {

--- a/crates/remux-server/src/db/media.rs
+++ b/crates/remux-server/src/db/media.rs
@@ -2185,15 +2185,6 @@ impl Media {
         }
 
         let missing = match self.kind {
-            MediaKind::Movie | MediaKind::Series => (self
-                .external_ids
-                .imdb
-                .is_none()
-                && self
-                    .external_ids
-                    .custom_stremio_id
-                    .is_none())
-            .then_some("imdb"),
             MediaKind::Season | MediaKind::Episode => self
                 .grandparent_id
                 .is_none()
@@ -8144,6 +8135,64 @@ pub(crate) fn build_genre_relations_from_names(
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn movie_and_series_accept_known_external_ids() {
+        for kind in [MediaKind::Movie, MediaKind::Series] {
+            for external_ids in [
+                ExternalIds {
+                    imdb: NonEmptyString::try_new("tt446001".to_string()).ok(),
+                    ..Default::default()
+                },
+                ExternalIds {
+                    tmdb: Some(446001),
+                    ..Default::default()
+                },
+                ExternalIds {
+                    tvdb: Some(446001),
+                    ..Default::default()
+                },
+                ExternalIds {
+                    kitsu: Some(446001),
+                    ..Default::default()
+                },
+                ExternalIds {
+                    custom_stremio_id: Some("custom:446001".into()),
+                    ..Default::default()
+                },
+            ] {
+                let media = Media {
+                    kind: kind.clone(),
+                    external_ids,
+                    ..Default::default()
+                };
+                assert!(
+                    media
+                        .validate()
+                        .is_ok(),
+                    "{:?}",
+                    media.external_ids
+                );
+            }
+            for external_ids in [
+                ExternalIds::default(),
+                ExternalIds {
+                    youtube_id: Some("unrelated".into()),
+                    ..Default::default()
+                },
+            ] {
+                assert!(
+                    Media {
+                        kind: kind.clone(),
+                        external_ids,
+                        ..Default::default()
+                    }
+                    .validate()
+                    .is_err()
+                );
+            }
+        }
+    }
+
     use super::*;
     use crate::db::MediaIdRaw;
 
@@ -10391,8 +10440,7 @@ mod dedup_tests {
     /// Multi-match: incoming carries two ids that resolve to two different
     /// stored rows. The stronger id (imdb over custom_stremio_id) wins, per
     /// priority. Both stored rows carry an id from {imdb, custom_stremio_id}
-    /// so each independently satisfies `validate()`'s Movie rule (imdb OR
-    /// custom_stremio_id — tmdb/tvdb/kitsu alone do not).
+    /// so each independently satisfies the Movie external-ID requirement.
     #[tokio::test]
     async fn strongest_id_wins_on_ambiguous_match() {
         let (_s, guard) = new_test_server()

--- a/crates/remux-server/src/services/resolve.rs
+++ b/crates/remux-server/src/services/resolve.rs
@@ -322,6 +322,123 @@ impl MediaResolveService {
         }
     }
 
+    /// Fills in whichever of tmdb/imdb/tvdb are missing on `media`, using
+    /// only the calls actually needed — an item with everything already
+    /// resolved makes no network calls at all. Movies only ever get
+    /// tmdb/imdb (TVDB doesn't track movies); tvdb is Series-only.
+    ///
+    /// Deliberately does not attempt to backfill a missing kitsu id: kitsu
+    /// only matters for anime, which we can't tell from ids alone at this
+    /// point (genre/original_language aren't known until an addon's own
+    /// `meta_fetch` runs, later in `refresh_meta`) — trying it unconditionally
+    /// for every Series added a mandatory third-party round trip that misses
+    /// for the vast majority of shows. Kitsu stays exactly what it was
+    /// before this method existed: a fallback *key source* in
+    /// `tmdb_search_key` (used only when neither imdb nor tvdb is known) and
+    /// the anime-tracker completion flow's own on-demand resolution — never
+    /// something resolved speculatively on every refresh.
+    ///
+    /// Called once at the top of `refresh_meta`, before any addon's own
+    /// `meta_fetch` runs, so every addon sees the fuller id set. This is
+    /// intentionally sequential, not parallelized: TMDB's series
+    /// `external_ids` sub-resource returns imdb *and* tvdb together in one
+    /// call — there's no pair
+    /// of independent lookups left to run concurrently once that's used.
+    pub async fn resolve_missing_external_ids(media: &mut db::Media, ctx: &AppContext) {
+        if !matches!(media.kind, db::MediaKind::Movie | db::MediaKind::Series) {
+            return;
+        }
+        let is_tv = media.kind == db::MediaKind::Series;
+        let needs_tmdb = media
+            .external_ids
+            .tmdb
+            .is_none();
+        let needs_imdb = media
+            .external_ids
+            .imdb
+            .is_none();
+        let needs_tvdb = is_tv
+            && media
+                .external_ids
+                .tvdb
+                .is_none();
+        if !needs_tmdb && !needs_imdb && !needs_tvdb {
+            return;
+        }
+        let Some(client) = Self::tmdb(ctx).await else {
+            return;
+        };
+
+        let tmdb_id = if let Some(id) = media
+            .external_ids
+            .tmdb
+        {
+            Some(id)
+        } else {
+            match Self::tmdb_search_key(
+                &media.external_ids,
+                Some(&sdks::kitsu::client()),
+            )
+            .await
+            {
+                Some((external_id, external_source)) => {
+                    Self::find_tmdb_id_by(external_id, external_source, is_tv, &client)
+                        .await
+                        .ok()
+                        .flatten()
+                }
+                None => None,
+            }
+        };
+        let Some(tmdb_id) = tmdb_id else {
+            return;
+        };
+        media
+            .external_ids
+            .tmdb = Some(tmdb_id);
+
+        if needs_imdb || needs_tvdb {
+            if is_tv {
+                if let Ok(series) = client
+                    .execute(series_ids_endpoint(tmdb_id).with_cache(ID_CACHE_TTL))
+                    .await
+                    && let Some(e) = series.external_ids
+                {
+                    if media
+                        .external_ids
+                        .imdb
+                        .is_none()
+                    {
+                        media
+                            .external_ids
+                            .imdb = e
+                            .imdb_id
+                            .and_then(|s| db::NonEmptyString::try_new(s).ok());
+                    }
+                    if media
+                        .external_ids
+                        .tvdb
+                        .is_none()
+                    {
+                        media
+                            .external_ids
+                            .tvdb = e.tvdb_id;
+                    }
+                }
+            } else if needs_imdb
+                && let Ok(movie) = client
+                    .execute(movie_ids_endpoint(tmdb_id).with_cache(ID_CACHE_TTL))
+                    .await
+            {
+                media
+                    .external_ids
+                    .imdb = movie
+                    .imdb_id
+                    .and_then(|s| db::NonEmptyString::try_new(s).ok());
+            }
+        }
+    }
+
     /// The likeliest id to hit on `/find`: imdb, then tvdb, then tvdb via kitsu.
     /// Not tmdb, which a caller holding one would have skipped this for.
     pub(crate) async fn tmdb_search_key(
@@ -710,13 +827,18 @@ impl MediaResolveService {
         let config = std::sync::Arc::new(
             crate::db::Settings::get_config_or_default(&ctx.db).await,
         );
+        let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(
+            (config
+                .meta_concurrency
+                .max(1)) as usize,
+        ));
         // process_meta_item now owns all upserts internally and returns the actual UUID
         // (which may differ from resolved_id if an existing DB row was adopted).
         // force_refresh=true: this is a brand-new item; the stub is a placeholder,
         // so meta addons should fully replace any pre-populated fields.
         let actual_id = ctx
             .addons
-            .process_meta_item(media, ctx.clone(), true, config)
+            .process_meta_item(media, ctx.clone(), true, config, semaphore)
             .await;
         Ok(db::Media::get_by_id(&ctx.db, &actual_id).await?)
     }
@@ -778,9 +900,21 @@ impl MediaResolveService {
                             crate::db::Settings::get_config_or_default(&bg_ctx.db)
                                 .await,
                         );
+                        let semaphore =
+                            std::sync::Arc::new(tokio::sync::Semaphore::new(
+                                (config
+                                    .meta_concurrency
+                                    .max(1)) as usize,
+                            ));
                         bg_ctx
                             .addons
-                            .process_meta_item(root, bg_ctx.clone(), false, config)
+                            .process_meta_item(
+                                root,
+                                bg_ctx.clone(),
+                                false,
+                                config,
+                                semaphore,
+                            )
                             .await;
                     });
                 }
@@ -823,8 +957,13 @@ impl MediaResolveService {
             let config = std::sync::Arc::new(
                 crate::db::Settings::get_config_or_default(&ctx.db).await,
             );
+            let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(
+                (config
+                    .meta_concurrency
+                    .max(1)) as usize,
+            ));
             ctx.addons
-                .process_meta_item(album_root, ctx.clone(), false, config)
+                .process_meta_item(album_root, ctx.clone(), false, config, semaphore)
                 .await;
         }
 
@@ -2345,5 +2484,88 @@ mod tests {
                 .unwrap()
                 .is_some()
         );
+    }
+
+    #[tokio::test]
+    async fn resolve_missing_external_ids_fills_tmdb_and_tvdb_from_imdb_alone() {
+        let tmdb = httpmock::MockServer::start();
+        tmdb.mock(|when, then| {
+            when.path("/find/tt0306414")
+                .query_param("external_source", "imdb_id");
+            then.status(200)
+                .json_body(serde_json::json!({
+                    "tv_results": [{ "id": 1438, "name": "The Wire" }],
+                    "movie_results": []
+                }));
+        });
+        tmdb.mock(|when, then| {
+            when.path("/tv/1438");
+            then.status(200)
+                .json_body(serde_json::json!({
+                    "id": 1438,
+                    "name": "The Wire",
+                    "external_ids": { "imdb_id": "tt0306414", "tvdb_id": 79126 }
+                }));
+        });
+        let guard = ctx_with_tmdb(&tmdb).await;
+        let ctx = &guard.0;
+        let mut media = series(
+            ctx,
+            db::ExternalIds {
+                imdb: db::NonEmptyString::try_new("tt0306414").ok(),
+                ..Default::default()
+            },
+        )
+        .await;
+
+        MediaResolveService::resolve_missing_external_ids(&mut media, ctx).await;
+
+        assert_eq!(
+            media
+                .external_ids
+                .tmdb,
+            Some(1438)
+        );
+        assert_eq!(
+            media
+                .external_ids
+                .tvdb,
+            Some(79126)
+        );
+        assert_eq!(
+            media
+                .external_ids
+                .imdb
+                .map(|s| s.to_string()),
+            Some("tt0306414".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_missing_external_ids_is_a_noop_when_nothing_is_missing() {
+        // No mocks registered at all — any request would fail the test by
+        // connection refused, proving no network call is made when every id
+        // this kind cares about is already present.
+        let tmdb = httpmock::MockServer::start();
+        let guard = ctx_with_tmdb(&tmdb).await;
+        let ctx = &guard.0;
+        let mut media = series(
+            ctx,
+            db::ExternalIds {
+                imdb: db::NonEmptyString::try_new("tt0306414").ok(),
+                tmdb: Some(1438),
+                tvdb: Some(79126),
+                kitsu: Some(1),
+                ..Default::default()
+            },
+        )
+        .await;
+        let before = media
+            .external_ids
+            .clone();
+
+        MediaResolveService::resolve_missing_external_ids(&mut media, ctx).await;
+
+        assert_eq!(media.external_ids, before);
     }
 }

--- a/crates/remux-server/src/services/resolve.rs
+++ b/crates/remux-server/src/services/resolve.rs
@@ -487,9 +487,9 @@ impl MediaResolveService {
         series
             .external_ids
             .tmdb = Some(tmdb);
-        // Cannot re-key the row out from under its own episodes: `candidate_ids`
-        // ranks imdb and the Stremio id above tmdb, and a series carrying
-        // neither is one `Media::save` refuses.
+        // Widen the stored IDs without changing the persisted UUID or child
+        // links, even when TMDB becomes the preferred canonical external ID.
+        // Later ingests find this row through its external IDs.
         if let Some(stored) = db::Media::widen_external_ids(
             &ctx.db,
             &series.id,
@@ -625,23 +625,8 @@ impl MediaResolveService {
 
         if matches!(media.kind, db::MediaKind::Movie | db::MediaKind::Series) {
             if !Self::resolve_media_imdb(&mut media, ctx).await {
-                // If the item arrived with a resolvable external ID (TMDB or TVDB), we
-                // expected to derive an IMDB ID from it. Bail early so the caller sees
-                // a clean failure instead of a silent crash.
-                if media
-                    .external_ids
-                    .tmdb
-                    .is_some()
-                    || media
-                        .external_ids
-                        .tvdb
-                        .is_some()
-                {
-                    warn!(%id, kind = ?media.kind, title = %media.title,
-                        "persist_from_store: IMDB resolution failed for TMDB/TVDB item, skipping");
-                    return Ok(None);
-                }
-                warn!(%id, kind = ?media.kind, "persist_from_store: IMDB resolution failed, saving without IMDB ID");
+                debug!(%id, kind = ?media.kind, title = %media.title,
+                    "persist_from_store: no IMDb ID resolved, retaining existing external IDs");
             }
             // External IDs resolved above may match a row already in the DB —
             // adopt its id rather than persisting a duplicate.
@@ -1397,46 +1382,117 @@ mod tests {
         .1
     }
 
-    /// A series tmdb could re-key is one `save` refuses outright, which is why
-    /// the completion path needs no re-key guard of its own.
     #[tokio::test]
-    async fn a_series_tmdb_could_re_key_cannot_be_stored_at_all() {
-        let (_s, guard) =
-            crate::integration_test::new_test_server_with_config(crate::Config {
-                database_url: Some("sqlite::memory:".into()),
-                torrent_http_port: None,
-                disable_dht: true,
+    async fn tvdb_series_keeps_stored_identity_when_tmdb_is_added() {
+        let tmdb = httpmock::MockServer::start();
+        tmdb.mock(|when, then| {
+            when.path("/find/7770002");
+            then.status(200)
+                .json_body(serde_json::json!({
+                    "tv_results": [{ "id": 7778, "name": "Show" }],
+                    "movie_results": []
+                }));
+        });
+        let guard = ctx_with_tmdb(&tmdb).await;
+        let ctx = &guard.0;
+        let mut media = series(
+            ctx,
+            db::ExternalIds {
+                tvdb: Some(7770002),
                 ..Default::default()
-            })
+            },
+        )
+        .await;
+        let original_id = media.id;
+        let client = MediaResolveService::tmdb(ctx)
             .await
             .unwrap();
-        let ids = db::ExternalIds {
-            tvdb: Some(7770002),
-            kitsu: Some(7770012),
-            ..Default::default()
-        };
-        let mut media = db::Media {
-            id: Uuid::from(&db::MediaIdRaw {
-                kind: db::MediaKind::Series,
-                external_ids: ids.clone(),
-                season: None,
-                episode: None,
-            }),
-            title: "Show".into(),
-            kind: db::MediaKind::Series,
-            external_ids: ids,
-            ..Default::default()
-        };
+        assert!(
+            MediaResolveService::fill_series_tmdb(&mut media, ctx, &client)
+                .await
+                .unwrap()
+        );
+        assert_eq!(media.id, original_id);
+        let stored = db::Media::get_by_id(&ctx.db, &original_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            stored
+                .external_ids
+                .tmdb,
+            Some(7778)
+        );
+        assert_eq!(
+            stored
+                .external_ids
+                .tvdb,
+            Some(7770002)
+        );
+        assert_eq!(
+            db::Media::find_existing_id_by_ext(&ctx.db, &media).await,
+            Some(original_id)
+        );
+    }
+
+    #[tokio::test]
+    async fn persist_tmdb_search_result_without_imdb_mapping() {
+        let tmdb = httpmock::MockServer::start();
+        let lookup = tmdb.mock(|when, then| {
+            when.path("/tv/446001");
+            then.status(200).json_body(serde_json::json!({
+                "id": 446001, "name": "No IMDb mapping", "external_ids": {"imdb_id": null}
+            }));
+        });
+        let guard = ctx_with_tmdb(&tmdb).await;
+        let ctx = &guard.0;
+        let id =
+            crate::common::stable_media_uuid(&db::MediaKind::Series, "tmdb:446001");
+        ctx.store
+            .save(
+                id.to_string(),
+                db::Media {
+                    id,
+                    title: "No IMDb mapping".into(),
+                    kind: db::MediaKind::Series,
+                    external_ids: db::ExternalIds {
+                        tmdb: Some(446001),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                std::time::Duration::from_secs(60),
+            );
+        let media = MediaResolveService::resolve_item(id, ctx)
+            .await
+            .unwrap()
+            .expect("TMDB-only series must persist");
+        assert_eq!(media.id, id);
+        assert_eq!(
+            media
+                .external_ids
+                .tmdb,
+            Some(446001)
+        );
         assert!(
             media
-                .save(
-                    &guard
-                        .0
-                        .db
-                )
-                .await
-                .is_err()
+                .external_ids
+                .imdb
+                .is_none()
         );
+        assert!(
+            db::Media::get_by_id(&ctx.db, &id)
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            MediaResolveService::resolve_item(id, ctx)
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert!(lookup.hits() >= 1);
     }
 
     /// One provider needs only the episode's own ids, another the show's tmdb

--- a/crates/remux-server/src/services/resolve.rs
+++ b/crates/remux-server/src/services/resolve.rs
@@ -170,6 +170,61 @@ impl MediaResolveService {
 
         // FindById returns a partial object without external_ids; use the TMDB id
         // to fetch the full record which includes external_ids (via append_to_response).
+        Self::imdb_from_tmdb_id(tmdb_id, is_tv, client).await
+    }
+
+    /// Title+year search fallback, used only when nothing else identifies the
+    /// item at all — e.g. a filename with no embedded provider id, matched by
+    /// title against TMDB directly. Never a substitute for id-based
+    /// resolution; see [`Self::resolve_imdb_from_ids`] for that.
+    pub(crate) async fn resolve_imdb_from_search(
+        client: &RestClient<BearerAuth>,
+        title: &str,
+        year: Option<i64>,
+        is_tv: bool,
+    ) -> Option<db::NonEmptyString> {
+        if title.is_empty() {
+            return None;
+        }
+        let tmdb_id = if is_tv {
+            client
+                .execute(
+                    sdks::tmdb::SearchTvEndpoint {
+                        query: title.to_string(),
+                    }
+                    .with_cache(ID_CACHE_TTL),
+                )
+                .await
+                .ok()?
+                .results
+                .into_iter()
+                .next()?
+                .id
+        } else {
+            client
+                .execute(
+                    sdks::tmdb::SearchMovieEndpoint {
+                        query: title.to_string(),
+                        year,
+                    }
+                    .with_cache(ID_CACHE_TTL),
+                )
+                .await
+                .ok()?
+                .results
+                .into_iter()
+                .next()?
+                .id
+        };
+        Self::imdb_from_tmdb_id(tmdb_id, is_tv, client).await
+    }
+
+    /// The minimal external-ids-only fetch for a TMDB id already in hand.
+    async fn imdb_from_tmdb_id<A: sdks::Auth + Clone>(
+        tmdb_id: i64,
+        is_tv: bool,
+        client: &RestClient<A>,
+    ) -> Option<db::NonEmptyString> {
         if is_tv {
             let series = client
                 .execute(series_ids_endpoint(tmdb_id).with_cache(ID_CACHE_TTL))

--- a/crates/remux-server/src/tasks/catalog_import_shared.rs
+++ b/crates/remux-server/src/tasks/catalog_import_shared.rs
@@ -89,23 +89,33 @@ where
             }
         }
 
-        // Partition: only new items need meta-batch processing.
-        let existing_ids: HashSet<Uuid> = if items.is_empty() {
-            HashSet::new()
-        } else {
-            let mut qb = sqlx::QueryBuilder::new("SELECT id FROM media WHERE id IN (");
-            let mut sep = qb.separated(", ");
-            for m in &items {
-                sep.push_bind(m.id);
+        // Adopt stored identities before recording positions or partitioning.
+        // A provider's stub UUID can differ from a row discovered through another
+        // provider, even though their external IDs identify the same content.
+        let mut existing_ids = HashSet::new();
+        for item in &mut items {
+            let existing_id = match item.kind {
+                // Channels and playlists have provider-defined UUID identities;
+                // the external-ID resolver does not support these kinds.
+                db::MediaKind::TvChannel | db::MediaKind::Playlist => {
+                    sqlx::query_scalar::<_, Uuid>(
+                        "SELECT id FROM media WHERE id = ? AND kind = ?",
+                    )
+                    .bind(item.id)
+                    .bind(
+                        item.kind
+                            .to_string(),
+                    )
+                    .fetch_optional(&ctx.db)
+                    .await?
+                }
+                _ => db::Media::find_existing_id_by_ext(&ctx.db, item).await,
+            };
+            if let Some(existing_id) = existing_id {
+                item.id = existing_id;
+                existing_ids.insert(existing_id);
             }
-            qb.push(")");
-            qb.build_query_scalar()
-                .fetch_all(&ctx.db)
-                .await
-                .unwrap_or_default()
-                .into_iter()
-                .collect()
-        };
+        }
         // Snapshot stream-order weights before partitioning — partition() does not
         // preserve the original order across the two vecs, so new items would
         // otherwise always get the lowest weights within a chunk regardless of where
@@ -523,4 +533,149 @@ pub async fn prune_stale_iptv_channels(db: &sqlx::SqlitePool, cutoff: NaiveDateT
 pub fn catalog_membership(media_id: &str) -> Option<(&str, &str)> {
     let rest = media_id.strip_prefix("addon:")?;
     rest.split_once(':')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn catalog_matches_external_ids_before_partitioning_and_membership() {
+        let (_server, guard) = crate::integration_test::new_test_server()
+            .await
+            .unwrap();
+        let ctx = &guard.0;
+        let addon_id = Uuid::new_v4();
+        let collection_id = Uuid::new_v5(&addon_id, b"test");
+        let catalog = ResolvedCatalog {
+            provider_catalog_id: "test".into(),
+            catalog_id: format!("addon:{addon_id}:test"),
+            collection_id,
+            name: "Test".into(),
+            media_kind: Some(db::MediaKind::Series),
+            collection_media_kind: None,
+            enabled: true,
+            max_items: None,
+            tags: vec![],
+        };
+        let mut collection = db::Media {
+            id: collection_id,
+            kind: db::MediaKind::Collection,
+            title: "Test".into(),
+            ..Default::default()
+        };
+        collection
+            .save(&ctx.db)
+            .await
+            .unwrap();
+        let imdb = db::NonEmptyString::try_new("tt446201".to_string()).unwrap();
+        let stored_id =
+            crate::common::stable_media_uuid(&db::MediaKind::Series, imdb.as_str());
+        let mut stored = db::Media {
+            id: stored_id,
+            kind: db::MediaKind::Series,
+            title: "Stored metadata".into(),
+            external_ids: db::ExternalIds {
+                imdb: Some(imdb.clone()),
+                tmdb: Some(446201),
+                tvdb: Some(446202),
+                kitsu: Some(446203),
+                custom_stremio_id: Some("custom:446201".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        stored
+            .save(&ctx.db)
+            .await
+            .unwrap();
+        let progress = ProgressReporter::new(Default::default());
+        for external_ids in [
+            db::ExternalIds {
+                imdb: Some(imdb),
+                ..Default::default()
+            },
+            db::ExternalIds {
+                tmdb: Some(446201),
+                ..Default::default()
+            },
+            db::ExternalIds {
+                tvdb: Some(446202),
+                ..Default::default()
+            },
+            db::ExternalIds {
+                kitsu: Some(446203),
+                ..Default::default()
+            },
+            db::ExternalIds {
+                custom_stremio_id: Some("custom:446201".into()),
+                ..Default::default()
+            },
+        ] {
+            let stub_id = Uuid::new_v4();
+            let stub = db::Media {
+                id: stub_id,
+                kind: db::MediaKind::Series,
+                title: "Catalog stub".into(),
+                external_ids,
+                ..Default::default()
+            };
+            let (counts, new_counts) = import_catalog_items(
+                ctx,
+                &catalog,
+                &catalog.catalog_id,
+                10,
+                futures::stream::iter([stub]),
+                &progress,
+            )
+            .await
+            .unwrap();
+            assert_eq!(counts.get(&db::MediaKind::Series.to_string()), Some(&1));
+            assert!(
+                new_counts.is_empty(),
+                "existing content must skip metadata processing"
+            );
+            let members: Vec<(Uuid, i64)> = sqlx::query_as("SELECT right_media_id, weight FROM media_relations WHERE left_media_id = ? AND role = 'catalog'")
+                .bind(collection_id).fetch_all(&ctx.db).await.unwrap();
+            assert_eq!(members, vec![(stored_id, 0)]);
+            assert!(
+                db::Media::get_by_id(&ctx.db, &stub_id)
+                    .await
+                    .unwrap()
+                    .is_none()
+            );
+            assert_eq!(
+                db::Media::get_by_id(&ctx.db, &stored_id)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .title,
+                "Stored metadata"
+            );
+        }
+        let fresh_id = Uuid::new_v4();
+        let fresh = db::Media {
+            id: fresh_id,
+            kind: db::MediaKind::Series,
+            title: "New series".into(),
+            external_ids: db::ExternalIds {
+                tmdb: Some(446204),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let (_, new_counts) = import_catalog_items(
+            ctx,
+            &catalog,
+            &catalog.catalog_id,
+            10,
+            futures::stream::iter([fresh]),
+            &progress,
+        )
+        .await
+        .unwrap();
+        assert_eq!(new_counts.get(&db::MediaKind::Series.to_string()), Some(&1));
+        let members: Vec<Uuid> = sqlx::query_scalar("SELECT right_media_id FROM media_relations WHERE left_media_id = ? AND role = 'catalog'").bind(collection_id).fetch_all(&ctx.db).await.unwrap();
+        assert_eq!(members, vec![fresh_id]);
+    }
 }

--- a/crates/remux-server/src/tasks/catalog_import_shared.rs
+++ b/crates/remux-server/src/tasks/catalog_import_shared.rs
@@ -92,23 +92,51 @@ where
         // Adopt stored identities before recording positions or partitioning.
         // A provider's stub UUID can differ from a row discovered through another
         // provider, even though their external IDs identify the same content.
+        //
+        // Fast path first: a single batched id lookup covers the common case
+        // (re-scanning the same addon's own catalog, where ids already match
+        // exactly) without a query per item. Only items whose own id isn't
+        // already a row fall through to the slower per-item external-ID
+        // match — that's the only path that can find a row saved under a
+        // different provider's id for the same content.
+        let candidate_ids: Vec<Uuid> = items
+            .iter()
+            .map(|i| i.id)
+            .collect();
+        let existing_by_id: HashMap<Uuid, String> = if candidate_ids.is_empty() {
+            HashMap::new()
+        } else {
+            let mut qb = sqlx::QueryBuilder::new(
+                "SELECT id, CAST(kind AS TEXT) FROM media WHERE id IN (",
+            );
+            let mut sep = qb.separated(", ");
+            for id in &candidate_ids {
+                sep.push_bind(id);
+            }
+            qb.push(")");
+            qb.build_query_as::<(Uuid, String)>()
+                .fetch_all(&ctx.db)
+                .await?
+                .into_iter()
+                .collect()
+        };
+
         let mut existing_ids = HashSet::new();
         for item in &mut items {
             let existing_id = match item.kind {
                 // Channels and playlists have provider-defined UUID identities;
-                // the external-ID resolver does not support these kinds.
-                db::MediaKind::TvChannel | db::MediaKind::Playlist => {
-                    sqlx::query_scalar::<_, Uuid>(
-                        "SELECT id FROM media WHERE id = ? AND kind = ?",
-                    )
-                    .bind(item.id)
-                    .bind(
-                        item.kind
-                            .to_string(),
-                    )
-                    .fetch_optional(&ctx.db)
-                    .await?
-                }
+                // the external-ID resolver does not support these kinds, so
+                // only an exact (id, kind) match — never an external-ID
+                // match — counts as "already exists" for them.
+                db::MediaKind::TvChannel | db::MediaKind::Playlist => existing_by_id
+                    .get(&item.id)
+                    .filter(|k| {
+                        **k == item
+                            .kind
+                            .to_string()
+                    })
+                    .map(|_| item.id),
+                _ if existing_by_id.contains_key(&item.id) => Some(item.id),
                 _ => db::Media::find_existing_id_by_ext(&ctx.db, item).await,
             };
             if let Some(existing_id) = existing_id {


### PR DESCRIPTION
Opening a TMDB search result previously failed when no IMDb mapping existed, and TMDB catalogs silently dropped those items. Make IMDb resolution optional so movies and series retain their existing identity and remain available without a mapping.

Database validation now uses the existing canonical-ID check, accepting IMDb, TMDB, TVDB, Kitsu, or custom Stremio IDs. Regression tests cover supported IDs, persistence and reopening without IMDb, catalog lookup misses and failures, and stable stored UUIDs after ID enrichment.

Validation: all 48 focused metadata, resolver, and validation tests passed. Cargo formatting and diff checks passed.

Fixes #446.
