### PR TITLE
feat: unify next up with continue watching

### DIFF
--- a/crates/remux-dashboard/src/pages/settings.rs
+++ b/crates/remux-dashboard/src/pages/settings.rs
@@ -344,6 +344,7 @@ pub fn PlaybackSettingsCard(app_state: AppState) -> Element {
     let mut min_resume_pct = use_signal(|| 5_i64);
     let mut max_resume_pct = use_signal(|| 90_i64);
     let mut min_resume_duration_seconds = use_signal(|| 90_i64);
+    let mut enable_next_up_in_continue_watching = use_signal(|| false);
     let mut loading = use_signal(|| true);
     let mut saving = use_signal(|| false);
     let mut error = use_signal(|| Option::<String>::None);
@@ -368,6 +369,10 @@ pub fn PlaybackSettingsCard(app_state: AppState) -> Element {
                 min_resume_duration_seconds.set(
                     cfg.min_resume_duration_seconds
                         .unwrap_or(90),
+                );
+                enable_next_up_in_continue_watching.set(
+                    cfg.enable_next_up_in_continue_watching
+                        .unwrap_or(false),
                 );
                 base_cfg.set(Some(cfg));
             }
@@ -520,6 +525,8 @@ pub fn PlaybackSettingsCard(app_state: AppState) -> Element {
         server_cfg.min_resume_pct = Some(min_pct);
         server_cfg.max_resume_pct = Some(max_pct);
         server_cfg.min_resume_duration_seconds = Some(min_dur);
+        server_cfg.enable_next_up_in_continue_watching =
+            Some(*enable_next_up_in_continue_watching.peek());
 
         saving.set(true);
         error.set(None);
@@ -830,6 +837,15 @@ pub fn PlaybackSettingsCard(app_state: AppState) -> Element {
                             }
                             p { class: "field-hint",
                                 "Items shorter than this (in seconds) are never shown in continue-watching. Default: 90."
+                            }
+                        }
+
+                        div { class: "field",
+                            ToggleRow {
+                                label: "Include Next Up in Continue Watching",
+                                description: "Add the next released episode of a started series when that series has no episode currently in progress. Disabled by default.",
+                                checked: *enable_next_up_in_continue_watching.read(),
+                                on_change: move |v| enable_next_up_in_continue_watching.set(v),
                             }
                         }
 

--- a/crates/remux-dashboard/src/pages/settings.rs
+++ b/crates/remux-dashboard/src/pages/settings.rs
@@ -25,6 +25,7 @@ pub fn ServerSettingsCard(app_state: AppState) -> Element {
     let mut digital_release_buffer = use_signal(|| 0_i64);
     let mut subtitle_languages = use_signal(String::new);
     let mut quick_connect_enabled = use_signal(|| true);
+    let mut enable_next_up_in_continue_watching = use_signal(|| false);
     let mut loading = use_signal(|| true);
     let mut saving = use_signal(|| false);
     let mut error = use_signal(|| Option::<String>::None);
@@ -71,6 +72,10 @@ pub fn ServerSettingsCard(app_state: AppState) -> Element {
                         cfg.quick_connect_available
                             .unwrap_or(true),
                     );
+                    enable_next_up_in_continue_watching.set(
+                        cfg.enable_next_up_in_continue_watching
+                            .unwrap_or(false),
+                    );
                     base_cfg.set(Some(cfg));
                 }
                 Err(e) => error.set(Some(format!("Failed to load settings: {e}"))),
@@ -111,6 +116,7 @@ pub fn ServerSettingsCard(app_state: AppState) -> Element {
             .peek()
             .clone();
         let qc_enabled = *quick_connect_enabled.peek();
+        let next_up_unified = *enable_next_up_in_continue_watching.peek();
 
         let mut cfg = base_cfg
             .peek()
@@ -120,6 +126,7 @@ pub fn ServerSettingsCard(app_state: AppState) -> Element {
         cfg.metadata_country_code = Some(country);
         cfg.preferred_metadata_language = Some(language);
         cfg.quick_connect_available = Some(qc_enabled);
+        cfg.enable_next_up_in_continue_watching = Some(next_up_unified);
         cfg.catalog_max_items = Some(max);
         cfg.meta_concurrency = concurrency;
         cfg.filter_by_digital_release_date = filter_dr;
@@ -300,6 +307,15 @@ pub fn ServerSettingsCard(app_state: AppState) -> Element {
                             }
                         }
 
+                        div { class: "field",
+                            ToggleRow {
+                                label: "Include Next Up in Continue Watching",
+                                description: "Add the next released episode of a started series when that series has no episode currently in progress. Disabled by default.",
+                                checked: *enable_next_up_in_continue_watching.read(),
+                                on_change: move |v| enable_next_up_in_continue_watching.set(v),
+                            }
+                        }
+
                         if let Some(err) = error.read().as_ref() {
                             ErrorAlert { message: err.clone() }
                         }
@@ -344,7 +360,6 @@ pub fn PlaybackSettingsCard(app_state: AppState) -> Element {
     let mut min_resume_pct = use_signal(|| 5_i64);
     let mut max_resume_pct = use_signal(|| 90_i64);
     let mut min_resume_duration_seconds = use_signal(|| 90_i64);
-    let mut enable_next_up_in_continue_watching = use_signal(|| false);
     let mut loading = use_signal(|| true);
     let mut saving = use_signal(|| false);
     let mut error = use_signal(|| Option::<String>::None);
@@ -369,10 +384,6 @@ pub fn PlaybackSettingsCard(app_state: AppState) -> Element {
                 min_resume_duration_seconds.set(
                     cfg.min_resume_duration_seconds
                         .unwrap_or(90),
-                );
-                enable_next_up_in_continue_watching.set(
-                    cfg.enable_next_up_in_continue_watching
-                        .unwrap_or(false),
                 );
                 base_cfg.set(Some(cfg));
             }
@@ -525,8 +536,6 @@ pub fn PlaybackSettingsCard(app_state: AppState) -> Element {
         server_cfg.min_resume_pct = Some(min_pct);
         server_cfg.max_resume_pct = Some(max_pct);
         server_cfg.min_resume_duration_seconds = Some(min_dur);
-        server_cfg.enable_next_up_in_continue_watching =
-            Some(*enable_next_up_in_continue_watching.peek());
 
         saving.set(true);
         error.set(None);
@@ -837,15 +846,6 @@ pub fn PlaybackSettingsCard(app_state: AppState) -> Element {
                             }
                             p { class: "field-hint",
                                 "Items shorter than this (in seconds) are never shown in continue-watching. Default: 90."
-                            }
-                        }
-
-                        div { class: "field",
-                            ToggleRow {
-                                label: "Include Next Up in Continue Watching",
-                                description: "Add the next released episode of a started series when that series has no episode currently in progress. Disabled by default.",
-                                checked: *enable_next_up_in_continue_watching.read(),
-                                on_change: move |v| enable_next_up_in_continue_watching.set(v),
                             }
                         }
 

--- a/crates/remux-sdks/src/remux/mod.rs
+++ b/crates/remux-sdks/src/remux/mod.rs
@@ -1475,6 +1475,9 @@ pub struct GetItemsQuery {
     /// Internal server-side constraint. This is not a Jellyfin query parameter.
     #[serde(skip)]
     pub promoted: Option<bool>,
+    /// Internal list query: do not reinterpret a single ID as a details lookup.
+    #[serde(skip)]
+    pub strict_item_filters: bool,
     // #[serde_as(as = "Option<StringWithSeparator::<CommaSeparator, ItemFields>>")]
     //#[serde_as(as = "Option<StringWithSeparator<CommaSeparator, ItemFields>>")]
     #[serde(

--- a/crates/remux-sdks/src/remux/mod.rs
+++ b/crates/remux-sdks/src/remux/mod.rs
@@ -716,6 +716,10 @@ pub struct ServerConfiguration {
     /// Items shorter than this are never shown in continue-watching. Default: 90.
     #[default(Some(90_i64))]
     pub min_resume_duration_seconds: Option<i64>,
+    /// Include the next released episode of started series in Continue Watching.
+    /// Disabled by default to retain Jellyfin's standard resume-only behaviour.
+    #[default(Some(false))]
+    pub enable_next_up_in_continue_watching: Option<bool>,
 }
 
 #[derive(

--- a/crates/remux-server/src/api/items.rs
+++ b/crates/remux-server/src/api/items.rs
@@ -795,7 +795,7 @@ pub async fn get_items(
 
     // handle details request
     if let Some(ids) = &q.ids {
-        if ids.len() == 1 {
+        if ids.len() == 1 && !q.strict_item_filters {
             let media = item(
                 state,
                 session.clone(),

--- a/crates/remux-server/src/api/shows.rs
+++ b/crates/remux-server/src/api/shows.rs
@@ -7,10 +7,7 @@ use uuid::Uuid;
 
 use crate::{
     AppState, OptionExt, api, db,
-    db::{
-        auth,
-        media::{push_policy_conditions, push_release_date_filter},
-    },
+    db::{auth, media::push_release_date_filter},
     services::resolve::ResolvedItem,
 };
 use axum_anyhow::ApiResult as Result;
@@ -306,59 +303,22 @@ pub async fn shows_nextup(
     .into_response())
 }
 
-/// Home-screen NextUp: one next-up episode per series that the user has started watching.
-/// Only returns series where at least one episode has been played or is in progress.
-pub(crate) struct NextUpCandidate {
-    pub media: db::Media,
-    pub user_state: Option<db::UserMediaState>,
-    pub effective_activity: chrono::DateTime<chrono::Utc>,
-}
-
-/// Everything `next_up_candidates` needs beyond the user id — bundled (rather
-/// than ~10 positional args) since most callers build it straight from a
-/// session + query. All owned: no lifetime on the struct itself.
-pub(crate) struct NextUpRequest {
-    pub user_id: Uuid,
-    pub enable_resumable: bool,
-    pub date_cutoff: String,
-    /// Same content-visibility policy a normal browse/resume query enforces
-    /// (parental rating, blocked/allowed tags, collection filter rules) —
-    /// without this, an injected episode could show content the user's
-    /// policy excludes everywhere else.
-    pub max_parental_rating: Option<i32>,
-    pub blocked_tags: Option<Vec<String>>,
-    pub allowed_tags: Option<Vec<String>>,
-    pub policy_filter: Option<remux_sdks::remux::CollectionFilter>,
-    /// Restrict candidates to series that are direct children of this
-    /// library/parent (mirrors a request's own `ParentId` scoping). Only
-    /// handles direct children, not arbitrarily nested virtual folders.
-    pub parent_id: Option<Uuid>,
-    /// Additionally require the episode's own PremiereDate to be known and
-    /// no later than now, regardless of the configured digital-release buffer.
-    pub require_actually_released: bool,
-}
-
-/// Select one eligible next-up episode per started series. Callers that
-/// paginate (both current ones do) should slice the result down to what
-/// they'll actually render *before* calling `hydrate_next_up_candidates` —
-/// parent/image hydration is deliberately not done here so a request that
-/// only renders e.g. 12 cards doesn't pay for hydrating every active series.
+/// Select the next episode per started series, with its release-aware sort key.
 pub(crate) async fn next_up_candidates(
     state: &AppState,
-    req: NextUpRequest,
-) -> Result<Vec<NextUpCandidate>> {
-    let NextUpRequest {
-        user_id,
-        enable_resumable,
-        date_cutoff,
-        max_parental_rating,
-        blocked_tags,
-        allowed_tags,
-        policy_filter,
-        parent_id,
-        require_actually_released,
-    } = req;
-
+    session: &auth::AuthSession,
+    q: &api::GetItemsQuery,
+) -> Result<Vec<(db::Media, chrono::DateTime<chrono::Utc>)>> {
+    let user_id = session
+        .user
+        .id;
+    let enable_resumable = q
+        .enable_resumable
+        .unwrap_or(true);
+    let date_cutoff = q
+        .next_up_date_cutoff
+        .as_deref()
+        .unwrap_or("1970-01-01 00:00:00");
     let server_config = db::Settings::get_config_or_default(
         &state
             .ctx
@@ -411,37 +371,6 @@ pub(crate) async fn next_up_candidates(
         }
     }
 
-    // Library/parent scoping (e.g. a Resume request scoped to one library):
-    // restrict to series that are direct children of `parent_id`.
-    if let Some(scope) = parent_id {
-        let mut scope_qb =
-            sqlx::QueryBuilder::new("SELECT id FROM media WHERE parent_id = ");
-        scope_qb.push_bind(scope);
-        scope_qb.push(" AND id IN (");
-        {
-            let mut sep = scope_qb.separated(", ");
-            for id in &series_ids {
-                sep.push_bind(id);
-            }
-        }
-        scope_qb.push(")");
-        let scoped_ids: std::collections::HashSet<Uuid> = scope_qb
-            .build_query_scalar()
-            .fetch_all(
-                &state
-                    .ctx
-                    .db,
-            )
-            .await?
-            .into_iter()
-            .collect();
-        series_ids.retain(|id| scoped_ids.contains(id));
-        series_last_activity.retain(|id, _| scoped_ids.contains(id));
-        if series_ids.is_empty() {
-            return Ok(Vec::new());
-        }
-    }
-
     let mut ep_qb =
         sqlx::QueryBuilder::new("SELECT * FROM media WHERE grandparent_id IN (");
     {
@@ -454,23 +383,6 @@ pub(crate) async fn next_up_candidates(
     if let Some(t) = release_threshold {
         push_release_date_filter(&mut ep_qb, "media", t, true);
     }
-    if require_actually_released {
-        // Independent of (and in addition to) the configurable threshold
-        // above: an episode injected into Continue Watching must have
-        // actually premiered, regardless of the server's release-filter
-        // buffer or whether that filter is disabled entirely.
-        ep_qb
-            .push(" AND media.released_at IS NOT NULL AND media.released_at <= ")
-            .push_bind(chrono::Utc::now().naive_utc());
-    }
-    push_policy_conditions(
-        &mut ep_qb,
-        max_parental_rating,
-        blocked_tags.as_deref(),
-        allowed_tags.as_deref(),
-        policy_filter.as_ref(),
-        Some(&user_id),
-    );
     ep_qb.push(
         " ORDER BY grandparent_id, COALESCE(parent_idx, 9999) ASC, COALESCE(idx, 9999) ASC",
     );
@@ -602,58 +514,8 @@ pub(crate) async fn next_up_candidates(
 
     Ok(next_eps
         .into_iter()
-        .map(|(media, effective)| NextUpCandidate {
-            user_state: states_map.remove(&media.id),
-            media,
-            effective_activity: effective.and_utc(),
-        })
+        .map(|(media, activity)| (media, activity.and_utc()))
         .collect())
-}
-
-/// Loads parent/image data for the given candidates in place. Deliberately
-/// separate from `next_up_candidates` so callers hydrate only the final,
-/// paginated slice they'll actually render — not every active series.
-pub(crate) async fn hydrate_next_up_candidates(
-    state: &AppState,
-    candidates: &mut [NextUpCandidate],
-) {
-    let mut media: Vec<db::Media> = candidates
-        .iter()
-        .map(|c| {
-            c.media
-                .clone()
-        })
-        .collect();
-    db::Media::preload_parents(
-        &state
-            .ctx
-            .db,
-        &mut media,
-    )
-    .await;
-    let ids: Vec<Uuid> = media
-        .iter()
-        .map(|m| m.id)
-        .collect();
-    let mut images_map = db::MediaImage::get_for_media_ids(
-        &state
-            .ctx
-            .db,
-        &ids,
-    )
-    .await
-    .unwrap_or_default();
-    for m in &mut media {
-        m.images = images_map
-            .remove(&m.id)
-            .unwrap_or_default();
-    }
-    for (candidate, hydrated) in candidates
-        .iter_mut()
-        .zip(media)
-    {
-        candidate.media = hydrated;
-    }
 }
 
 async fn shows_nextup_all(
@@ -661,87 +523,52 @@ async fn shows_nextup_all(
     session: auth::AuthSession,
     q: api::GetItemsQuery,
 ) -> Result<impl IntoResponse> {
-    let start_index = q
-        .start_index
-        .unwrap_or(0) as usize;
-    let limit = q
-        .limit
-        .map(|limit| limit as usize)
-        .unwrap_or(usize::MAX);
-    let policy = session
-        .user
-        .policy
-        .as_ref();
-    let mut candidates = next_up_candidates(
-        &state,
-        NextUpRequest {
-            user_id: session
-                .user
-                .id,
-            enable_resumable: q
-                .enable_resumable
-                .unwrap_or(true),
-            date_cutoff: q
-                .next_up_date_cutoff
-                .clone()
-                .unwrap_or_else(|| "1970-01-01 00:00:00".to_string()),
-            max_parental_rating: policy.and_then(|p| p.max_parental_rating),
-            blocked_tags: policy
-                .map(|p| {
-                    p.blocked_tags
-                        .clone()
-                })
-                .filter(|v| !v.is_empty()),
-            allowed_tags: policy
-                .map(|p| {
-                    p.allowed_tags
-                        .clone()
-                })
-                .filter(|v| !v.is_empty()),
-            policy_filter: policy.and_then(|p| {
-                p.filter_rules
-                    .clone()
-            }),
-            parent_id: q.parent_id,
-            // This is the standalone Next Up feed itself, not an injection
-            // into Continue Watching — respect the server's configured
-            // release-date threshold (buffer/disable) as it always has.
-            require_actually_released: false,
-        },
-    )
-    .await?;
-    let total = candidates.len() as i64;
-    let mut page: Vec<NextUpCandidate> = candidates
-        .drain(
-            start_index.min(candidates.len())
-                ..(start_index
-                    .saturating_add(limit)
-                    .min(candidates.len())),
-        )
+    let candidates = next_up_candidates(&state, &session, &q).await?;
+    if candidates.is_empty() {
+        return Ok(Json(api::BaseItemDtoQueryResult::default()));
+    }
+    let order: HashMap<Uuid, usize> = candidates
+        .iter()
+        .enumerate()
+        .map(|(index, (media, _))| (media.id, index))
         .collect();
-    hydrate_next_up_candidates(&state, &mut page).await;
-    let items = page
-        .into_iter()
-        .map(|candidate| {
-            let mut item = api::db_media_to_item(
-                candidate
-                    .media
-                    .clone(),
-                false,
-            );
-            if let Some(state) = candidate.user_state {
-                item.user_data = Some(api::db_state_to_dto(state, &candidate.media));
-            }
-            item
-        })
-        .collect();
+    let mut query = q.clone();
+    query.ids = Some(
+        candidates
+            .into_iter()
+            .map(|(media, _)| media.id)
+            .collect(),
+    );
+    query.include_item_types = Some(vec![api::MediaType::Episode]);
+    query.strict_item_filters = true;
+    query.start_index = None;
+    query.limit = Some(order.len() as u32);
+    let mut items = get_items(state, session, query, false)
+        .await?
+        .with_permissions()
+        .with_client_patches()
+        .build()
+        .items;
+    items.sort_by_key(|item| order[&item.id]);
+    let total = items.len() as i64;
     Ok(Json(api::BaseItemDtoQueryResult {
-        items,
+        items: items
+            .into_iter()
+            .skip(
+                q.start_index
+                    .unwrap_or(0) as usize,
+            )
+            .take(
+                q.limit
+                    .unwrap_or(u32::MAX) as usize,
+            )
+            .collect(),
         total_record_count: total,
-        start_index: start_index as u32,
+        start_index: q
+            .start_index
+            .unwrap_or(0),
         ..Default::default()
-    })
-    .into_response())
+    }))
 }
 
 /// Upcoming episodes sorted by premiere date, soonest first.
@@ -911,7 +738,7 @@ pub async fn shows_recommendations(
 }
 
 #[cfg(test)]
-mod test {
+pub(crate) mod test {
     use super::*;
     use chrono::{NaiveDate, NaiveDateTime};
     use sqlx::SqlitePool;
@@ -926,7 +753,7 @@ mod test {
         db
     }
 
-    async fn insert_series_with_episodes(
+    pub(crate) async fn insert_series_with_episodes(
         db: &SqlitePool,
         series_title: &str,
         episode_titles: &[&str],
@@ -1030,7 +857,7 @@ mod test {
         user
     }
 
-    async fn insert_state(
+    pub(crate) async fn insert_state(
         db: &SqlitePool,
         user_id: Uuid,
         media_id: Uuid,

--- a/crates/remux-server/src/api/shows.rs
+++ b/crates/remux-server/src/api/shows.rs
@@ -333,11 +333,8 @@ pub(crate) struct NextUpRequest {
     /// library/parent (mirrors a request's own `ParentId` scoping). Only
     /// handles direct children, not arbitrarily nested virtual folders.
     pub parent_id: Option<Uuid>,
-    /// When true, ignore the server's configured release-date threshold
-    /// (which can be disabled, or padded with a positive buffer for the
-    /// standalone Next Up feed) and require the episode to have actually
-    /// premiered as of now. Continue Watching must never show something
-    /// that isn't out yet, even if Next Up's own buffer would allow it.
+    /// Additionally require the episode's own PremiereDate to be known and
+    /// no later than now, regardless of the configured digital-release buffer.
     pub require_actually_released: bool,
 }
 
@@ -462,12 +459,9 @@ pub(crate) async fn next_up_candidates(
         // above: an episode injected into Continue Watching must have
         // actually premiered, regardless of the server's release-filter
         // buffer or whether that filter is disabled entirely.
-        push_release_date_filter(
-            &mut ep_qb,
-            "media",
-            chrono::Utc::now().naive_utc(),
-            true,
-        );
+        ep_qb
+            .push(" AND media.released_at IS NOT NULL AND media.released_at <= ")
+            .push_bind(chrono::Utc::now().naive_utc());
     }
     push_policy_conditions(
         &mut ep_qb,

--- a/crates/remux-server/src/api/shows.rs
+++ b/crates/remux-server/src/api/shows.rs
@@ -131,27 +131,31 @@ pub async fn shows_nextup(
     session: auth::AuthSession,
     Query(q): Query<api::GetItemsQuery>,
 ) -> Result<impl IntoResponse> {
-    if db::Settings::get_config_or_default(
-        &state
-            .ctx
-            .db,
-    )
-    .await
-    .enable_next_up_in_continue_watching
-    .unwrap_or(false)
-    {
-        return Ok(Json(api::BaseItemDtoQueryResult {
-            start_index: q
-                .start_index
-                .unwrap_or(0),
-            ..Default::default()
-        })
-        .into_response());
-    }
-    // Home-screen call: no seriesId — return one next-up episode per in-progress series
+    // Home-screen call: no seriesId — return one next-up episode per in-progress series.
+    // When the unified setting is on, this feed is folded into Continue
+    // Watching instead — but only for this seriesId-less aggregate call; a
+    // per-series lookup (e.g. a client's "Next Episode" button) must still
+    // resolve normally regardless of the setting.
     if q.series_id
         .is_none()
     {
+        if db::Settings::get_config_or_default(
+            &state
+                .ctx
+                .db,
+        )
+        .await
+        .enable_next_up_in_continue_watching
+        .unwrap_or(false)
+        {
+            return Ok(Json(api::BaseItemDtoQueryResult {
+                start_index: q
+                    .start_index
+                    .unwrap_or(0),
+                ..Default::default()
+            })
+            .into_response());
+        }
         return shows_nextup_all(state, session, q)
             .await
             .map(IntoResponse::into_response);

--- a/crates/remux-server/src/api/shows.rs
+++ b/crates/remux-server/src/api/shows.rs
@@ -7,7 +7,10 @@ use uuid::Uuid;
 
 use crate::{
     AppState, OptionExt, api, db,
-    db::{auth, media::push_release_date_filter},
+    db::{
+        auth,
+        media::{push_policy_conditions, push_release_date_filter},
+    },
     services::resolve::ResolvedItem,
 };
 use axum_anyhow::ApiResult as Result;
@@ -311,13 +314,54 @@ pub(crate) struct NextUpCandidate {
     pub effective_activity: chrono::DateTime<chrono::Utc>,
 }
 
-/// Select and hydrate one eligible next-up episode per started series.
+/// Everything `next_up_candidates` needs beyond the user id — bundled (rather
+/// than ~10 positional args) since most callers build it straight from a
+/// session + query. All owned: no lifetime on the struct itself.
+pub(crate) struct NextUpRequest {
+    pub user_id: Uuid,
+    pub enable_resumable: bool,
+    pub date_cutoff: String,
+    /// Same content-visibility policy a normal browse/resume query enforces
+    /// (parental rating, blocked/allowed tags, collection filter rules) —
+    /// without this, an injected episode could show content the user's
+    /// policy excludes everywhere else.
+    pub max_parental_rating: Option<i32>,
+    pub blocked_tags: Option<Vec<String>>,
+    pub allowed_tags: Option<Vec<String>>,
+    pub policy_filter: Option<remux_sdks::remux::CollectionFilter>,
+    /// Restrict candidates to series that are direct children of this
+    /// library/parent (mirrors a request's own `ParentId` scoping). Only
+    /// handles direct children, not arbitrarily nested virtual folders.
+    pub parent_id: Option<Uuid>,
+    /// When true, ignore the server's configured release-date threshold
+    /// (which can be disabled, or padded with a positive buffer for the
+    /// standalone Next Up feed) and require the episode to have actually
+    /// premiered as of now. Continue Watching must never show something
+    /// that isn't out yet, even if Next Up's own buffer would allow it.
+    pub require_actually_released: bool,
+}
+
+/// Select one eligible next-up episode per started series. Callers that
+/// paginate (both current ones do) should slice the result down to what
+/// they'll actually render *before* calling `hydrate_next_up_candidates` —
+/// parent/image hydration is deliberately not done here so a request that
+/// only renders e.g. 12 cards doesn't pay for hydrating every active series.
 pub(crate) async fn next_up_candidates(
     state: &AppState,
-    user_id: Uuid,
-    enable_resumable: bool,
-    date_cutoff: String,
+    req: NextUpRequest,
 ) -> Result<Vec<NextUpCandidate>> {
+    let NextUpRequest {
+        user_id,
+        enable_resumable,
+        date_cutoff,
+        max_parental_rating,
+        blocked_tags,
+        allowed_tags,
+        policy_filter,
+        parent_id,
+        require_actually_released,
+    } = req;
+
     let server_config = db::Settings::get_config_or_default(
         &state
             .ctx
@@ -370,6 +414,37 @@ pub(crate) async fn next_up_candidates(
         }
     }
 
+    // Library/parent scoping (e.g. a Resume request scoped to one library):
+    // restrict to series that are direct children of `parent_id`.
+    if let Some(scope) = parent_id {
+        let mut scope_qb =
+            sqlx::QueryBuilder::new("SELECT id FROM media WHERE parent_id = ");
+        scope_qb.push_bind(scope);
+        scope_qb.push(" AND id IN (");
+        {
+            let mut sep = scope_qb.separated(", ");
+            for id in &series_ids {
+                sep.push_bind(id);
+            }
+        }
+        scope_qb.push(")");
+        let scoped_ids: std::collections::HashSet<Uuid> = scope_qb
+            .build_query_scalar()
+            .fetch_all(
+                &state
+                    .ctx
+                    .db,
+            )
+            .await?
+            .into_iter()
+            .collect();
+        series_ids.retain(|id| scoped_ids.contains(id));
+        series_last_activity.retain(|id, _| scoped_ids.contains(id));
+        if series_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+    }
+
     let mut ep_qb =
         sqlx::QueryBuilder::new("SELECT * FROM media WHERE grandparent_id IN (");
     {
@@ -382,6 +457,26 @@ pub(crate) async fn next_up_candidates(
     if let Some(t) = release_threshold {
         push_release_date_filter(&mut ep_qb, "media", t, true);
     }
+    if require_actually_released {
+        // Independent of (and in addition to) the configurable threshold
+        // above: an episode injected into Continue Watching must have
+        // actually premiered, regardless of the server's release-filter
+        // buffer or whether that filter is disabled entirely.
+        push_release_date_filter(
+            &mut ep_qb,
+            "media",
+            chrono::Utc::now().naive_utc(),
+            true,
+        );
+    }
+    push_policy_conditions(
+        &mut ep_qb,
+        max_parental_rating,
+        blocked_tags.as_deref(),
+        allowed_tags.as_deref(),
+        policy_filter.as_ref(),
+        Some(&user_id),
+    );
     ep_qb.push(
         " ORDER BY grandparent_id, COALESCE(parent_idx, 9999) ASC, COALESCE(idx, 9999) ASC",
     );
@@ -476,15 +571,23 @@ pub(crate) async fn next_up_candidates(
         }
     }
 
-    // Re-sort: if next ep released more recently than the user's last watch,
-    // use the release date as the effective key so fresh episodes surface first.
+    if next_eps.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Compute the effective activity once per episode (if next ep released
+    // more recently than the user's last watch, the release date becomes the
+    // effective key so fresh episodes surface first), then sort and build
+    // candidates from that same precomputed value instead of recomputing it
+    // per comparison and again afterward.
     let epoch = chrono::NaiveDateTime::parse_from_str(
         "1970-01-01 00:00:00",
         "%Y-%m-%d %H:%M:%S",
     )
     .unwrap();
-    next_eps.sort_by(|a, b| {
-        let key = |ep: &db::Media| {
+    let mut next_eps: Vec<(db::Media, chrono::NaiveDateTime)> = next_eps
+        .into_iter()
+        .map(|ep| {
             let release = ep
                 .digital_released_at
                 .or(ep.released_at)
@@ -497,64 +600,66 @@ pub(crate) async fn next_up_candidates(
                         .copied()
                 })
                 .unwrap_or(epoch);
-            release.max(activity)
-        };
-        key(b).cmp(&key(a))
-    });
+            let effective = release.max(activity);
+            (ep, effective)
+        })
+        .collect();
+    next_eps.sort_by(|(_, a), (_, b)| b.cmp(a));
 
-    if next_eps.is_empty() {
-        return Ok(Vec::new());
-    }
+    Ok(next_eps
+        .into_iter()
+        .map(|(media, effective)| NextUpCandidate {
+            user_state: states_map.remove(&media.id),
+            media,
+            effective_activity: effective.and_utc(),
+        })
+        .collect())
+}
 
+/// Loads parent/image data for the given candidates in place. Deliberately
+/// separate from `next_up_candidates` so callers hydrate only the final,
+/// paginated slice they'll actually render — not every active series.
+pub(crate) async fn hydrate_next_up_candidates(
+    state: &AppState,
+    candidates: &mut [NextUpCandidate],
+) {
+    let mut media: Vec<db::Media> = candidates
+        .iter()
+        .map(|c| {
+            c.media
+                .clone()
+        })
+        .collect();
     db::Media::preload_parents(
         &state
             .ctx
             .db,
-        &mut next_eps,
+        &mut media,
     )
     .await;
-    let next_ep_ids: Vec<Uuid> = next_eps
+    let ids: Vec<Uuid> = media
         .iter()
-        .map(|e| e.id)
+        .map(|m| m.id)
         .collect();
     let mut images_map = db::MediaImage::get_for_media_ids(
         &state
             .ctx
             .db,
-        &next_ep_ids,
+        &ids,
     )
     .await
     .unwrap_or_default();
-    for ep in &mut next_eps {
-        ep.images = images_map
-            .remove(&ep.id)
+    for m in &mut media {
+        m.images = images_map
+            .remove(&m.id)
             .unwrap_or_default();
     }
-
-    Ok(next_eps
-        .into_iter()
-        .map(|media| {
-            let release = media
-                .digital_released_at
-                .or(media.released_at)
-                .unwrap_or(epoch);
-            let activity = media
-                .grandparent_id
-                .and_then(|id| {
-                    series_last_activity
-                        .get(&id)
-                        .copied()
-                })
-                .unwrap_or(epoch);
-            NextUpCandidate {
-                user_state: states_map.remove(&media.id),
-                media,
-                effective_activity: release
-                    .max(activity)
-                    .and_utc(),
-            }
-        })
-        .collect())
+    for (candidate, hydrated) in candidates
+        .iter_mut()
+        .zip(media)
+    {
+        candidate.media = hydrated;
+    }
 }
 
 async fn shows_nextup_all(
@@ -569,22 +674,60 @@ async fn shows_nextup_all(
         .limit
         .map(|limit| limit as usize)
         .unwrap_or(usize::MAX);
-    let candidates = next_up_candidates(
+    let policy = session
+        .user
+        .policy
+        .as_ref();
+    let mut candidates = next_up_candidates(
         &state,
-        session
-            .user
-            .id,
-        q.enable_resumable
-            .unwrap_or(true),
-        q.next_up_date_cutoff
-            .unwrap_or_else(|| "1970-01-01 00:00:00".to_string()),
+        NextUpRequest {
+            user_id: session
+                .user
+                .id,
+            enable_resumable: q
+                .enable_resumable
+                .unwrap_or(true),
+            date_cutoff: q
+                .next_up_date_cutoff
+                .clone()
+                .unwrap_or_else(|| "1970-01-01 00:00:00".to_string()),
+            max_parental_rating: policy.and_then(|p| p.max_parental_rating),
+            blocked_tags: policy
+                .map(|p| {
+                    p.blocked_tags
+                        .clone()
+                })
+                .filter(|v| !v.is_empty()),
+            allowed_tags: policy
+                .map(|p| {
+                    p.allowed_tags
+                        .clone()
+                })
+                .filter(|v| !v.is_empty()),
+            policy_filter: policy.and_then(|p| {
+                p.filter_rules
+                    .clone()
+            }),
+            parent_id: q.parent_id,
+            // This is the standalone Next Up feed itself, not an injection
+            // into Continue Watching — respect the server's configured
+            // release-date threshold (buffer/disable) as it always has.
+            require_actually_released: false,
+        },
     )
     .await?;
     let total = candidates.len() as i64;
-    let items = candidates
+    let mut page: Vec<NextUpCandidate> = candidates
+        .drain(
+            start_index.min(candidates.len())
+                ..(start_index
+                    .saturating_add(limit)
+                    .min(candidates.len())),
+        )
+        .collect();
+    hydrate_next_up_candidates(&state, &mut page).await;
+    let items = page
         .into_iter()
-        .skip(start_index)
-        .take(limit)
         .map(|candidate| {
             let mut item = api::db_media_to_item(
                 candidate

--- a/crates/remux-server/src/api/shows.rs
+++ b/crates/remux-server/src/api/shows.rs
@@ -131,6 +131,23 @@ pub async fn shows_nextup(
     session: auth::AuthSession,
     Query(q): Query<api::GetItemsQuery>,
 ) -> Result<impl IntoResponse> {
+    if db::Settings::get_config_or_default(
+        &state
+            .ctx
+            .db,
+    )
+    .await
+    .enable_next_up_in_continue_watching
+    .unwrap_or(false)
+    {
+        return Ok(Json(api::BaseItemDtoQueryResult {
+            start_index: q
+                .start_index
+                .unwrap_or(0),
+            ..Default::default()
+        })
+        .into_response());
+    }
     // Home-screen call: no seriesId — return one next-up episode per in-progress series
     if q.series_id
         .is_none()
@@ -284,24 +301,19 @@ pub async fn shows_nextup(
 
 /// Home-screen NextUp: one next-up episode per series that the user has started watching.
 /// Only returns series where at least one episode has been played or is in progress.
-async fn shows_nextup_all(
-    state: AppState,
-    session: auth::AuthSession,
-    q: api::GetItemsQuery,
-) -> Result<impl IntoResponse> {
-    let user_id = session
-        .user
-        .id;
-    let limit = q
-        .limit
-        .map(|l| l as usize);
-    let start_index = q
-        .start_index
-        .unwrap_or(0) as usize;
-    let enable_resumable = q
-        .enable_resumable
-        .unwrap_or(true);
+pub(crate) struct NextUpCandidate {
+    pub media: db::Media,
+    pub user_state: Option<db::UserMediaState>,
+    pub effective_activity: chrono::DateTime<chrono::Utc>,
+}
 
+/// Select and hydrate one eligible next-up episode per started series.
+pub(crate) async fn next_up_candidates(
+    state: &AppState,
+    user_id: Uuid,
+    enable_resumable: bool,
+    date_cutoff: String,
+) -> Result<Vec<NextUpCandidate>> {
     let server_config = db::Settings::get_config_or_default(
         &state
             .ctx
@@ -317,10 +329,6 @@ async fn shows_nextup_all(
     // media rows, avoiding a slow scan over the full episode index.
     // No series-count LIMIT here — we apply the page limit to the final episode list
     // (matching Jellyfin's approach: consider all active series, paginate results).
-    let date_cutoff = q
-        .next_up_date_cutoff
-        .clone()
-        .unwrap_or_else(|| "1970-01-01 00:00:00".to_string());
     let active_series: Vec<(Uuid, Option<chrono::NaiveDateTime>)> = sqlx::query_as(
         "SELECT m.grandparent_id, \
                 MAX(COALESCE(active.last_played_at, active.played_at, '1970-01-01 00:00:00')) AS last_activity \
@@ -345,7 +353,7 @@ async fn shows_nextup_all(
     .await?;
 
     if active_series.is_empty() {
-        return Ok(Json(api::BaseItemDtoQueryResult::default()).into_response());
+        return Ok(Vec::new());
     }
 
     let mut series_ids: Vec<Uuid> = Vec::with_capacity(active_series.len());
@@ -491,7 +499,7 @@ async fn shows_nextup_all(
     });
 
     if next_eps.is_empty() {
-        return Ok(Json(api::BaseItemDtoQueryResult::default()).into_response());
+        return Ok(Vec::new());
     }
 
     db::Media::preload_parents(
@@ -519,20 +527,73 @@ async fn shows_nextup_all(
             .unwrap_or_default();
     }
 
-    let total = next_eps.len() as i64;
-    let items: Vec<api::BaseItemDto> = next_eps
+    Ok(next_eps
+        .into_iter()
+        .map(|media| {
+            let release = media
+                .digital_released_at
+                .or(media.released_at)
+                .unwrap_or(epoch);
+            let activity = media
+                .grandparent_id
+                .and_then(|id| {
+                    series_last_activity
+                        .get(&id)
+                        .copied()
+                })
+                .unwrap_or(epoch);
+            NextUpCandidate {
+                user_state: states_map.remove(&media.id),
+                media,
+                effective_activity: release
+                    .max(activity)
+                    .and_utc(),
+            }
+        })
+        .collect())
+}
+
+async fn shows_nextup_all(
+    state: AppState,
+    session: auth::AuthSession,
+    q: api::GetItemsQuery,
+) -> Result<impl IntoResponse> {
+    let start_index = q
+        .start_index
+        .unwrap_or(0) as usize;
+    let limit = q
+        .limit
+        .map(|limit| limit as usize)
+        .unwrap_or(usize::MAX);
+    let candidates = next_up_candidates(
+        &state,
+        session
+            .user
+            .id,
+        q.enable_resumable
+            .unwrap_or(true),
+        q.next_up_date_cutoff
+            .unwrap_or_else(|| "1970-01-01 00:00:00".to_string()),
+    )
+    .await?;
+    let total = candidates.len() as i64;
+    let items = candidates
         .into_iter()
         .skip(start_index)
-        .take(limit.unwrap_or(usize::MAX))
-        .map(|ep| {
-            let mut item = api::db_media_to_item(ep.clone(), false);
-            if let Some(s) = states_map.get(&ep.id) {
-                item.user_data = Some(api::db_state_to_dto(s.clone(), &ep));
+        .take(limit)
+        .map(|candidate| {
+            let mut item = api::db_media_to_item(
+                candidate
+                    .media
+                    .clone(),
+                false,
+            );
+            if let Some(state) = candidate.user_state {
+                item.user_data = Some(api::db_state_to_dto(state, &candidate.media));
             }
             item
         })
         .collect();
-
     Ok(Json(api::BaseItemDtoQueryResult {
         items,
         total_record_count: total,

--- a/crates/remux-server/src/api/users.rs
+++ b/crates/remux-server/src/api/users.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use anyhow::Context;
 use axum::{
@@ -1496,7 +1496,11 @@ async fn resume_items(
                 .with_client_patches()
                 .build()
                 .items;
-            total += next_up.len() as i64;
+            if q.enable_total_record_count
+                .unwrap_or(true)
+            {
+                total += next_up.len() as i64;
+            }
             items.extend(next_up);
         }
         items.sort_by_key(|item| {
@@ -1951,6 +1955,7 @@ mod e2e_tests {
                 .simple()
                 .to_string()
         );
+        assert_eq!(body["TotalRecordCount"], 0);
 
         insert_state(db, user.id, next[1].id, 0, 0, None, None).await;
         sqlx::query("UPDATE user_media_state SET favorite = 1 WHERE user_id = ? AND media_id = ?")

--- a/crates/remux-server/src/api/users.rs
+++ b/crates/remux-server/src/api/users.rs
@@ -33,7 +33,10 @@ use remux_sdks::remux::Username;
 use super::{
     items::{ItemsQueryResultBuilder, get_items, item, items, items_flat},
     mock_items,
-    shows::livetv_view_item,
+    shows::{
+        NextUpCandidate, NextUpRequest, hydrate_next_up_candidates, livetv_view_item,
+        next_up_candidates,
+    },
 };
 
 #[post("/users/{user_id}/configuration")]
@@ -1422,7 +1425,12 @@ pub(crate) async fn resume_items(
     )
     .await
     .enable_next_up_in_continue_watching
-    .unwrap_or(false);
+    .unwrap_or(false)
+        // A request that doesn't even want Episodes (e.g. a movie-only or
+        // otherwise type-scoped Resume call) must never have one injected —
+        // matching the same request constraint the resume fetch itself honours.
+        && q.get_requested_item_types()
+            .contains(&api::MediaType::Episode);
     // Merge and rank before paginating so an injected new release can displace
     // an older resume item on the first page.
     let mut items_query = q.clone();
@@ -1445,59 +1453,137 @@ pub(crate) async fn resume_items(
         .with_client_patches()
         .build();
 
-    let fetched_resume_count = items
-        .items
-        .len();
-    let mut resume_items = items.items;
-    if unified_next_up {
-        let next_up = crate::api::shows::next_up_candidates(
-            &state,
-            session
-                .user
-                .id,
-            false,
-            "1970-01-01 00:00:00".to_string(),
-        )
-        .await?
-        .into_iter()
-        .map(|candidate| {
-            (
-                api::db_media_to_item(candidate.media, false),
-                candidate.effective_activity,
-            )
-        });
-        resume_items = merge_continue_watching(resume_items, next_up);
-    }
-
-    // `items.total_count` is the true, unbounded resume-item total (a
-    // separate COUNT(*) unaffected by the deliberately capped `items_query`
-    // limit above) — it must stay the base of the reported total, not be
-    // replaced by `resume_items.len()`, which only reflects the bounded
-    // fetch window and would make clients that paginate off
-    // TotalRecordCount stop after the first page. Add however many next-up
-    // entries got injected on top of what was actually fetched.
-    let injected_count = resume_items
-        .len()
-        .saturating_sub(fetched_resume_count) as i64;
-    let total_record_count = if unified_next_up {
-        items.total_count as i64 + injected_count
-    } else {
-        items.total_count as i64
-    };
+    let resume_items = items.items;
     let start_index = q
         .start_index
         .unwrap_or(0) as usize;
     let limit = q
         .limit
         .unwrap_or(50) as usize;
-    let response_items = if unified_next_up {
-        resume_items
+
+    let (response_items, total_record_count) = if unified_next_up {
+        // The authoritative, unbounded set of series with a resumable
+        // episode — not derived from `resume_items` above, which is only
+        // the fetch window. Using the window would make dedup (and thus
+        // which episode gets injected, and the reported total) depend on
+        // which page was requested.
+        let represented_series = db::Media::resumable_series_ids(
+            &state
+                .ctx
+                .db,
+            session
+                .user
+                .id,
+        )
+        .await?;
+
+        let policy = session
+            .user
+            .policy
+            .as_ref();
+        let next_up = next_up_candidates(
+            &state,
+            NextUpRequest {
+                user_id: session
+                    .user
+                    .id,
+                enable_resumable: false,
+                date_cutoff: "1970-01-01 00:00:00".to_string(),
+                max_parental_rating: policy.and_then(|p| p.max_parental_rating),
+                blocked_tags: policy
+                    .map(|p| {
+                        p.blocked_tags
+                            .clone()
+                    })
+                    .filter(|v| !v.is_empty()),
+                allowed_tags: policy
+                    .map(|p| {
+                        p.allowed_tags
+                            .clone()
+                    })
+                    .filter(|v| !v.is_empty()),
+                policy_filter: policy.and_then(|p| {
+                    p.filter_rules
+                        .clone()
+                }),
+                parent_id: q.parent_id,
+                // Injected into Continue Watching, not the standalone Next Up
+                // feed — must never show something that hasn't actually
+                // premiered, regardless of the server's release-date buffer.
+                require_actually_released: true,
+            },
+        )
+        .await?;
+
+        // `items.total_count` is the true, unbounded resume total (a
+        // separate COUNT(*) unaffected by the deliberately capped fetch
+        // above) — using `resume_items.len()` here would silently reproduce
+        // the exact undercount this was fixed to avoid.
+        let total_record_count = items.total_count as i64
+            + next_up_injected_count(&next_up, &represented_series);
+
+        let page = merge_continue_watching(resume_items, next_up, &represented_series);
+        let mut page: Vec<ContinueWatchingItem> = page
             .into_iter()
             .skip(start_index)
             .take(limit)
-            .collect()
+            .collect();
+
+        let mut next_up_in_page: Vec<&mut NextUpCandidate> = page
+            .iter_mut()
+            .filter_map(|item| match item {
+                ContinueWatchingItem::NextUp(c) => Some(c),
+                ContinueWatchingItem::Resume(_) => None,
+            })
+            .collect();
+        if !next_up_in_page.is_empty() {
+            let mut owned: Vec<NextUpCandidate> = next_up_in_page
+                .iter_mut()
+                .map(|c| NextUpCandidate {
+                    media: std::mem::take(&mut c.media),
+                    user_state: c
+                        .user_state
+                        .take(),
+                    effective_activity: c.effective_activity,
+                })
+                .collect();
+            hydrate_next_up_candidates(&state, &mut owned).await;
+            for (slot, hydrated) in next_up_in_page
+                .into_iter()
+                .zip(owned)
+            {
+                slot.media = hydrated.media;
+            }
+        }
+
+        let items: Vec<api::BaseItemDto> = page
+            .into_iter()
+            .map(|item| match item {
+                ContinueWatchingItem::Resume(dto) => dto,
+                ContinueWatchingItem::NextUp(candidate) => {
+                    let mut item = api::db_media_to_item(
+                        candidate
+                            .media
+                            .clone(),
+                        false,
+                    );
+                    if let Some(state) = candidate.user_state {
+                        item.user_data =
+                            Some(api::db_state_to_dto(state, &candidate.media));
+                    }
+                    item
+                }
+            })
+            .collect();
+        (items, total_record_count)
     } else {
-        resume_items
+        let total = items.total_count as i64;
+        let page = resume_items
+            .into_iter()
+            .skip(start_index)
+            .take(limit)
+            .collect();
+        (page, total)
     };
 
     Ok(Json(api::BaseItemDtoQueryResult {
@@ -1508,17 +1594,37 @@ pub(crate) async fn resume_items(
     }))
 }
 
+enum ContinueWatchingItem {
+    Resume(api::BaseItemDto),
+    NextUp(NextUpCandidate),
+}
+
+/// How many of `next_up` are not already represented among `represented_series`
+/// — i.e. how many would actually get injected by `merge_continue_watching`.
+/// Kept as its own pass (rather than reading it back off the merged result)
+/// so the total-count computation doesn't depend on hydration order.
+fn next_up_injected_count(
+    next_up: &[NextUpCandidate],
+    represented_series: &HashSet<Uuid>,
+) -> i64 {
+    next_up
+        .iter()
+        .filter(|c| {
+            c.media
+                .grandparent_id
+                .is_some_and(|series_id| !represented_series.contains(&series_id))
+        })
+        .count() as i64
+}
+
 fn merge_continue_watching(
     resume_items: Vec<api::BaseItemDto>,
-    next_up: impl IntoIterator<Item = (api::BaseItemDto, chrono::DateTime<chrono::Utc>)>,
-) -> Vec<api::BaseItemDto> {
-    let mut represented_series: HashSet<Uuid> = resume_items
-        .iter()
-        .filter_map(|item| item.series_id)
-        .collect();
+    next_up: Vec<NextUpCandidate>,
+    represented_series: &HashSet<Uuid>,
+) -> Vec<ContinueWatchingItem> {
     let epoch = chrono::DateTime::from_timestamp(0, 0)
         .expect("Unix epoch is a valid timestamp");
-    let mut ranked: Vec<(api::BaseItemDto, chrono::DateTime<chrono::Utc>)> =
+    let mut ranked: Vec<(ContinueWatchingItem, chrono::DateTime<chrono::Utc>)> =
         resume_items
             .into_iter()
             .map(|item| {
@@ -1527,15 +1633,17 @@ fn merge_continue_watching(
                     .as_ref()
                     .and_then(|data| data.last_played_date)
                     .unwrap_or(epoch);
-                (item, activity)
+                (ContinueWatchingItem::Resume(item), activity)
             })
             .collect();
-    for (item, activity) in next_up {
-        if item
-            .series_id
-            .is_some_and(|series_id| represented_series.insert(series_id))
-        {
-            ranked.push((item, activity));
+    for candidate in next_up {
+        let already_represented = candidate
+            .media
+            .grandparent_id
+            .is_none_or(|series_id| represented_series.contains(&series_id));
+        if !already_represented {
+            let activity = candidate.effective_activity;
+            ranked.push((ContinueWatchingItem::NextUp(candidate), activity));
         }
     }
     ranked.sort_by(|(_, a), (_, b)| b.cmp(a));
@@ -1866,6 +1974,36 @@ mod e2e_tests {
     use http::header::HeaderValue;
     use serde_json::json;
 
+    fn merged_item_id(item: &ContinueWatchingItem) -> Uuid {
+        match item {
+            ContinueWatchingItem::Resume(dto) => dto.id,
+            ContinueWatchingItem::NextUp(c) => {
+                c.media
+                    .id
+            }
+        }
+    }
+
+    fn next_up_candidate(
+        id: Uuid,
+        series_id: Uuid,
+        effective_activity_secs: i64,
+    ) -> NextUpCandidate {
+        NextUpCandidate {
+            media: db::Media {
+                id,
+                grandparent_id: Some(series_id),
+                ..Default::default()
+            },
+            user_state: None,
+            effective_activity: chrono::DateTime::from_timestamp(
+                effective_activity_secs,
+                0,
+            )
+            .unwrap(),
+        }
+    }
+
     #[test]
     fn merge_continue_watching_deduplicates_series_and_orders_by_activity() {
         let existing_series = Uuid::new_v4();
@@ -1892,28 +2030,394 @@ mod e2e_tests {
             }),
             ..Default::default()
         };
-        let duplicate_next_up = api::BaseItemDto {
-            id: duplicate_next_up_id,
-            series_id: Some(existing_series),
-            ..Default::default()
-        };
-        let injected_next_up = api::BaseItemDto {
-            id: injected_next_up_id,
-            series_id: Some(injected_series),
-            ..Default::default()
-        };
+        let duplicate_next_up =
+            next_up_candidate(duplicate_next_up_id, existing_series, 300);
+        let injected_next_up =
+            next_up_candidate(injected_next_up_id, injected_series, 400);
 
+        // `existing_series` is represented (it has a resume item) — the
+        // *authoritative* set passed in, not derived from `resume_items`.
+        let represented_series: HashSet<Uuid> = [existing_series]
+            .into_iter()
+            .collect();
         let merged = merge_continue_watching(
             vec![resume_episode, movie],
-            vec![(duplicate_next_up, at(300)), (injected_next_up, at(400))],
+            vec![duplicate_next_up, injected_next_up],
+            &represented_series,
         );
 
         assert_eq!(
             merged
                 .iter()
-                .map(|item| item.id)
+                .map(merged_item_id)
                 .collect::<Vec<_>>(),
             vec![injected_next_up_id, movie_id, resume_episode_id]
+        );
+    }
+
+    #[test]
+    fn merge_continue_watching_suppresses_next_up_for_a_series_resumable_outside_the_fetch_window()
+     {
+        // Regression test: dedup must use the full, unbounded resumable-series
+        // set, not just whatever resume items happened to be in the fetched
+        // page. Here the fetched `resume_items` window is empty (as if the
+        // series' own resumable item fell on a later page), but the
+        // authoritative `represented_series` set still knows about it.
+        let series_on_a_later_page = Uuid::new_v4();
+        let next_up = next_up_candidate(Uuid::new_v4(), series_on_a_later_page, 999);
+        let represented_series: HashSet<Uuid> = [series_on_a_later_page]
+            .into_iter()
+            .collect();
+
+        let merged =
+            merge_continue_watching(vec![], vec![next_up], &represented_series);
+
+        assert!(
+            merged.is_empty(),
+            "a series already known to have a resumable episode must never get a next-up injection, \
+             regardless of which page that episode happens to be on"
+        );
+    }
+
+    async fn insert_state(
+        db: &sqlx::SqlitePool,
+        user_id: Uuid,
+        media_id: Uuid,
+        play_count: i64,
+        playback_position: i64,
+        played_at: Option<chrono::NaiveDateTime>,
+        last_played_at: Option<chrono::NaiveDateTime>,
+    ) {
+        sqlx::query(
+            r#"
+            INSERT INTO user_media_state (
+                user_id,
+                media_id,
+                media_raw,
+                stream_id,
+                favorite,
+                play_count,
+                played_at,
+                playback_position,
+                last_played_at,
+                subtitle_idx,
+                audio_idx
+            )
+            VALUES (?1, ?2, NULL, NULL, 0, ?3, ?4, ?5, ?6, NULL, NULL)
+            ON CONFLICT(user_id, media_id)
+            DO UPDATE SET
+                play_count = excluded.play_count,
+                played_at = excluded.played_at,
+                playback_position = excluded.playback_position,
+                last_played_at = excluded.last_played_at
+            "#,
+        )
+        .bind(user_id)
+        .bind(media_id)
+        .bind(play_count)
+        .bind(played_at)
+        .bind(playback_position)
+        .bind(last_played_at)
+        .execute(db)
+        .await
+        .unwrap();
+    }
+
+    async fn seed_series_with_episode_count(
+        db: &sqlx::SqlitePool,
+        title: &str,
+        episode_count: i64,
+    ) -> (db::Media, Vec<db::Media>) {
+        let imdb = db::NonEmptyString::try_new(format!(
+            "tt{}",
+            Uuid::new_v4().as_u128() as u64
+        ))
+        .unwrap();
+        let mut series = db::Media {
+            id: Uuid::new_v4(),
+            title: title.to_string(),
+            kind: db::MediaKind::Series,
+            external_ids: db::ExternalIds {
+                imdb: Some(imdb),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        series
+            .save(db)
+            .await
+            .unwrap();
+
+        let mut episodes = Vec::new();
+        for idx in 1..=episode_count {
+            let mut ep = db::Media {
+                id: Uuid::new_v4(),
+                title: format!("{title} Ep {idx}"),
+                kind: db::MediaKind::Episode,
+                grandparent_id: Some(series.id),
+                idx: Some(idx),
+                ..Default::default()
+            };
+            ep.save(db)
+                .await
+                .unwrap();
+            episodes.push(ep);
+        }
+        (series, episodes)
+    }
+
+    async fn set_server_config(
+        db: &sqlx::SqlitePool,
+        f: impl FnOnce(&mut api::ServerConfiguration),
+    ) {
+        let mut cfg = db::Settings::get_config_or_default(db).await;
+        f(&mut cfg);
+        db::Settings::set_config(db, &cfg)
+            .await
+            .unwrap();
+    }
+
+    async fn set_max_parental_rating(db: &sqlx::SqlitePool, rating: i32) {
+        let mut user: db::User = sqlx::query_as("SELECT * FROM users LIMIT 1")
+            .fetch_one(db)
+            .await
+            .unwrap();
+        let mut policy = user
+            .policy
+            .as_ref()
+            .map(|p| {
+                p.0.clone()
+            })
+            .unwrap_or_default();
+        policy.max_parental_rating = Some(rating);
+        user.policy = Some(sqlx::types::Json(policy));
+        user.save(db)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn resume_unified_next_up_skips_series_already_resumable_on_another_page() {
+        let (server, guard, token) = authenticated_server().await;
+        let auth = auth_header_with_token(&token);
+        let db = &guard
+            .0
+            .db;
+        set_server_config(db, |cfg| {
+            cfg.enable_next_up_in_continue_watching = Some(true);
+        })
+        .await;
+        let user: db::User = sqlx::query_as("SELECT * FROM users LIMIT 1")
+            .fetch_one(db)
+            .await
+            .unwrap();
+        let now = chrono::Utc::now().naive_utc();
+
+        // Series A: ep1+ep2 fully watched long ago, ep2 *also* currently
+        // resumable (a rewatch in progress) — so A has a resumable episode,
+        // but it's an old one. ep3 is untouched and would be a valid
+        // next-up candidate (released moments ago, so it would rank very
+        // high if wrongly injected).
+        let (_series_a, eps_a) =
+            seed_series_with_episode_count(db, "Series A", 3).await;
+        insert_state(
+            db,
+            user.id,
+            eps_a[0].id,
+            1,
+            0,
+            Some(now - chrono::Duration::days(200)),
+            Some(now - chrono::Duration::days(200)),
+        )
+        .await;
+        insert_state(
+            db,
+            user.id,
+            eps_a[1].id,
+            1,
+            500,
+            Some(now - chrono::Duration::days(200)),
+            Some(now - chrono::Duration::days(200)),
+        )
+        .await;
+        let mut ep_a3 = eps_a[2].clone();
+        ep_a3.digital_released_at = Some(now - chrono::Duration::minutes(1));
+        ep_a3
+            .save(db)
+            .await
+            .unwrap();
+
+        // Series B: a single resumable episode, more recent than A's, so it
+        // takes the one slot on a `limit=1` page ahead of A's.
+        let (_series_b, eps_b) =
+            seed_series_with_episode_count(db, "Series B", 1).await;
+        insert_state(
+            db,
+            user.id,
+            eps_b[0].id,
+            0,
+            100,
+            None,
+            Some(now - chrono::Duration::hours(2)),
+        )
+        .await;
+
+        let resp = server
+            .get("/users/me/items/resume?limit=1")
+            .add_header(
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth).unwrap(),
+            )
+            .await;
+        resp.assert_status_ok();
+        let body: serde_json::Value = resp.json();
+        let items = body["Items"]
+            .as_array()
+            .unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(
+            items[0]["Id"],
+            eps_b[0]
+                .id
+                .simple()
+                .to_string(),
+            "series A already has a resumable episode (even though it's not on this page), \
+             so its next-up episode must not be injected ahead of series B's real resume item"
+        );
+        assert_eq!(
+            body["TotalRecordCount"], 2,
+            "total should count the two real resumable episodes, not an incorrectly-injected third"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_unified_next_up_respects_parental_rating_policy() {
+        let (server, guard, token) = authenticated_server().await;
+        let auth = auth_header_with_token(&token);
+        let db = &guard
+            .0
+            .db;
+        set_server_config(db, |cfg| {
+            cfg.enable_next_up_in_continue_watching = Some(true);
+        })
+        .await;
+        let user: db::User = sqlx::query_as("SELECT * FROM users LIMIT 1")
+            .fetch_one(db)
+            .await
+            .unwrap();
+        let now = chrono::Utc::now().naive_utc();
+
+        let (mut series, eps) =
+            seed_series_with_episode_count(db, "Mature Show", 2).await;
+        series.certification_age = Some(18);
+        series
+            .save(db)
+            .await
+            .unwrap();
+        insert_state(
+            db,
+            user.id,
+            eps[0].id,
+            1,
+            0,
+            Some(now - chrono::Duration::days(1)),
+            Some(now - chrono::Duration::days(1)),
+        )
+        .await;
+        let mut ep2 = eps[1].clone();
+        ep2.digital_released_at = Some(now - chrono::Duration::minutes(1));
+        ep2.save(db)
+            .await
+            .unwrap();
+
+        set_max_parental_rating(db, 13).await;
+
+        let resp = server
+            .get("/users/me/items/resume")
+            .add_header(
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth).unwrap(),
+            )
+            .await;
+        resp.assert_status_ok();
+        let body: serde_json::Value = resp.json();
+        let items = body["Items"]
+            .as_array()
+            .unwrap();
+        assert!(
+            items
+                .iter()
+                .all(|item| item["Id"]
+                    != eps[1]
+                        .id
+                        .simple()
+                        .to_string()),
+            "an episode from a series that exceeds the user's max parental rating must never \
+             be injected into Continue Watching, {items:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_unified_next_up_excludes_unreleased_episodes_even_with_release_filter_disabled()
+     {
+        let (server, guard, token) = authenticated_server().await;
+        let auth = auth_header_with_token(&token);
+        let db = &guard
+            .0
+            .db;
+        set_server_config(db, |cfg| {
+            cfg.enable_next_up_in_continue_watching = Some(true);
+            // Disabled server-wide — the standalone Next Up feed would allow
+            // any future date through in this configuration.
+            cfg.filter_by_digital_release_date = false;
+        })
+        .await;
+        let user: db::User = sqlx::query_as("SELECT * FROM users LIMIT 1")
+            .fetch_one(db)
+            .await
+            .unwrap();
+        let now = chrono::Utc::now().naive_utc();
+
+        let (_series, eps) =
+            seed_series_with_episode_count(db, "Upcoming Show", 2).await;
+        insert_state(
+            db,
+            user.id,
+            eps[0].id,
+            1,
+            0,
+            Some(now - chrono::Duration::days(1)),
+            Some(now - chrono::Duration::days(1)),
+        )
+        .await;
+        let mut ep2 = eps[1].clone();
+        ep2.digital_released_at = Some(now + chrono::Duration::days(10));
+        ep2.save(db)
+            .await
+            .unwrap();
+
+        let resp = server
+            .get("/users/me/items/resume")
+            .add_header(
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth).unwrap(),
+            )
+            .await;
+        resp.assert_status_ok();
+        let body: serde_json::Value = resp.json();
+        let items = body["Items"]
+            .as_array()
+            .unwrap();
+        assert!(
+            items
+                .iter()
+                .all(|item| item["Id"]
+                    != eps[1]
+                        .id
+                        .simple()
+                        .to_string()),
+            "Continue Watching must never show an episode that hasn't actually premiered, \
+             even when the server's release-date filter is disabled: {items:?}"
         );
     }
 

--- a/crates/remux-server/src/api/users.rs
+++ b/crates/remux-server/src/api/users.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use anyhow::Context;
 use axum::{
@@ -33,10 +33,7 @@ use remux_sdks::remux::Username;
 use super::{
     items::{ItemsQueryResultBuilder, get_items, item, items, items_flat},
     mock_items,
-    shows::{
-        NextUpCandidate, NextUpRequest, hydrate_next_up_candidates, livetv_view_item,
-        next_up_candidates,
-    },
+    shows::{livetv_view_item, next_up_candidates},
 };
 
 #[post("/users/{user_id}/configuration")]
@@ -1392,7 +1389,7 @@ pub async fn users_views(
     userviews(State(state), session, Query(q)).await
 }
 
-pub(crate) async fn resume_items(
+async fn resume_items(
     state: AppState,
     session: auth::AuthSession,
     mut q: api::GetItemsQuery,
@@ -1403,71 +1400,44 @@ pub(crate) async fn resume_items(
             .id,
     );
     q.filters = Some(vec![api::ItemFilter::IsResumable]);
-    if q.limit
-        .is_none()
-    {
-        q.limit = Some(50);
-    }
-    if q.sort_by
-        .is_none()
-    {
-        q.sort_by = Some(vec![api::ItemSortBy::DatePlayed]);
-    }
-    if q.sort_order
-        .is_none()
-    {
-        q.sort_order = Some(vec![api::SortOrder::Descending]);
-    }
-    let unified_next_up = db::Settings::get_config_or_default(
+    let limit = *q
+        .limit
+        .get_or_insert(50);
+    let start = q
+        .start_index
+        .unwrap_or(0);
+    q.sort_by
+        .get_or_insert(vec![api::ItemSortBy::DatePlayed]);
+    q.sort_order
+        .get_or_insert(vec![api::SortOrder::Descending]);
+    let config = db::Settings::get_config_or_default(
         &state
             .ctx
             .db,
     )
-    .await
-    .enable_next_up_in_continue_watching
-    .unwrap_or(false)
-        // A request that doesn't even want Episodes (e.g. a movie-only or
-        // otherwise type-scoped Resume call) must never have one injected —
-        // matching the same request constraint the resume fetch itself honours.
+    .await;
+    let unified = config
+        .enable_next_up_in_continue_watching
+        .unwrap_or(false)
         && q.get_requested_item_types()
             .contains(&api::MediaType::Episode);
-    // Merge and rank before paginating so an injected new release can displace
-    // an older resume item on the first page.
-    let mut items_query = q.clone();
-    if unified_next_up {
-        items_query.start_index = None;
-        // Injected Next Up entries only push resume items down, never pull a
-        // later resume item into this page. Keep the database fetch bounded.
-        items_query.limit = Some(
-            q.start_index
-                .unwrap_or(0)
-                .saturating_add(
-                    q.limit
-                        .unwrap_or(50),
-                ),
-        );
+    let mut query = q.clone();
+    if unified {
+        query.start_index = None;
+        query.limit = Some(start.saturating_add(limit));
+        // The merged feed uses activity order, so the bounded prefix must too.
+        query.sort_by = Some(vec![api::ItemSortBy::DatePlayed]);
+        query.sort_order = Some(vec![api::SortOrder::Descending]);
     }
-    let items = get_items(state.clone(), session.clone(), items_query, true)
+    let result = get_items(state.clone(), session.clone(), query, true)
         .await?
         .with_permissions()
         .with_client_patches()
         .build();
-
-    let resume_items = items.items;
-    let start_index = q
-        .start_index
-        .unwrap_or(0) as usize;
-    let limit = q
-        .limit
-        .unwrap_or(50) as usize;
-
-    let (response_items, total_record_count) = if unified_next_up {
-        // The authoritative, unbounded set of series with a resumable
-        // episode — not derived from `resume_items` above, which is only
-        // the fetch window. Using the window would make dedup (and thus
-        // which episode gets injected, and the reported total) depend on
-        // which page was requested.
-        let represented_series = db::Media::resumable_series_ids(
+    let mut total = result.total_count;
+    let mut items = result.items;
+    if unified {
+        let represented = db::Media::resumable_series_ids(
             &state
                 .ctx
                 .db,
@@ -1476,60 +1446,39 @@ pub(crate) async fn resume_items(
                 .id,
         )
         .await?;
-
-        let policy = session
-            .user
-            .policy
-            .as_ref();
-        let mut next_up = next_up_candidates(
-            &state,
-            NextUpRequest {
-                user_id: session
-                    .user
-                    .id,
-                enable_resumable: false,
-                date_cutoff: "1970-01-01 00:00:00".to_string(),
-                max_parental_rating: policy.and_then(|p| p.max_parental_rating),
-                blocked_tags: policy
-                    .map(|p| {
-                        p.blocked_tags
-                            .clone()
-                    })
-                    .filter(|v| !v.is_empty()),
-                allowed_tags: policy
-                    .map(|p| {
-                        p.allowed_tags
-                            .clone()
-                    })
-                    .filter(|v| !v.is_empty()),
-                policy_filter: policy.and_then(|p| {
-                    p.filter_rules
-                        .clone()
-                }),
-                // Apply scope through the normal item query below, which also
-                // understands recursive folders and collection membership.
-                parent_id: None,
-                // Injected into Continue Watching, not the standalone Next Up
-                // feed — must never show something that hasn't actually
-                // premiered, regardless of the server's release-date buffer.
-                require_actually_released: true,
-            },
-        )
-        .await?;
-
-        next_up.retain(|c| {
-            c.media
-                .grandparent_id
-                .is_some_and(|id| !represented_series.contains(&id))
-        });
-        if !next_up.is_empty() {
-            let mut eligible_query = q.clone();
-            eligible_query.filters = None;
-            eligible_query.start_index = None;
-            eligible_query.limit = None;
-            eligible_query.strict_item_filters = true;
-            eligible_query.include_item_types = Some(vec![api::MediaType::Episode]);
-            if let Some(term) = eligible_query
+        let mut query = q.clone();
+        query.enable_resumable = Some(false);
+        let now = chrono::Utc::now();
+        let candidates = next_up_candidates(&state, &session, &query).await?;
+        let activity: HashMap<Uuid, chrono::DateTime<chrono::Utc>> = candidates
+            .into_iter()
+            .filter(|(media, _)| {
+                media
+                    .released_at
+                    .is_some_and(|date| date.and_utc() <= now)
+                    && media
+                        .grandparent_id
+                        .is_some_and(|id| !represented.contains(&id))
+                    && q.ids
+                        .as_ref()
+                        .is_none_or(|ids| ids.contains(&media.id))
+            })
+            .map(|(media, date)| (media.id, date))
+            .collect();
+        if !activity.is_empty() {
+            // Reuse normal request scope, policy, user data and image handling.
+            query.ids = Some(
+                activity
+                    .keys()
+                    .copied()
+                    .collect(),
+            );
+            query.filters = None;
+            query.include_item_types = Some(vec![api::MediaType::Episode]);
+            query.start_index = None;
+            query.limit = Some(activity.len() as u32);
+            query.strict_item_filters = true;
+            if let Some(term) = query
                 .search_term
                 .as_mut()
             {
@@ -1537,172 +1486,40 @@ pub(crate) async fn resume_items(
                     *term = format!("local:{term}");
                 }
             }
-            let ids: Vec<Uuid> = next_up
-                .iter()
-                .map(|c| {
-                    c.media
-                        .id
-                })
-                .filter(|id| {
-                    q.ids
-                        .as_ref()
-                        .is_none_or(|ids| ids.contains(id))
-                })
-                .collect();
-            if ids.is_empty() {
-                next_up.clear();
-            } else {
-                eligible_query.limit =
-                    Some(u32::try_from(ids.len()).unwrap_or(u32::MAX));
-                eligible_query.ids = Some(ids);
-                let eligible: HashSet<Uuid> =
-                    get_items(state.clone(), session.clone(), eligible_query, false)
-                        .await?
-                        .build()
-                        .items
-                        .into_iter()
-                        .map(|item| item.id)
-                        .collect();
-                next_up.retain(|c| {
-                    eligible.contains(
-                        &c.media
-                            .id,
-                    )
-                });
-            }
+            let next_up = get_items(state, session, query, false)
+                .await?
+                .with_permissions()
+                .with_client_patches()
+                .build()
+                .items;
+            total += next_up.len() as i64;
+            items.extend(next_up);
         }
-
-        // `items.total_count` is the true, unbounded resume total (a
-        // separate COUNT(*) unaffected by the deliberately capped fetch
-        // above) — using `resume_items.len()` here would silently reproduce
-        // the exact undercount this was fixed to avoid.
-        let total_record_count = items.total_count as i64
-            + next_up_injected_count(&next_up, &represented_series);
-
-        let page = merge_continue_watching(resume_items, next_up, &represented_series);
-        let mut page: Vec<ContinueWatchingItem> = page
+        items.sort_by_key(|item| {
+            std::cmp::Reverse((
+                activity
+                    .get(&item.id)
+                    .copied()
+                    .or_else(|| {
+                        item.user_data
+                            .as_ref()
+                            .and_then(|data| data.last_played_date)
+                    }),
+                item.id,
+            ))
+        });
+        items = items
             .into_iter()
-            .skip(start_index)
-            .take(limit)
+            .skip(start as usize)
+            .take(limit as usize)
             .collect();
-
-        let mut next_up_in_page: Vec<&mut NextUpCandidate> = page
-            .iter_mut()
-            .filter_map(|item| match item {
-                ContinueWatchingItem::NextUp(c) => Some(c),
-                ContinueWatchingItem::Resume(_) => None,
-            })
-            .collect();
-        if !next_up_in_page.is_empty() {
-            let mut owned: Vec<NextUpCandidate> = next_up_in_page
-                .iter_mut()
-                .map(|c| NextUpCandidate {
-                    media: std::mem::take(&mut c.media),
-                    user_state: c
-                        .user_state
-                        .take(),
-                    effective_activity: c.effective_activity,
-                })
-                .collect();
-            hydrate_next_up_candidates(&state, &mut owned).await;
-            for (slot, hydrated) in next_up_in_page
-                .into_iter()
-                .zip(owned)
-            {
-                *slot = hydrated;
-            }
-        }
-
-        let items: Vec<api::BaseItemDto> = page
-            .into_iter()
-            .map(|item| match item {
-                ContinueWatchingItem::Resume(dto) => dto,
-                ContinueWatchingItem::NextUp(candidate) => {
-                    let mut item = api::db_media_to_item(
-                        candidate
-                            .media
-                            .clone(),
-                        false,
-                    );
-                    if let Some(state) = candidate.user_state {
-                        item.user_data =
-                            Some(api::db_state_to_dto(state, &candidate.media));
-                    }
-                    item
-                }
-            })
-            .collect();
-        (items, total_record_count)
-    } else {
-        let total = items.total_count as i64;
-        (resume_items, total)
-    };
-
+    }
     Ok(Json(api::BaseItemDtoQueryResult {
-        items: response_items,
-        total_record_count,
-        start_index: start_index as u32,
+        items,
+        total_record_count: total,
+        start_index: start,
         ..Default::default()
     }))
-}
-
-enum ContinueWatchingItem {
-    Resume(api::BaseItemDto),
-    NextUp(NextUpCandidate),
-}
-
-/// How many of `next_up` are not already represented among `represented_series`
-/// — i.e. how many would actually get injected by `merge_continue_watching`.
-/// Kept as its own pass (rather than reading it back off the merged result)
-/// so the total-count computation doesn't depend on hydration order.
-fn next_up_injected_count(
-    next_up: &[NextUpCandidate],
-    represented_series: &HashSet<Uuid>,
-) -> i64 {
-    next_up
-        .iter()
-        .filter(|c| {
-            c.media
-                .grandparent_id
-                .is_some_and(|series_id| !represented_series.contains(&series_id))
-        })
-        .count() as i64
-}
-
-fn merge_continue_watching(
-    resume_items: Vec<api::BaseItemDto>,
-    next_up: Vec<NextUpCandidate>,
-    represented_series: &HashSet<Uuid>,
-) -> Vec<ContinueWatchingItem> {
-    let epoch = chrono::DateTime::from_timestamp(0, 0)
-        .expect("Unix epoch is a valid timestamp");
-    let mut ranked: Vec<(ContinueWatchingItem, chrono::DateTime<chrono::Utc>)> =
-        resume_items
-            .into_iter()
-            .map(|item| {
-                let activity = item
-                    .user_data
-                    .as_ref()
-                    .and_then(|data| data.last_played_date)
-                    .unwrap_or(epoch);
-                (ContinueWatchingItem::Resume(item), activity)
-            })
-            .collect();
-    for candidate in next_up {
-        let already_represented = candidate
-            .media
-            .grandparent_id
-            .is_none_or(|series_id| represented_series.contains(&series_id));
-        if !already_represented {
-            let activity = candidate.effective_activity;
-            ranked.push((ContinueWatchingItem::NextUp(candidate), activity));
-        }
-    }
-    ranked.sort_by(|(_, a), (_, b)| b.cmp(a));
-    ranked
-        .into_iter()
-        .map(|(item, _)| item)
-        .collect()
 }
 
 #[get("/users/{user_id}/items/resume")]
@@ -2026,359 +1843,76 @@ mod e2e_tests {
     use http::header::HeaderValue;
     use serde_json::json;
 
-    fn merged_item_id(item: &ContinueWatchingItem) -> Uuid {
-        match item {
-            ContinueWatchingItem::Resume(dto) => dto.id,
-            ContinueWatchingItem::NextUp(c) => {
-                c.media
-                    .id
-            }
-        }
-    }
-
-    fn next_up_candidate(
-        id: Uuid,
-        series_id: Uuid,
-        effective_activity_secs: i64,
-    ) -> NextUpCandidate {
-        NextUpCandidate {
-            media: db::Media {
-                id,
-                grandparent_id: Some(series_id),
-                ..Default::default()
-            },
-            user_state: None,
-            effective_activity: chrono::DateTime::from_timestamp(
-                effective_activity_secs,
-                0,
-            )
-            .unwrap(),
-        }
-    }
-
-    #[test]
-    fn merge_continue_watching_deduplicates_series_and_orders_by_activity() {
-        let existing_series = Uuid::new_v4();
-        let injected_series = Uuid::new_v4();
-        let resume_episode_id = Uuid::new_v4();
-        let movie_id = Uuid::new_v4();
-        let duplicate_next_up_id = Uuid::new_v4();
-        let injected_next_up_id = Uuid::new_v4();
-        let at = |seconds| chrono::DateTime::from_timestamp(seconds, 0).unwrap();
-        let resume_episode = api::BaseItemDto {
-            id: resume_episode_id,
-            series_id: Some(existing_series),
-            user_data: Some(api::UserItemDataDto {
-                last_played_date: Some(at(100)),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-        let movie = api::BaseItemDto {
-            id: movie_id,
-            user_data: Some(api::UserItemDataDto {
-                last_played_date: Some(at(200)),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-        let duplicate_next_up =
-            next_up_candidate(duplicate_next_up_id, existing_series, 300);
-        let injected_next_up =
-            next_up_candidate(injected_next_up_id, injected_series, 400);
-
-        // `existing_series` is represented (it has a resume item) — the
-        // *authoritative* set passed in, not derived from `resume_items`.
-        let represented_series: HashSet<Uuid> = [existing_series]
-            .into_iter()
-            .collect();
-        let merged = merge_continue_watching(
-            vec![resume_episode, movie],
-            vec![duplicate_next_up, injected_next_up],
-            &represented_series,
-        );
-
-        assert_eq!(
-            merged
-                .iter()
-                .map(merged_item_id)
-                .collect::<Vec<_>>(),
-            vec![injected_next_up_id, movie_id, resume_episode_id]
-        );
-    }
-
-    #[test]
-    fn merge_continue_watching_suppresses_next_up_for_a_series_resumable_outside_the_fetch_window()
-     {
-        // Regression test: dedup must use the full, unbounded resumable-series
-        // set, not just whatever resume items happened to be in the fetched
-        // page. Here the fetched `resume_items` window is empty (as if the
-        // series' own resumable item fell on a later page), but the
-        // authoritative `represented_series` set still knows about it.
-        let series_on_a_later_page = Uuid::new_v4();
-        let next_up = next_up_candidate(Uuid::new_v4(), series_on_a_later_page, 999);
-        let represented_series: HashSet<Uuid> = [series_on_a_later_page]
-            .into_iter()
-            .collect();
-
-        let merged =
-            merge_continue_watching(vec![], vec![next_up], &represented_series);
-
-        assert!(
-            merged.is_empty(),
-            "a series already known to have a resumable episode must never get a next-up injection, \
-             regardless of which page that episode happens to be on"
-        );
-    }
-
-    async fn insert_state(
-        db: &sqlx::SqlitePool,
-        user_id: Uuid,
-        media_id: Uuid,
-        play_count: i64,
-        playback_position: i64,
-        played_at: Option<chrono::NaiveDateTime>,
-        last_played_at: Option<chrono::NaiveDateTime>,
-    ) {
-        sqlx::query(
-            r#"
-            INSERT INTO user_media_state (
-                user_id,
-                media_id,
-                media_raw,
-                stream_id,
-                favorite,
-                play_count,
-                played_at,
-                playback_position,
-                last_played_at,
-                subtitle_idx,
-                audio_idx
-            )
-            VALUES (?1, ?2, NULL, NULL, 0, ?3, ?4, ?5, ?6, NULL, NULL)
-            ON CONFLICT(user_id, media_id)
-            DO UPDATE SET
-                play_count = excluded.play_count,
-                played_at = excluded.played_at,
-                playback_position = excluded.playback_position,
-                last_played_at = excluded.last_played_at
-            "#,
-        )
-        .bind(user_id)
-        .bind(media_id)
-        .bind(play_count)
-        .bind(played_at)
-        .bind(playback_position)
-        .bind(last_played_at)
-        .execute(db)
-        .await
-        .unwrap();
-    }
-
-    async fn seed_series_with_episode_count(
-        db: &sqlx::SqlitePool,
-        title: &str,
-        episode_count: i64,
-    ) -> (db::Media, Vec<db::Media>) {
-        let imdb = db::NonEmptyString::try_new(format!(
-            "tt{}",
-            Uuid::new_v4().as_u128() as u64
-        ))
-        .unwrap();
-        let mut series = db::Media {
-            id: Uuid::new_v4(),
-            title: title.to_string(),
-            kind: db::MediaKind::Series,
-            external_ids: db::ExternalIds {
-                imdb: Some(imdb),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        series
-            .save(db)
-            .await
-            .unwrap();
-
-        let mut episodes = Vec::new();
-        for idx in 1..=episode_count {
-            let mut ep = db::Media {
-                id: Uuid::new_v4(),
-                title: format!("{title} Ep {idx}"),
-                kind: db::MediaKind::Episode,
-                parent_id: Some(series.id),
-                released_at: Some(
-                    chrono::Utc::now().naive_utc() - chrono::Duration::days(30),
-                ),
-                grandparent_id: Some(series.id),
-                idx: Some(idx),
-                ..Default::default()
-            };
-            ep.save(db)
-                .await
-                .unwrap();
-            episodes.push(ep);
-        }
-        (series, episodes)
-    }
-
-    async fn set_server_config(
-        db: &sqlx::SqlitePool,
-        f: impl FnOnce(&mut api::ServerConfiguration),
-    ) {
-        let mut cfg = db::Settings::get_config_or_default(db).await;
-        f(&mut cfg);
-        db::Settings::set_config(db, &cfg)
-            .await
-            .unwrap();
-    }
-
-    async fn set_max_parental_rating(db: &sqlx::SqlitePool, rating: i32) {
+    #[tokio::test]
+    async fn unified_resume_regression() {
+        use crate::api::shows::test::{insert_series_with_episodes, insert_state};
+        use chrono::{Duration, Utc};
+        let (server, guard, token) = authenticated_server().await;
+        let db = &guard
+            .0
+            .db;
+        let auth = HeaderValue::from_str(&auth_header_with_token(&token)).unwrap();
         let mut user: db::User = sqlx::query_as("SELECT * FROM users LIMIT 1")
             .fetch_one(db)
             .await
             .unwrap();
-        let mut policy = user
-            .policy
-            .as_ref()
-            .map(|p| {
-                p.0.clone()
-            })
-            .unwrap_or_default();
-        policy.max_parental_rating = Some(rating);
-        user.policy = Some(sqlx::types::Json(policy));
-        user.save(db)
-            .await
-            .unwrap();
-    }
-
-    #[tokio::test]
-    async fn resume_unified_next_up_skips_series_already_resumable_on_another_page() {
-        let (server, guard, token) = authenticated_server().await;
-        let auth = auth_header_with_token(&token);
-        let db = &guard
-            .0
-            .db;
-        set_server_config(db, |cfg| {
-            cfg.enable_next_up_in_continue_watching = Some(true);
-        })
-        .await;
-        let user: db::User = sqlx::query_as("SELECT * FROM users LIMIT 1")
-            .fetch_one(db)
-            .await
-            .unwrap();
-        let now = chrono::Utc::now().naive_utc();
-
-        // Series A: ep1+ep2 fully watched long ago, ep2 *also* currently
-        // resumable (a rewatch in progress) — so A has a resumable episode,
-        // but it's an old one. ep3 is untouched and would be a valid
-        // next-up candidate (released moments ago, so it would rank very
-        // high if wrongly injected).
-        let (_series_a, eps_a) =
-            seed_series_with_episode_count(db, "Series A", 3).await;
-        insert_state(
-            db,
-            user.id,
-            eps_a[0].id,
-            1,
-            0,
-            Some(now - chrono::Duration::days(200)),
-            Some(now - chrono::Duration::days(200)),
-        )
-        .await;
-        insert_state(
-            db,
-            user.id,
-            eps_a[1].id,
-            1,
-            500,
-            Some(now - chrono::Duration::days(200)),
-            Some(now - chrono::Duration::days(200)),
-        )
-        .await;
-        let mut ep_a3 = eps_a[2].clone();
-        ep_a3.digital_released_at = Some(now - chrono::Duration::minutes(1));
-        ep_a3
+        let now = Utc::now().naive_utc();
+        let (mut series, mut next) =
+            insert_series_with_episodes(db, "Next", &["N1", "N2"]).await;
+        let (_, mut rewatch) =
+            insert_series_with_episodes(db, "Rewatch", &["R1", "R2"]).await;
+        let (_, mut future) =
+            insert_series_with_episodes(db, "Future", &["F1", "F2"]).await;
+        for ep in next
+            .iter_mut()
+            .chain(rewatch.iter_mut())
+            .chain(future.iter_mut())
+        {
+            ep.released_at = Some(now - Duration::days(30));
+            ep.save(db)
+                .await
+                .unwrap();
+        }
+        // This future premiere must be excluded despite a past digital date.
+        future[1].released_at = Some(now + Duration::days(10));
+        future[1]
             .save(db)
             .await
             .unwrap();
-
-        // Series B: a single resumable episode, more recent than A's, so it
-        // takes the one slot on a `limit=1` page ahead of A's.
-        let (_series_b, eps_b) =
-            seed_series_with_episode_count(db, "Series B", 1).await;
-        insert_state(
-            db,
-            user.id,
-            eps_b[0].id,
-            0,
-            100,
-            None,
-            Some(now - chrono::Duration::hours(2)),
-        )
-        .await;
-
-        let resp = server
-            .get("/users/me/items/resume?limit=1")
-            .add_header(
-                http::header::AUTHORIZATION,
-                HeaderValue::from_str(&auth).unwrap(),
-            )
-            .await;
-        resp.assert_status_ok();
-        let body: serde_json::Value = resp.json();
-        let items = body["Items"]
-            .as_array()
-            .unwrap();
-        assert_eq!(items.len(), 1);
-        assert_eq!(
-            items[0]["Id"],
-            eps_b[0]
-                .id
-                .simple()
-                .to_string(),
-            "series A already has a resumable episode (even though it's not on this page), \
-             so its next-up episode must not be injected ahead of series B's real resume item"
-        );
-        assert_eq!(
-            body["TotalRecordCount"], 2,
-            "total should count the two real resumable episodes, not an incorrectly-injected third"
-        );
-    }
-
-    #[tokio::test]
-    async fn resume_disabled_paginates_only_once() {
-        let (server, guard, token) = authenticated_server().await;
-        let db = &guard
-            .0
-            .db;
-        let user: db::User = sqlx::query_as("SELECT * FROM users LIMIT 1")
-            .fetch_one(db)
+        let mut movie = db::Media {
+            id: Uuid::new_v4(),
+            title: "Resume movie".into(),
+            kind: db::MediaKind::Movie,
+            external_ids: db::ExternalIds {
+                imdb: Some(
+                    db::NonEmptyString::try_new("tt1234567".to_string()).unwrap(),
+                ),
+                ..Default::default()
+            },
+            released_at: Some(now - Duration::days(30)),
+            ..Default::default()
+        };
+        movie
+            .save(db)
             .await
             .unwrap();
-        let (_, episodes) = seed_series_with_episode_count(db, "Pagination", 3).await;
-        let now = chrono::Utc::now().naive_utc();
-        for (index, episode) in episodes
-            .iter()
-            .enumerate()
-        {
-            insert_state(
-                db,
-                user.id,
-                episode.id,
-                0,
-                100,
-                None,
-                Some(now - chrono::Duration::hours(index as i64)),
-            )
-            .await;
+        for (id, count, position, date) in [
+            (next[0].id, 1, 0, now),
+            (rewatch[0].id, 1, 100, now - Duration::days(20)),
+            (future[0].id, 1, 0, now),
+            (movie.id, 0, 100, now - Duration::days(1)),
+        ] {
+            insert_state(db, user.id, id, count, position, Some(date), Some(date))
+                .await;
         }
+        insert_state(db, user.id, next[1].id, 0, 0, None, None).await;
+        sqlx::query("UPDATE user_media_state SET favorite = 1 WHERE user_id = ? AND media_id = ?")
+            .bind(user.id).bind(next[1].id).execute(db).await.unwrap();
+
+        // Default-off path already paginates in the database.
         let response = server
             .get("/users/me/items/resume?StartIndex=1&Limit=1")
-            .add_header(
-                http::header::AUTHORIZATION,
-                HeaderValue::from_str(&auth_header_with_token(&token)).unwrap(),
-            )
+            .add_header(http::header::AUTHORIZATION, auth.clone())
             .await;
         response.assert_status_ok();
         let body: serde_json::Value = response.json();
@@ -2391,200 +1925,125 @@ mod e2e_tests {
         );
         assert_eq!(
             body["Items"][0]["Id"],
-            episodes[1]
+            rewatch[0]
                 .id
                 .simple()
                 .to_string()
         );
-    }
 
-    #[tokio::test]
-    async fn resume_injected_episode_preserves_favorite_and_request_scope() {
-        let (server, guard, token) = authenticated_server().await;
-        let db = &guard
-            .0
-            .db;
-        set_server_config(db, |cfg| {
-            cfg.enable_next_up_in_continue_watching = Some(true)
-        })
-        .await;
-        let user: db::User = sqlx::query_as("SELECT * FROM users LIMIT 1")
-            .fetch_one(db)
+        let mut config = db::Settings::get_config_or_default(db).await;
+        config.enable_next_up_in_continue_watching = Some(true);
+        config.filter_by_digital_release_date = false;
+        db::Settings::set_config(db, &config)
             .await
             .unwrap();
-        let (series, episodes) = seed_series_with_episode_count(db, "Scoped", 2).await;
-        let (other_series, _) = seed_series_with_episode_count(db, "Other", 1).await;
-        let now = chrono::Utc::now().naive_utc();
-        insert_state(db, user.id, episodes[0].id, 1, 0, Some(now), Some(now)).await;
-        insert_state(db, user.id, episodes[1].id, 0, 0, None, None).await;
-        sqlx::query("UPDATE user_media_state SET favorite = 1 WHERE user_id = ? AND media_id = ?")
-            .bind(user.id).bind(episodes[1].id).execute(db).await.unwrap();
-        for (query, expected_count) in [
-            (format!("SeriesId={}&IsFavorite=true", series.id), 1),
-            (format!("SeriesId={}", other_series.id), 0),
-            (format!("ParentId={}&Recursive=true", series.id), 1),
-            (format!("ParentId={}&Recursive=true", other_series.id), 0),
-            ("IsFavorite=false".to_string(), 0),
+
+        // Sorting, bounded-page dedup, scope, user data and actual premiere gating.
+        for (query, expected) in [
+            ("Limit=1".to_string(), vec![next[1].id]),
+            ("StartIndex=1&Limit=1".to_string(), vec![movie.id]),
+            (
+                "Limit=10".to_string(),
+                vec![next[1].id, movie.id, rewatch[0].id],
+            ),
+            (format!("SeriesId={}", series.id), vec![next[1].id]),
+            (
+                format!("ParentId={}&Recursive=true", series.id),
+                vec![next[1].id],
+            ),
+            ("IsFavorite=true".to_string(), vec![next[1].id]),
+            ("IncludeItemTypes=Movie".to_string(), vec![movie.id]),
         ] {
             let response = server
                 .get(&format!("/users/me/items/resume?{query}"))
-                .add_header(
-                    http::header::AUTHORIZATION,
-                    HeaderValue::from_str(&auth_header_with_token(&token)).unwrap(),
-                )
+                .add_header(http::header::AUTHORIZATION, auth.clone())
                 .await;
             response.assert_status_ok();
             let body: serde_json::Value = response.json();
+            let items = body["Items"]
+                .as_array()
+                .unwrap();
+            let ids: Vec<&str> = items
+                .iter()
+                .map(|item| {
+                    item["Id"]
+                        .as_str()
+                        .unwrap()
+                })
+                .collect();
             assert_eq!(
-                body["Items"]
-                    .as_array()
-                    .unwrap()
-                    .len(),
-                expected_count,
-                "{query}: {body}"
+                ids,
+                expected
+                    .iter()
+                    .map(|id| id
+                        .simple()
+                        .to_string())
+                    .collect::<Vec<_>>(),
+                "{query}"
             );
-            if expected_count == 1 {
-                assert_eq!(
-                    body["Items"][0]["Id"],
-                    episodes[1]
+            if query == "Limit=1" {
+                assert_eq!(body["TotalRecordCount"], 3);
+            }
+            for item in items {
+                if item["Id"]
+                    == next[1]
                         .id
                         .simple()
                         .to_string()
-                );
-                assert_eq!(body["Items"][0]["UserData"]["IsFavorite"], true);
+                {
+                    assert_eq!(item["UserData"]["IsFavorite"], true);
+                    assert_eq!(item["SeriesName"], "Next");
+                }
             }
         }
-    }
 
-    #[tokio::test]
-    async fn resume_unified_next_up_respects_parental_rating_policy() {
-        let (server, guard, token) = authenticated_server().await;
-        let auth = auth_header_with_token(&token);
-        let db = &guard
-            .0
-            .db;
-        set_server_config(db, |cfg| {
-            cfg.enable_next_up_in_continue_watching = Some(true);
-        })
-        .await;
-        let user: db::User = sqlx::query_as("SELECT * FROM users LIMIT 1")
-            .fetch_one(db)
-            .await
-            .unwrap();
-        let now = chrono::Utc::now().naive_utc();
+        // Hide only the aggregate Next Up row.
+        for (url, count) in [
+            ("/shows/nextup".to_string(), 0),
+            (format!("/shows/nextup?SeriesId={}", series.id), 1),
+        ] {
+            let response = server
+                .get(&url)
+                .add_header(http::header::AUTHORIZATION, auth.clone())
+                .await;
+            response.assert_status_ok();
+            assert_eq!(
+                response.json::<serde_json::Value>()["Items"]
+                    .as_array()
+                    .unwrap()
+                    .len(),
+                count
+            );
+        }
 
-        let (mut series, eps) =
-            seed_series_with_episode_count(db, "Mature Show", 2).await;
+        // A previously watched series can become hidden by an updated policy.
         series.certification_age = Some(18);
         series
             .save(db)
             .await
             .unwrap();
-        insert_state(
-            db,
-            user.id,
-            eps[0].id,
-            1,
-            0,
-            Some(now - chrono::Duration::days(1)),
-            Some(now - chrono::Duration::days(1)),
-        )
-        .await;
-        let mut ep2 = eps[1].clone();
-        ep2.digital_released_at = Some(now - chrono::Duration::minutes(1));
-        ep2.save(db)
+        let mut policy = user
+            .policy
+            .as_ref()
+            .map(|p| {
+                p.0.clone()
+            })
+            .unwrap_or_default();
+        policy.max_parental_rating = Some(13);
+        user.policy = Some(sqlx::types::Json(policy));
+        user.save(db)
             .await
             .unwrap();
-
-        set_max_parental_rating(db, 13).await;
-
-        let resp = server
-            .get("/users/me/items/resume")
-            .add_header(
-                http::header::AUTHORIZATION,
-                HeaderValue::from_str(&auth).unwrap(),
-            )
+        let response = server
+            .get(&format!("/users/me/items/resume?SeriesId={}", series.id))
+            .add_header(http::header::AUTHORIZATION, auth)
             .await;
-        resp.assert_status_ok();
-        let body: serde_json::Value = resp.json();
-        let items = body["Items"]
-            .as_array()
-            .unwrap();
+        response.assert_status_ok();
         assert!(
-            items
-                .iter()
-                .all(|item| item["Id"]
-                    != eps[1]
-                        .id
-                        .simple()
-                        .to_string()),
-            "an episode from a series that exceeds the user's max parental rating must never \
-             be injected into Continue Watching, {items:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn resume_unified_next_up_excludes_unreleased_episodes_even_with_release_filter_disabled()
-     {
-        let (server, guard, token) = authenticated_server().await;
-        let auth = auth_header_with_token(&token);
-        let db = &guard
-            .0
-            .db;
-        set_server_config(db, |cfg| {
-            cfg.enable_next_up_in_continue_watching = Some(true);
-            // Disabled server-wide — the standalone Next Up feed would allow
-            // any future date through in this configuration.
-            cfg.filter_by_digital_release_date = false;
-        })
-        .await;
-        let user: db::User = sqlx::query_as("SELECT * FROM users LIMIT 1")
-            .fetch_one(db)
-            .await
-            .unwrap();
-        let now = chrono::Utc::now().naive_utc();
-
-        let (_series, eps) =
-            seed_series_with_episode_count(db, "Upcoming Show", 2).await;
-        insert_state(
-            db,
-            user.id,
-            eps[0].id,
-            1,
-            0,
-            Some(now - chrono::Duration::days(1)),
-            Some(now - chrono::Duration::days(1)),
-        )
-        .await;
-        let mut ep2 = eps[1].clone();
-        ep2.digital_released_at = Some(now - chrono::Duration::days(1));
-        ep2.released_at = Some(now + chrono::Duration::days(10));
-        ep2.save(db)
-            .await
-            .unwrap();
-
-        let resp = server
-            .get("/users/me/items/resume")
-            .add_header(
-                http::header::AUTHORIZATION,
-                HeaderValue::from_str(&auth).unwrap(),
-            )
-            .await;
-        resp.assert_status_ok();
-        let body: serde_json::Value = resp.json();
-        let items = body["Items"]
-            .as_array()
-            .unwrap();
-        assert!(
-            items
-                .iter()
-                .all(|item| item["Id"]
-                    != eps[1]
-                        .id
-                        .simple()
-                        .to_string()),
-            "Continue Watching must never show an episode that hasn't actually premiered, \
-             even when the server's release-date filter is disabled: {items:?}"
+            response.json::<serde_json::Value>()["Items"]
+                .as_array()
+                .unwrap()
+                .is_empty()
         );
     }
 

--- a/crates/remux-server/src/api/users.rs
+++ b/crates/remux-server/src/api/users.rs
@@ -1445,6 +1445,9 @@ pub(crate) async fn resume_items(
         .with_client_patches()
         .build();
 
+    let fetched_resume_count = items
+        .items
+        .len();
     let mut resume_items = items.items;
     if unified_next_up {
         let next_up = crate::api::shows::next_up_candidates(
@@ -1466,8 +1469,18 @@ pub(crate) async fn resume_items(
         resume_items = merge_continue_watching(resume_items, next_up);
     }
 
+    // `items.total_count` is the true, unbounded resume-item total (a
+    // separate COUNT(*) unaffected by the deliberately capped `items_query`
+    // limit above) — it must stay the base of the reported total, not be
+    // replaced by `resume_items.len()`, which only reflects the bounded
+    // fetch window and would make clients that paginate off
+    // TotalRecordCount stop after the first page. Add however many next-up
+    // entries got injected on top of what was actually fetched.
+    let injected_count = resume_items
+        .len()
+        .saturating_sub(fetched_resume_count) as i64;
     let total_record_count = if unified_next_up {
-        resume_items.len() as i64
+        items.total_count as i64 + injected_count
     } else {
         items.total_count as i64
     };

--- a/crates/remux-server/src/api/users.rs
+++ b/crates/remux-server/src/api/users.rs
@@ -1474,6 +1474,10 @@ async fn resume_items(
                     .collect(),
             );
             query.filters = None;
+            // DatePlayed queries start from playback history and omit untouched
+            // episodes. Ordering is applied after the merge, not during lookup.
+            query.sort_by = Some(vec![api::ItemSortBy::IndexNumber]);
+            query.sort_order = Some(vec![api::SortOrder::Ascending]);
             query.include_item_types = Some(vec![api::MediaType::Episode]);
             query.start_index = None;
             query.limit = Some(activity.len() as u32);
@@ -1905,9 +1909,6 @@ mod e2e_tests {
             insert_state(db, user.id, id, count, position, Some(date), Some(date))
                 .await;
         }
-        insert_state(db, user.id, next[1].id, 0, 0, None, None).await;
-        sqlx::query("UPDATE user_media_state SET favorite = 1 WHERE user_id = ? AND media_id = ?")
-            .bind(user.id).bind(next[1].id).execute(db).await.unwrap();
 
         // Default-off path already paginates in the database.
         let response = server
@@ -1937,6 +1938,23 @@ mod e2e_tests {
         db::Settings::set_config(db, &config)
             .await
             .unwrap();
+
+        // A genuinely untouched episode has no user_media_state row at all.
+        let response = server.get("/users/me/items/resume?Limit=12&Recursive=true&Fields=PrimaryImageAspectRatio&ImageTypeLimit=1&EnableImageTypes=Primary%2CBackdrop%2CThumb&EnableTotalRecordCount=false&MediaTypes=Video")
+            .add_header(http::header::AUTHORIZATION, auth.clone()).await;
+        response.assert_status_ok();
+        let body: serde_json::Value = response.json();
+        assert_eq!(
+            body["Items"][0]["Id"],
+            next[1]
+                .id
+                .simple()
+                .to_string()
+        );
+
+        insert_state(db, user.id, next[1].id, 0, 0, None, None).await;
+        sqlx::query("UPDATE user_media_state SET favorite = 1 WHERE user_id = ? AND media_id = ?")
+            .bind(user.id).bind(next[1].id).execute(db).await.unwrap();
 
         // Sorting, bounded-page dedup, scope, user data and actual premiere gating.
         for (query, expected) in [

--- a/crates/remux-server/src/api/users.rs
+++ b/crates/remux-server/src/api/users.rs
@@ -1481,7 +1481,7 @@ pub(crate) async fn resume_items(
             .user
             .policy
             .as_ref();
-        let next_up = next_up_candidates(
+        let mut next_up = next_up_candidates(
             &state,
             NextUpRequest {
                 user_id: session
@@ -1506,7 +1506,9 @@ pub(crate) async fn resume_items(
                     p.filter_rules
                         .clone()
                 }),
-                parent_id: q.parent_id,
+                // Apply scope through the normal item query below, which also
+                // understands recursive folders and collection membership.
+                parent_id: None,
                 // Injected into Continue Watching, not the standalone Next Up
                 // feed — must never show something that hasn't actually
                 // premiered, regardless of the server's release-date buffer.
@@ -1514,6 +1516,61 @@ pub(crate) async fn resume_items(
             },
         )
         .await?;
+
+        next_up.retain(|c| {
+            c.media
+                .grandparent_id
+                .is_some_and(|id| !represented_series.contains(&id))
+        });
+        if !next_up.is_empty() {
+            let mut eligible_query = q.clone();
+            eligible_query.filters = None;
+            eligible_query.start_index = None;
+            eligible_query.limit = None;
+            eligible_query.strict_item_filters = true;
+            eligible_query.include_item_types = Some(vec![api::MediaType::Episode]);
+            if let Some(term) = eligible_query
+                .search_term
+                .as_mut()
+            {
+                if !term.starts_with("local:") {
+                    *term = format!("local:{term}");
+                }
+            }
+            let ids: Vec<Uuid> = next_up
+                .iter()
+                .map(|c| {
+                    c.media
+                        .id
+                })
+                .filter(|id| {
+                    q.ids
+                        .as_ref()
+                        .is_none_or(|ids| ids.contains(id))
+                })
+                .collect();
+            if ids.is_empty() {
+                next_up.clear();
+            } else {
+                eligible_query.limit =
+                    Some(u32::try_from(ids.len()).unwrap_or(u32::MAX));
+                eligible_query.ids = Some(ids);
+                let eligible: HashSet<Uuid> =
+                    get_items(state.clone(), session.clone(), eligible_query, false)
+                        .await?
+                        .build()
+                        .items
+                        .into_iter()
+                        .map(|item| item.id)
+                        .collect();
+                next_up.retain(|c| {
+                    eligible.contains(
+                        &c.media
+                            .id,
+                    )
+                });
+            }
+        }
 
         // `items.total_count` is the true, unbounded resume total (a
         // separate COUNT(*) unaffected by the deliberately capped fetch
@@ -1552,7 +1609,7 @@ pub(crate) async fn resume_items(
                 .into_iter()
                 .zip(owned)
             {
-                slot.media = hydrated.media;
+                *slot = hydrated;
             }
         }
 
@@ -1578,12 +1635,7 @@ pub(crate) async fn resume_items(
         (items, total_record_count)
     } else {
         let total = items.total_count as i64;
-        let page = resume_items
-            .into_iter()
-            .skip(start_index)
-            .take(limit)
-            .collect();
-        (page, total)
+        (resume_items, total)
     };
 
     Ok(Json(api::BaseItemDtoQueryResult {
@@ -2154,6 +2206,10 @@ mod e2e_tests {
                 id: Uuid::new_v4(),
                 title: format!("{title} Ep {idx}"),
                 kind: db::MediaKind::Episode,
+                parent_id: Some(series.id),
+                released_at: Some(
+                    chrono::Utc::now().naive_utc() - chrono::Duration::days(30),
+                ),
                 grandparent_id: Some(series.id),
                 idx: Some(idx),
                 ..Default::default()
@@ -2291,6 +2347,116 @@ mod e2e_tests {
     }
 
     #[tokio::test]
+    async fn resume_disabled_paginates_only_once() {
+        let (server, guard, token) = authenticated_server().await;
+        let db = &guard
+            .0
+            .db;
+        let user: db::User = sqlx::query_as("SELECT * FROM users LIMIT 1")
+            .fetch_one(db)
+            .await
+            .unwrap();
+        let (_, episodes) = seed_series_with_episode_count(db, "Pagination", 3).await;
+        let now = chrono::Utc::now().naive_utc();
+        for (index, episode) in episodes
+            .iter()
+            .enumerate()
+        {
+            insert_state(
+                db,
+                user.id,
+                episode.id,
+                0,
+                100,
+                None,
+                Some(now - chrono::Duration::hours(index as i64)),
+            )
+            .await;
+        }
+        let response = server
+            .get("/users/me/items/resume?StartIndex=1&Limit=1")
+            .add_header(
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth_header_with_token(&token)).unwrap(),
+            )
+            .await;
+        response.assert_status_ok();
+        let body: serde_json::Value = response.json();
+        assert_eq!(
+            body["Items"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(
+            body["Items"][0]["Id"],
+            episodes[1]
+                .id
+                .simple()
+                .to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_injected_episode_preserves_favorite_and_request_scope() {
+        let (server, guard, token) = authenticated_server().await;
+        let db = &guard
+            .0
+            .db;
+        set_server_config(db, |cfg| {
+            cfg.enable_next_up_in_continue_watching = Some(true)
+        })
+        .await;
+        let user: db::User = sqlx::query_as("SELECT * FROM users LIMIT 1")
+            .fetch_one(db)
+            .await
+            .unwrap();
+        let (series, episodes) = seed_series_with_episode_count(db, "Scoped", 2).await;
+        let (other_series, _) = seed_series_with_episode_count(db, "Other", 1).await;
+        let now = chrono::Utc::now().naive_utc();
+        insert_state(db, user.id, episodes[0].id, 1, 0, Some(now), Some(now)).await;
+        insert_state(db, user.id, episodes[1].id, 0, 0, None, None).await;
+        sqlx::query("UPDATE user_media_state SET favorite = 1 WHERE user_id = ? AND media_id = ?")
+            .bind(user.id).bind(episodes[1].id).execute(db).await.unwrap();
+        for (query, expected_count) in [
+            (format!("SeriesId={}&IsFavorite=true", series.id), 1),
+            (format!("SeriesId={}", other_series.id), 0),
+            (format!("ParentId={}&Recursive=true", series.id), 1),
+            (format!("ParentId={}&Recursive=true", other_series.id), 0),
+            ("IsFavorite=false".to_string(), 0),
+        ] {
+            let response = server
+                .get(&format!("/users/me/items/resume?{query}"))
+                .add_header(
+                    http::header::AUTHORIZATION,
+                    HeaderValue::from_str(&auth_header_with_token(&token)).unwrap(),
+                )
+                .await;
+            response.assert_status_ok();
+            let body: serde_json::Value = response.json();
+            assert_eq!(
+                body["Items"]
+                    .as_array()
+                    .unwrap()
+                    .len(),
+                expected_count,
+                "{query}: {body}"
+            );
+            if expected_count == 1 {
+                assert_eq!(
+                    body["Items"][0]["Id"],
+                    episodes[1]
+                        .id
+                        .simple()
+                        .to_string()
+                );
+                assert_eq!(body["Items"][0]["UserData"]["IsFavorite"], true);
+            }
+        }
+    }
+
+    #[tokio::test]
     async fn resume_unified_next_up_respects_parental_rating_policy() {
         let (server, guard, token) = authenticated_server().await;
         let auth = auth_header_with_token(&token);
@@ -2391,7 +2557,8 @@ mod e2e_tests {
         )
         .await;
         let mut ep2 = eps[1].clone();
-        ep2.digital_released_at = Some(now + chrono::Duration::days(10));
+        ep2.digital_released_at = Some(now - chrono::Duration::days(1));
+        ep2.released_at = Some(now + chrono::Duration::days(10));
         ep2.save(db)
             .await
             .unwrap();

--- a/crates/remux-server/src/api/users.rs
+++ b/crates/remux-server/src/api/users.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::HashSet;
 
 use anyhow::Context;
 use axum::{
@@ -1389,7 +1389,7 @@ pub async fn users_views(
     userviews(State(state), session, Query(q)).await
 }
 
-async fn resume_items(
+pub(crate) async fn resume_items(
     state: AppState,
     session: auth::AuthSession,
     mut q: api::GetItemsQuery,
@@ -1415,20 +1415,121 @@ async fn resume_items(
     {
         q.sort_order = Some(vec![api::SortOrder::Descending]);
     }
-    let items = get_items(state.clone(), session.clone(), q.clone(), true)
+    let unified_next_up = db::Settings::get_config_or_default(
+        &state
+            .ctx
+            .db,
+    )
+    .await
+    .enable_next_up_in_continue_watching
+    .unwrap_or(false);
+    // Merge and rank before paginating so an injected new release can displace
+    // an older resume item on the first page.
+    let mut items_query = q.clone();
+    if unified_next_up {
+        items_query.start_index = None;
+        // Injected Next Up entries only push resume items down, never pull a
+        // later resume item into this page. Keep the database fetch bounded.
+        items_query.limit = Some(
+            q.start_index
+                .unwrap_or(0)
+                .saturating_add(
+                    q.limit
+                        .unwrap_or(50),
+                ),
+        );
+    }
+    let items = get_items(state.clone(), session.clone(), items_query, true)
         .await?
         .with_permissions()
         .with_client_patches()
         .build();
 
+    let mut resume_items = items.items;
+    if unified_next_up {
+        let next_up = crate::api::shows::next_up_candidates(
+            &state,
+            session
+                .user
+                .id,
+            false,
+            "1970-01-01 00:00:00".to_string(),
+        )
+        .await?
+        .into_iter()
+        .map(|candidate| {
+            (
+                api::db_media_to_item(candidate.media, false),
+                candidate.effective_activity,
+            )
+        });
+        resume_items = merge_continue_watching(resume_items, next_up);
+    }
+
+    let total_record_count = if unified_next_up {
+        resume_items.len() as i64
+    } else {
+        items.total_count as i64
+    };
+    let start_index = q
+        .start_index
+        .unwrap_or(0) as usize;
+    let limit = q
+        .limit
+        .unwrap_or(50) as usize;
+    let response_items = if unified_next_up {
+        resume_items
+            .into_iter()
+            .skip(start_index)
+            .take(limit)
+            .collect()
+    } else {
+        resume_items
+    };
+
     Ok(Json(api::BaseItemDtoQueryResult {
-        items: items.items,
-        total_record_count: items.total_count as i64,
-        start_index: q
-            .start_index
-            .unwrap_or(0),
+        items: response_items,
+        total_record_count,
+        start_index: start_index as u32,
         ..Default::default()
     }))
+}
+
+fn merge_continue_watching(
+    resume_items: Vec<api::BaseItemDto>,
+    next_up: impl IntoIterator<Item = (api::BaseItemDto, chrono::DateTime<chrono::Utc>)>,
+) -> Vec<api::BaseItemDto> {
+    let mut represented_series: HashSet<Uuid> = resume_items
+        .iter()
+        .filter_map(|item| item.series_id)
+        .collect();
+    let epoch = chrono::DateTime::from_timestamp(0, 0)
+        .expect("Unix epoch is a valid timestamp");
+    let mut ranked: Vec<(api::BaseItemDto, chrono::DateTime<chrono::Utc>)> =
+        resume_items
+            .into_iter()
+            .map(|item| {
+                let activity = item
+                    .user_data
+                    .as_ref()
+                    .and_then(|data| data.last_played_date)
+                    .unwrap_or(epoch);
+                (item, activity)
+            })
+            .collect();
+    for (item, activity) in next_up {
+        if item
+            .series_id
+            .is_some_and(|series_id| represented_series.insert(series_id))
+        {
+            ranked.push((item, activity));
+        }
+    }
+    ranked.sort_by(|(_, a), (_, b)| b.cmp(a));
+    ranked
+        .into_iter()
+        .map(|(item, _)| item)
+        .collect()
 }
 
 #[get("/users/{user_id}/items/resume")]
@@ -1751,6 +1852,57 @@ mod e2e_tests {
     };
     use http::header::HeaderValue;
     use serde_json::json;
+
+    #[test]
+    fn merge_continue_watching_deduplicates_series_and_orders_by_activity() {
+        let existing_series = Uuid::new_v4();
+        let injected_series = Uuid::new_v4();
+        let resume_episode_id = Uuid::new_v4();
+        let movie_id = Uuid::new_v4();
+        let duplicate_next_up_id = Uuid::new_v4();
+        let injected_next_up_id = Uuid::new_v4();
+        let at = |seconds| chrono::DateTime::from_timestamp(seconds, 0).unwrap();
+        let resume_episode = api::BaseItemDto {
+            id: resume_episode_id,
+            series_id: Some(existing_series),
+            user_data: Some(api::UserItemDataDto {
+                last_played_date: Some(at(100)),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let movie = api::BaseItemDto {
+            id: movie_id,
+            user_data: Some(api::UserItemDataDto {
+                last_played_date: Some(at(200)),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let duplicate_next_up = api::BaseItemDto {
+            id: duplicate_next_up_id,
+            series_id: Some(existing_series),
+            ..Default::default()
+        };
+        let injected_next_up = api::BaseItemDto {
+            id: injected_next_up_id,
+            series_id: Some(injected_series),
+            ..Default::default()
+        };
+
+        let merged = merge_continue_watching(
+            vec![resume_episode, movie],
+            vec![(duplicate_next_up, at(300)), (injected_next_up, at(400))],
+        );
+
+        assert_eq!(
+            merged
+                .iter()
+                .map(|item| item.id)
+                .collect::<Vec<_>>(),
+            vec![injected_next_up_id, movie_id, resume_episode_id]
+        );
+    }
 
     #[tokio::test]
     async fn test_authenticate_valid_credentials() {

--- a/crates/remux-server/src/db/media.rs
+++ b/crates/remux-server/src/db/media.rs
@@ -1984,13 +1984,7 @@ enum IdValue {
 }
 
 impl Media {
-    /// Every series that has at least one resumable (playback_position > 0)
-    /// episode for `user_id`, regardless of pagination — a cheap, unbounded
-    /// companion query to a windowed Resume-items fetch. Used to decide
-    /// whether a Next Up candidate's series is "already represented" without
-    /// that decision depending on how much of the Resume list was actually
-    /// fetched (see `find_by_external_ids` for the analogous "one query,
-    /// no per-item round trip" shape).
+    /// Series with in-progress episodes, including those outside the requested page.
     pub async fn resumable_series_ids(
         db: &SqlitePool,
         user_id: Uuid,
@@ -4375,22 +4369,44 @@ impl Media {
                     .is_some();
 
             if !container_only && has_policy {
-                push_policy_conditions(
-                    qb,
-                    filter.max_parental_rating,
-                    filter
-                        .blocked_tags
-                        .as_deref(),
-                    filter
-                        .allowed_tags
-                        .as_deref(),
-                    filter
-                        .policy_filter
-                        .as_ref(),
-                    filter
-                        .user_id
-                        .as_ref(),
-                );
+                if let Some(max_rating) = filter.max_parental_rating {
+                    qb.push(" AND COALESCE(certification_age, (SELECT p.certification_age FROM media p WHERE p.id = COALESCE(media.grandparent_id, media.parent_id))) <= ")
+                        .push_bind(max_rating)
+                        .push("");
+                }
+
+                if let Some(blocked) = &filter.blocked_tags {
+                    if !blocked.is_empty() {
+                        qb.push(" AND NOT EXISTS (SELECT 1 FROM media_tags mt WHERE mt.media_id = media.id AND mt.tag IN (");
+                        let mut sep = qb.separated(", ");
+                        for t in blocked {
+                            sep.push_bind(t);
+                        }
+                        qb.push("))");
+                    }
+                }
+
+                if let Some(allowed) = &filter.allowed_tags {
+                    if !allowed.is_empty() {
+                        qb.push(" AND EXISTS (SELECT 1 FROM media_tags mt WHERE mt.media_id = media.id AND mt.tag IN (");
+                        let mut sep = qb.separated(", ");
+                        for t in allowed {
+                            sep.push_bind(t);
+                        }
+                        qb.push("))");
+                    }
+                }
+
+                if let Some(ref f) = filter.policy_filter {
+                    apply_filter_rules(
+                        qb,
+                        f,
+                        filter
+                            .user_id
+                            .as_ref(),
+                        false,
+                    );
+                }
             }
 
             // Hide specific collections from browse views per the user's
@@ -7552,53 +7568,6 @@ fn collection_visibility_filters(
 /// - `tag` — `media.id IN (SELECT media_id FROM media_tags WHERE ...)`
 /// - `genre` / `studio` / `country` / `person` — `media.id IN (SELECT left_media_id FROM media_relations JOIN media WHERE ...)`
 /// - `catalog` / `collection_member` — `media.id IN (SELECT right_media_id FROM media_relations WHERE ...)`
-/// Appends parental-rating / blocked-tag / allowed-tag / policy-filter-rule
-/// conditions for the bare `media` table referenced in `qb`. Shared by
-/// `get_by_filter_inner` and any other raw query (e.g. `next_up_candidates`)
-/// that needs to enforce the same content-visibility policy a user's normal
-/// browsing already gets — assumes the query's base table is literally named
-/// `media` (not aliased), matching every current caller.
-pub fn push_policy_conditions<'a>(
-    qb: &mut sqlx::QueryBuilder<'a, sqlx::Sqlite>,
-    max_parental_rating: Option<i32>,
-    blocked_tags: Option<&'a [String]>,
-    allowed_tags: Option<&'a [String]>,
-    policy_filter: Option<&remux_sdks::remux::CollectionFilter>,
-    user_id: Option<&Uuid>,
-) {
-    if let Some(max_rating) = max_parental_rating {
-        qb.push(" AND COALESCE(certification_age, (SELECT p.certification_age FROM media p WHERE p.id = COALESCE(media.grandparent_id, media.parent_id))) <= ")
-            .push_bind(max_rating)
-            .push("");
-    }
-
-    if let Some(blocked) = blocked_tags {
-        if !blocked.is_empty() {
-            qb.push(" AND NOT EXISTS (SELECT 1 FROM media_tags mt WHERE mt.media_id = media.id AND mt.tag IN (");
-            let mut sep = qb.separated(", ");
-            for t in blocked {
-                sep.push_bind(t);
-            }
-            qb.push("))");
-        }
-    }
-
-    if let Some(allowed) = allowed_tags {
-        if !allowed.is_empty() {
-            qb.push(" AND EXISTS (SELECT 1 FROM media_tags mt WHERE mt.media_id = media.id AND mt.tag IN (");
-            let mut sep = qb.separated(", ");
-            for t in allowed {
-                sep.push_bind(t);
-            }
-            qb.push("))");
-        }
-    }
-
-    if let Some(f) = policy_filter {
-        apply_filter_rules(qb, f, user_id, false);
-    }
-}
-
 /// - `has_trailer` — json_array_length check
 pub fn apply_filter_rules(
     qb: &mut sqlx::QueryBuilder<sqlx::Sqlite>,

--- a/crates/remux-server/src/db/media.rs
+++ b/crates/remux-server/src/db/media.rs
@@ -1984,6 +1984,31 @@ enum IdValue {
 }
 
 impl Media {
+    /// Every series that has at least one resumable (playback_position > 0)
+    /// episode for `user_id`, regardless of pagination — a cheap, unbounded
+    /// companion query to a windowed Resume-items fetch. Used to decide
+    /// whether a Next Up candidate's series is "already represented" without
+    /// that decision depending on how much of the Resume list was actually
+    /// fetched (see `find_by_external_ids` for the analogous "one query,
+    /// no per-item round trip" shape).
+    pub async fn resumable_series_ids(
+        db: &SqlitePool,
+        user_id: Uuid,
+    ) -> Result<std::collections::HashSet<Uuid>> {
+        let ids: Vec<Uuid> = sqlx::query_scalar(
+            "SELECT DISTINCT m.grandparent_id FROM user_media_state ums \
+             JOIN media m ON m.id = ums.media_id \
+             WHERE ums.user_id = ? AND ums.playback_position > 0 \
+             AND m.grandparent_id IS NOT NULL",
+        )
+        .bind(user_id)
+        .fetch_all(db)
+        .await?;
+        Ok(ids
+            .into_iter()
+            .collect())
+    }
+
     pub fn is_live(&self) -> bool {
         self.kind == MediaKind::TvChannel
     }
@@ -4350,44 +4375,22 @@ impl Media {
                     .is_some();
 
             if !container_only && has_policy {
-                if let Some(max_rating) = filter.max_parental_rating {
-                    qb.push(" AND COALESCE(certification_age, (SELECT p.certification_age FROM media p WHERE p.id = COALESCE(media.grandparent_id, media.parent_id))) <= ")
-                        .push_bind(max_rating)
-                        .push("");
-                }
-
-                if let Some(blocked) = &filter.blocked_tags {
-                    if !blocked.is_empty() {
-                        qb.push(" AND NOT EXISTS (SELECT 1 FROM media_tags mt WHERE mt.media_id = media.id AND mt.tag IN (");
-                        let mut sep = qb.separated(", ");
-                        for t in blocked {
-                            sep.push_bind(t);
-                        }
-                        qb.push("))");
-                    }
-                }
-
-                if let Some(allowed) = &filter.allowed_tags {
-                    if !allowed.is_empty() {
-                        qb.push(" AND EXISTS (SELECT 1 FROM media_tags mt WHERE mt.media_id = media.id AND mt.tag IN (");
-                        let mut sep = qb.separated(", ");
-                        for t in allowed {
-                            sep.push_bind(t);
-                        }
-                        qb.push("))");
-                    }
-                }
-
-                if let Some(ref f) = filter.policy_filter {
-                    apply_filter_rules(
-                        qb,
-                        f,
-                        filter
-                            .user_id
-                            .as_ref(),
-                        false,
-                    );
-                }
+                push_policy_conditions(
+                    qb,
+                    filter.max_parental_rating,
+                    filter
+                        .blocked_tags
+                        .as_deref(),
+                    filter
+                        .allowed_tags
+                        .as_deref(),
+                    filter
+                        .policy_filter
+                        .as_ref(),
+                    filter
+                        .user_id
+                        .as_ref(),
+                );
             }
 
             // Hide specific collections from browse views per the user's
@@ -7549,6 +7552,53 @@ fn collection_visibility_filters(
 /// - `tag` — `media.id IN (SELECT media_id FROM media_tags WHERE ...)`
 /// - `genre` / `studio` / `country` / `person` — `media.id IN (SELECT left_media_id FROM media_relations JOIN media WHERE ...)`
 /// - `catalog` / `collection_member` — `media.id IN (SELECT right_media_id FROM media_relations WHERE ...)`
+/// Appends parental-rating / blocked-tag / allowed-tag / policy-filter-rule
+/// conditions for the bare `media` table referenced in `qb`. Shared by
+/// `get_by_filter_inner` and any other raw query (e.g. `next_up_candidates`)
+/// that needs to enforce the same content-visibility policy a user's normal
+/// browsing already gets — assumes the query's base table is literally named
+/// `media` (not aliased), matching every current caller.
+pub fn push_policy_conditions<'a>(
+    qb: &mut sqlx::QueryBuilder<'a, sqlx::Sqlite>,
+    max_parental_rating: Option<i32>,
+    blocked_tags: Option<&'a [String]>,
+    allowed_tags: Option<&'a [String]>,
+    policy_filter: Option<&remux_sdks::remux::CollectionFilter>,
+    user_id: Option<&Uuid>,
+) {
+    if let Some(max_rating) = max_parental_rating {
+        qb.push(" AND COALESCE(certification_age, (SELECT p.certification_age FROM media p WHERE p.id = COALESCE(media.grandparent_id, media.parent_id))) <= ")
+            .push_bind(max_rating)
+            .push("");
+    }
+
+    if let Some(blocked) = blocked_tags {
+        if !blocked.is_empty() {
+            qb.push(" AND NOT EXISTS (SELECT 1 FROM media_tags mt WHERE mt.media_id = media.id AND mt.tag IN (");
+            let mut sep = qb.separated(", ");
+            for t in blocked {
+                sep.push_bind(t);
+            }
+            qb.push("))");
+        }
+    }
+
+    if let Some(allowed) = allowed_tags {
+        if !allowed.is_empty() {
+            qb.push(" AND EXISTS (SELECT 1 FROM media_tags mt WHERE mt.media_id = media.id AND mt.tag IN (");
+            let mut sep = qb.separated(", ");
+            for t in allowed {
+                sep.push_bind(t);
+            }
+            qb.push("))");
+        }
+    }
+
+    if let Some(f) = policy_filter {
+        apply_filter_rules(qb, f, user_id, false);
+    }
+}
+
 /// - `has_trailer` — json_array_length check
 pub fn apply_filter_rules(
     qb: &mut sqlx::QueryBuilder<sqlx::Sqlite>,


### PR DESCRIPTION
Adds an off-by-default General setting, `enable_next_up_in_continue_watching`, that combines Resume with Next Up. A started series without an in-progress episode contributes its next released episode, ranked by the newer of series playback activity and episode release time. The aggregate Next Up endpoint returns empty while enabled; per-series Next Up lookups still work.

Both feeds share the existing Next Up selector and normal item-query builder for scope, policy, images, user data, and client permissions. Continue Watching merges the results before pagination, with a separate series-ID query to avoid duplicates outside the fetched page.

Regression coverage exercises default-off pagination, merged ordering/counts, rewatch deduplication, future premieres, request scope, favorites, policy restrictions, and aggregate versus per-series Next Up behavior.
