### PR TITLE
perf: speed up metadata refresh

### DIFF
--- a/crates/remux-sdks/src/lib.rs
+++ b/crates/remux-sdks/src/lib.rs
@@ -11,7 +11,6 @@ pub mod trakt;
 
 mod rate_limit;
 
-use bytes::Bytes;
 use http::{Extensions, HeaderMap, HeaderValue, Method, header};
 use itertools::Itertools;
 use remux_utils::Secret;
@@ -21,12 +20,7 @@ use reqwest_retry::{RetryPolicy, RetryTransientMiddleware};
 use serde::{Deserialize, Deserializer, Serialize, de::DeserializeOwned};
 use std::{collections::HashMap, fmt, iter, ops, sync::Arc, time::Duration};
 #[cfg(not(target_arch = "wasm32"))]
-use {
-    async_trait::async_trait,
-    md5,
-    remux_utils::Store,
-    reqwest_middleware::{Middleware, Next},
-};
+use {md5, remux_utils::Store};
 
 #[cfg(not(target_arch = "wasm32"))]
 static HTTP_CACHE: std::sync::LazyLock<Store> =
@@ -40,16 +34,22 @@ pub fn clear_http_cache() {
     HTTP_CACHE.clear();
 }
 
-/// Returns `(entry_count, weighted_size)` for the HTTP response cache.
+/// Returns `(entry_count, weighted_size)` for the deserialized response cache.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn http_cache_stats() -> (u64, u64) {
     (HTTP_CACHE.entry_count(), HTTP_CACHE.weighted_size())
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn hash_key(key: &str) -> String {
-    let result = md5::compute(key.as_bytes());
-    format!("{:x}", result)
+fn cache_key<T>(url: &str) -> String {
+    // A URL can legitimately be decoded into more than one output type (for
+    // example an endpoint wrapped in `Option<T>`). Keep those entries apart so
+    // `Store::get` is always a typed cache hit rather than a downcast miss.
+    format!(
+        "{}:{:x}",
+        std::any::type_name::<T>(),
+        md5::compute(url.as_bytes())
+    )
 }
 
 pub trait Auth: Send + Sync + Clone {
@@ -290,95 +290,6 @@ pub trait Endpoint {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
-#[derive(Clone, Copy)]
-struct CacheTTL(Duration);
-
-#[cfg(not(target_arch = "wasm32"))]
-#[derive(Clone)]
-struct CachedResponse {
-    status: u16,
-    body: String,
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-struct InMemoryCacheMiddleware;
-
-#[cfg(not(target_arch = "wasm32"))]
-#[async_trait]
-impl Middleware for InMemoryCacheMiddleware {
-    async fn handle(
-        &self,
-        req: reqwest::Request,
-        extensions: &mut Extensions,
-        next: Next<'_>,
-    ) -> reqwest_middleware::Result<reqwest::Response> {
-        let ttl = extensions
-            .get::<CacheTTL>()
-            .copied();
-        // Derive the cache key from the pre-redirect URL so hits are consistent
-        // regardless of whether the server redirects the request.
-        let key = ttl.map(|_| {
-            hash_key(
-                req.url()
-                    .as_str(),
-            )
-        });
-
-        if let Some(ref k) = key {
-            if let Some(cached) = HTTP_CACHE.get::<CachedResponse>(k) {
-                let resp = http::Response::builder()
-                    .status(cached.status)
-                    .header(header::CONTENT_TYPE, "application/json")
-                    .body(Bytes::from(
-                        cached
-                            .body
-                            .clone(),
-                    ))
-                    .unwrap();
-                return Ok(reqwest::Response::from(resp));
-            }
-        }
-
-        let resp = next
-            .run(req, extensions)
-            .await?;
-
-        if let (Some(CacheTTL(ttl)), Some(k)) = (ttl, key) {
-            if resp
-                .status()
-                .is_success()
-            {
-                let status = resp.status();
-                let text = resp
-                    .text()
-                    .await
-                    .map_err(reqwest_middleware::Error::Reqwest)?;
-                let weight = text
-                    .len()
-                    .min(u32::MAX as usize) as u32;
-                HTTP_CACHE.save_arc_with_weight(
-                    k,
-                    Arc::new(CachedResponse {
-                        status: status.as_u16(),
-                        body: text.clone(),
-                    }),
-                    weight,
-                    ttl,
-                );
-                let rebuilt = http::Response::builder()
-                    .status(status)
-                    .header(header::CONTENT_TYPE, "application/json")
-                    .body(Bytes::from(text))
-                    .unwrap();
-                return Ok(reqwest::Response::from(rebuilt));
-            }
-        }
-
-        Ok(resp)
-    }
-}
-
 struct DynRetryPolicy(Arc<dyn RetryPolicy + Send + Sync>);
 
 impl RetryPolicy for DynRetryPolicy {
@@ -396,10 +307,6 @@ fn build_mw(
     retry: Option<Arc<dyn RetryPolicy + Send + Sync>>,
     default_retry_after: Duration,
 ) -> ClientWithMiddleware {
-    #[cfg(not(target_arch = "wasm32"))]
-    let builder =
-        MwClientBuilder::new(SHARED_HTTP_CLIENT.clone()).with(InMemoryCacheMiddleware);
-    #[cfg(target_arch = "wasm32")]
     let builder = MwClientBuilder::new(SHARED_HTTP_CLIENT.clone());
     let builder = match retry {
         Some(policy) => builder.with(
@@ -516,6 +423,17 @@ impl<A: Auth + Clone> RestClient<A> {
             url.set_query(Some(&qs));
         }
 
+        #[cfg(not(target_arch = "wasm32"))]
+        let cache_key = endpoint
+            .cache_options()
+            .map(|_| cache_key::<EP::Output>(url.as_str()));
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(ref key) = cache_key {
+            if let Some(cached) = HTTP_CACHE.get::<EP::Output>(key) {
+                return Ok(cached);
+            }
+        }
+
         let mut req = SHARED_HTTP_CLIENT
             .request(endpoint.method(), url.clone())
             .headers(endpoint.headers());
@@ -553,11 +471,6 @@ impl<A: Auth + Clone> RestClient<A> {
             .map_err(ClientError::Transport)?;
 
         let mut ext = Extensions::new();
-        #[cfg(not(target_arch = "wasm32"))]
-        if let Some(opts) = endpoint.cache_options() {
-            ext.insert(CacheTTL(opts.ttl));
-        }
-
         let resp = self
             .mw
             .execute_with_extensions(request, &mut ext)
@@ -607,11 +520,8 @@ impl<A: Auth + Clone> RestClient<A> {
                         .len()
                         .min(u32::MAX as usize) as u32;
                     HTTP_CACHE.save_arc_with_weight(
-                        hash_key(url.as_str()),
-                        Arc::new(CachedResponse {
-                            status: s,
-                            body: text,
-                        }),
+                        cache_key.expect("cache key exists for a cacheable response"),
+                        Arc::clone(&arc),
                         weight,
                         ttl,
                     );
@@ -631,11 +541,8 @@ impl<A: Auth + Clone> RestClient<A> {
                 #[cfg(not(target_arch = "wasm32"))]
                 if let Some(ttl) = endpoint.should_cache(&arc) {
                     HTTP_CACHE.save_arc_with_weight(
-                        hash_key(url.as_str()),
-                        Arc::new(CachedResponse {
-                            status: s,
-                            body: "null".to_string(),
-                        }),
+                        cache_key.expect("cache key exists for a cacheable response"),
+                        Arc::clone(&arc),
                         4,
                         ttl,
                     );
@@ -1113,6 +1020,26 @@ mod cache_tests {
             .await
             .unwrap();
         assert_eq!(mock.hits(), 2, "asked again once the short TTL was up");
+    }
+
+    #[tokio::test]
+    async fn cached_execute_arc_reuses_the_deserialized_value() {
+        let server = httpmock::MockServer::start();
+        let (mock, client, probe) =
+            probe(&server, "typed-arc", serde_json::json!(["found"]));
+        let endpoint = probe.with_cache(NEVER);
+
+        let first = client
+            .execute_arc(endpoint.clone())
+            .await
+            .unwrap();
+        let second = client
+            .execute_arc(endpoint)
+            .await
+            .unwrap();
+
+        assert_eq!(mock.hits(), 1);
+        assert!(Arc::ptr_eq(&first, &second));
     }
 
     #[tokio::test]

--- a/crates/remux-sdks/src/tmdb/mod.rs
+++ b/crates/remux-sdks/src/tmdb/mod.rs
@@ -53,6 +53,7 @@ pub enum ExternalIdType {
 pub struct FindByIdResponse {
     pub movie_results: Vec<Movie>,
     pub tv_results: Vec<Series>,
+    pub tv_episode_results: Vec<series::Episode>,
 }
 
 // pub fn get_endpoint_for_media_type(t: media::MediaType) -> tmdb::MediaEndpoint {

--- a/crates/remux-sdks/src/tmdb/mod.rs
+++ b/crates/remux-sdks/src/tmdb/mod.rs
@@ -51,8 +51,11 @@ pub enum ExternalIdType {
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct FindByIdResponse {
+    #[serde(default)]
     pub movie_results: Vec<Movie>,
+    #[serde(default)]
     pub tv_results: Vec<Series>,
+    #[serde(default)]
     pub tv_episode_results: Vec<series::Episode>,
 }
 

--- a/crates/remux-server/src/addons/mod.rs
+++ b/crates/remux-server/src/addons/mod.rs
@@ -1888,13 +1888,19 @@ impl AddonService {
         // every addon in this batch sees the fuller id set rather than each
         // doing its own partial, addon-specific resolution.
         let resolve_started = Instant::now();
-        // External IDs are identity data. Keep this as a backfill-only operation:
-        // a metadata force refresh must not fan out into an external-ID request for
-        // every already-identified child item.
-        MediaResolveService::resolve_external_ids(media, ctx, false).await;
+        // Seasons and episodes already carry the TMDB identity needed by their
+        // metadata providers. Do not turn a metadata tree refresh into a
+        // per-child external-ID enrichment job; that remains available to
+        // explicit callers of `resolve_external_ids` when it is actually needed.
+        let resolves_external_ids =
+            !matches!(media.kind, db::MediaKind::Season | db::MediaKind::Episode);
+        if resolves_external_ids {
+            MediaResolveService::resolve_external_ids(media, ctx, false).await;
+        }
         trace!(
             target: "remux_server::metadata_refresh",
             id = %media.id,
+            resolves_external_ids,
             elapsed = ?resolve_started.elapsed(),
             "refresh_meta: external ID resolution complete"
         );

--- a/crates/remux-server/src/addons/mod.rs
+++ b/crates/remux-server/src/addons/mod.rs
@@ -1909,21 +1909,12 @@ impl AddonService {
             .addons_for::<dyn MetaAddon>(media, &ctx.db, None)
             .await;
 
-        let addon_names = applicable
-            .iter()
-            .map(|r| {
-                r.row
-                    .name
-                    .as_str()
-            })
-            .collect::<Vec<_>>()
-            .join(", ");
         trace!(
             target: "remux_server::metadata_refresh",
             id = %media.id,
             title = %media.title,
             kind = %media.kind,
-            addons = %addon_names,
+            addons = %applicable.iter().map(|r| r.row.name.as_str()).collect::<Vec<_>>().join(", "),
             "metadata refresh addons selected"
         );
 

--- a/crates/remux-server/src/addons/mod.rs
+++ b/crates/remux-server/src/addons/mod.rs
@@ -32,7 +32,7 @@ use std::{
 
 use crate::keyed_lock::KeyedLock;
 use libc;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, trace, warn};
 use uuid::Uuid;
 
 use crate::{
@@ -1864,37 +1864,118 @@ impl AddonService {
         force_refresh: bool,
         config: &api::ServerConfiguration,
     ) -> Result<()> {
+        trace!(
+            target: "remux_server::metadata_refresh",
+            id = %media.id,
+            title = %media.title,
+            kind = %media.kind,
+            force_refresh,
+            "metadata refresh starting"
+        );
+        let grandparent_started = Instant::now();
         media
             .grandparent(&ctx.db)
             .await
             .ok();
+        trace!(
+            target: "remux_server::metadata_refresh",
+            id = %media.id,
+            elapsed = ?grandparent_started.elapsed(),
+            "refresh_meta: grandparent lookup complete"
+        );
 
         // Fill in whatever external ids we can before any addon runs, so
         // every addon in this batch sees the fuller id set rather than each
         // doing its own partial, addon-specific resolution.
-        MediaResolveService::resolve_missing_external_ids(media, ctx).await;
+        let resolve_started = Instant::now();
+        // External IDs are identity data. Keep this as a backfill-only operation:
+        // a metadata force refresh must not fan out into an external-ID request for
+        // every already-identified child item.
+        MediaResolveService::resolve_external_ids(media, ctx, false).await;
+        trace!(
+            target: "remux_server::metadata_refresh",
+            id = %media.id,
+            elapsed = ?resolve_started.elapsed(),
+            "refresh_meta: external ID resolution complete"
+        );
 
         let applicable = self
             .addons_for::<dyn MetaAddon>(media, &ctx.db, None)
             .await;
+
+        let addon_names = applicable
+            .iter()
+            .map(|r| {
+                r.row
+                    .name
+                    .as_str()
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        trace!(
+            target: "remux_server::metadata_refresh",
+            id = %media.id,
+            title = %media.title,
+            kind = %media.kind,
+            addons = %addon_names,
+            "metadata refresh addons selected"
+        );
 
         if applicable.is_empty() {
             return Ok(());
         }
 
         let fetch_started = std::time::Instant::now();
+        let media_ref: &db::Media = media;
         let results = futures::future::join_all(
             applicable
                 .iter()
                 .map(|r| {
-                    r.meta
-                        .as_ref()
-                        .unwrap()
-                        .meta_fetch(media, ctx, config)
+                    let addon = r
+                        .row
+                        .name
+                        .clone();
+                    async move {
+                        let addon_started = Instant::now();
+                        trace!(
+                            target: "remux_server::metadata_refresh",
+                            id = %media_ref.id,
+                            title = %media_ref.title,
+                            kind = %media_ref.kind,
+                            addon = %addon,
+                            "metadata addon request starting"
+                        );
+                        let result = r
+                            .meta
+                            .as_ref()
+                            .unwrap()
+                            .meta_fetch(media_ref, ctx, config)
+                            .await;
+                        trace!(
+                            target: "remux_server::metadata_refresh",
+                            id = %media_ref.id,
+                            addon = %addon,
+                            elapsed = ?addon_started.elapsed(),
+                            success = result.is_ok(),
+                            "refresh_meta: addon meta_fetch complete"
+                        );
+                        trace!(
+                            target: "remux_server::metadata_refresh",
+                            id = %media_ref.id,
+                            title = %media_ref.title,
+                            kind = %media_ref.kind,
+                            addon = %addon,
+                            elapsed = ?addon_started.elapsed(),
+                            success = result.is_ok(),
+                            "metadata addon request complete"
+                        );
+                        result
+                    }
                 }),
         )
         .await;
-        debug!(
+        trace!(
+            target: "remux_server::metadata_refresh",
             id = %media.id,
             title = %media.title,
             kind = %media.kind,
@@ -2068,6 +2149,13 @@ impl AddonService {
         let concurrency = config
             .meta_concurrency
             .max(1) as usize;
+        trace!(
+            target: "remux_server::metadata_refresh",
+            items = media.len(),
+            force_refresh,
+            concurrency,
+            "processing metadata batch"
+        );
         let config = Arc::new(config);
         // Shared across this whole batch — top-level items, and every season/
         // episode any of them refreshes — so nested fan-out inside a single
@@ -2216,10 +2304,25 @@ impl AddonService {
             .kind
             .clone();
         let started = std::time::Instant::now();
+        trace!(
+            target: "remux_server::metadata_refresh",
+            id = %media.id,
+            title = %title,
+            kind = %kind,
+            force_refresh,
+            "top-level metadata item starting"
+        );
         let id = self
             .process_meta_item_inner(media, ctx, force_refresh, config, semaphore)
             .await;
-        debug!(%id, %title, %kind, elapsed = ?started.elapsed(), "process_meta_item done");
+        trace!(
+            target: "remux_server::metadata_refresh",
+            %id,
+            %title,
+            %kind,
+            elapsed = ?started.elapsed(),
+            "process_meta_item done"
+        );
         id
     }
 
@@ -2245,12 +2348,33 @@ impl AddonService {
         let original_id = media.id;
 
         let root_refresh_result = {
+            let permit_wait_started = Instant::now();
             let _permit = semaphore
                 .acquire()
                 .await
                 .expect("semaphore is never closed");
-            self.refresh_meta(&mut media, &ctx, force_refresh, &config)
-                .await
+            trace!(
+                target: "remux_server::metadata_refresh",
+                id = %media.id,
+                title = %media.title,
+                kind = %media.kind,
+                wait_elapsed = ?permit_wait_started.elapsed(),
+                "top-level metadata item acquired refresh slot"
+            );
+            let refresh_started = Instant::now();
+            let result = self
+                .refresh_meta(&mut media, &ctx, force_refresh, &config)
+                .await;
+            trace!(
+                target: "remux_server::metadata_refresh",
+                id = %media.id,
+                title = %media.title,
+                kind = %media.kind,
+                elapsed = ?refresh_started.elapsed(),
+                success = result.is_ok(),
+                "top-level metadata item root refresh complete"
+            );
+            result
         };
         if let Err(e) = root_refresh_result {
             warn!(id = %media.id, error = %e, "failed to refresh metadata, keeping as-is");

--- a/crates/remux-server/src/addons/tmdb.rs
+++ b/crates/remux-server/src/addons/tmdb.rs
@@ -1276,7 +1276,7 @@ async fn fetch_tmdb_meta(
 
     match media.kind {
         db::MediaKind::Movie => {
-            // `resolve_missing_external_ids` (called at the top of
+            // `resolve_external_ids` (called at the top of
             // `refresh_meta`, before any addon runs) already resolves a
             // tmdb id from whatever else is known, if one is resolvable at
             // all — nothing left to discover here.
@@ -1465,7 +1465,7 @@ async fn fetch_tmdb_meta(
             }
         }
         db::MediaKind::Series => {
-            // `resolve_missing_external_ids` (called at the top of
+            // `resolve_external_ids` (called at the top of
             // `refresh_meta`, before any addon runs) already resolves a
             // tmdb id from whatever else is known, if one is resolvable at
             // all — nothing left to discover here.
@@ -1731,26 +1731,7 @@ async fn fetch_tmdb_meta(
                 else {
                     return Ok(None);
                 };
-                let mut patch = db::Media::from(ep);
-                match client
-                    .execute(
-                        sdks::tmdb::EpisodeExternalIdsEndpoint {
-                            series_id: tmdb_id,
-                            season_number: s_n,
-                            episode_number: e_n,
-                        }
-                        .with_cache(Duration::from_secs(360)),
-                    )
-                    .await
-                {
-                    Ok(ids) => patch
-                        .external_ids
-                        .merge(&tmdb_external_ids(ep.id, Some(&ids)), true),
-                    Err(error) => {
-                        warn!(%error, series_id = tmdb_id, season = s_n, episode = e_n, "TMDB episode external IDs unavailable")
-                    }
-                }
-                return Ok(Some(patch));
+                return Ok(Some(db::Media::from(ep)));
             }
         }
         db::MediaKind::Season => {

--- a/crates/remux-server/src/services/resolve.rs
+++ b/crates/remux-server/src/services/resolve.rs
@@ -29,6 +29,9 @@ fn find_matched_nothing(found: &sdks::tmdb::FindByIdResponse) -> bool {
         && found
             .tv_results
             .is_empty()
+        && found
+            .tv_episode_results
+            .is_empty()
 }
 
 /// The ids the call was for are not there: no such episode, or one TMDB knows
@@ -322,10 +325,12 @@ impl MediaResolveService {
         }
     }
 
-    /// Fills in whichever of tmdb/imdb/tvdb are missing on `media`, using
-    /// only the calls actually needed — an item with everything already
-    /// resolved makes no network calls at all. Movies only ever get
-    /// tmdb/imdb (TVDB doesn't track movies); tvdb is Series-only.
+    /// Resolves external IDs on `media`.
+    ///
+    /// With `force_refresh` disabled, makes only the calls needed to fill a
+    /// missing ID. With it enabled, re-fetches IDs that TMDB can authoritatively
+    /// provide. Movies only ever get tmdb/imdb (TVDB doesn't track movies);
+    /// TVDB is Series- and Episode-only.
     ///
     /// Deliberately does not attempt to backfill a missing kitsu id: kitsu
     /// only matters for anime, which we can't tell from ids alone at this
@@ -344,7 +349,59 @@ impl MediaResolveService {
     /// `external_ids` sub-resource returns imdb *and* tvdb together in one
     /// call — there's no pair
     /// of independent lookups left to run concurrently once that's used.
-    pub async fn resolve_missing_external_ids(media: &mut db::Media, ctx: &AppContext) {
+    pub async fn resolve_external_ids(
+        media: &mut db::Media,
+        ctx: &AppContext,
+        force_refresh: bool,
+    ) {
+        if media.kind == db::MediaKind::Episode {
+            let needs_ids = force_refresh
+                || media
+                    .external_ids
+                    .imdb
+                    .is_none()
+                || media
+                    .external_ids
+                    .tvdb
+                    .is_none();
+            if !needs_ids {
+                return;
+            }
+            let Some(client) = Self::tmdb(ctx).await else {
+                return;
+            };
+            let series_tmdb = if let Some(series_tmdb) =
+                Self::stored_series_tmdb_id(media, ctx)
+                    .await
+                    .ok()
+                    .flatten()
+            {
+                series_tmdb
+            } else {
+                let Some((episode_tmdb, series_tmdb)) =
+                    Self::find_episode_tmdb_ids(&media.external_ids, &client).await
+                else {
+                    return;
+                };
+                media
+                    .external_ids
+                    .tmdb = Some(episode_tmdb);
+                series_tmdb
+            };
+            let (Some(season), Some(episode)) = (media.parent_idx, media.idx) else {
+                return;
+            };
+            let Ok(Some(ids)) =
+                Self::episode_external_ids(series_tmdb, season, episode, &client).await
+            else {
+                return;
+            };
+            media
+                .external_ids
+                .merge(&ids, force_refresh);
+            return;
+        }
+
         if !matches!(media.kind, db::MediaKind::Movie | db::MediaKind::Series) {
             return;
         }
@@ -362,7 +419,7 @@ impl MediaResolveService {
                 .external_ids
                 .tvdb
                 .is_none();
-        if !needs_tmdb && !needs_imdb && !needs_tvdb {
+        if !force_refresh && !needs_tmdb && !needs_imdb && !needs_tvdb {
             return;
         }
         let Some(client) = Self::tmdb(ctx).await else {
@@ -397,17 +454,18 @@ impl MediaResolveService {
             .external_ids
             .tmdb = Some(tmdb_id);
 
-        if needs_imdb || needs_tvdb {
+        if force_refresh || needs_imdb || needs_tvdb {
             if is_tv {
                 if let Ok(series) = client
                     .execute(series_ids_endpoint(tmdb_id).with_cache(ID_CACHE_TTL))
                     .await
                     && let Some(e) = series.external_ids
                 {
-                    if media
-                        .external_ids
-                        .imdb
-                        .is_none()
+                    if force_refresh
+                        || media
+                            .external_ids
+                            .imdb
+                            .is_none()
                     {
                         media
                             .external_ids
@@ -415,17 +473,18 @@ impl MediaResolveService {
                             .imdb_id
                             .and_then(|s| db::NonEmptyString::try_new(s).ok());
                     }
-                    if media
-                        .external_ids
-                        .tvdb
-                        .is_none()
+                    if force_refresh
+                        || media
+                            .external_ids
+                            .tvdb
+                            .is_none()
                     {
                         media
                             .external_ids
                             .tvdb = e.tvdb_id;
                     }
                 }
-            } else if needs_imdb
+            } else if (force_refresh || needs_imdb)
                 && let Ok(movie) = client
                     .execute(movie_ids_endpoint(tmdb_id).with_cache(ID_CACHE_TTL))
                     .await
@@ -499,6 +558,42 @@ impl MediaResolveService {
                 .next()
                 .map(|m| m.id)
         })
+    }
+
+    /// Finds an episode's TMDB id and its parent series id from the episode's
+    /// own IMDb or TVDB id. `/find` accepts either ID without requiring a
+    /// resolved parent series first.
+    async fn find_episode_tmdb_ids<A: sdks::Auth + Clone>(
+        ids: &db::ExternalIds,
+        client: &RestClient<A>,
+    ) -> Option<(i64, i64)> {
+        let (external_id, external_source) =
+            Self::tmdb_search_key(ids, Some(&sdks::kitsu::client())).await?;
+        let found = client
+            .execute(
+                sdks::tmdb::FindByIdEndpoint {
+                    external_id,
+                    external_source: external_source.to_string(),
+                }
+                .with_cache(ID_CACHE_TTL)
+                .should_cache(|r| {
+                    Some(if find_matched_nothing(r) {
+                        ID_MISS_CACHE_TTL
+                    } else {
+                        ID_CACHE_TTL
+                    })
+                }),
+            )
+            .await
+            .ok()?;
+        found
+            .tv_episode_results
+            .into_iter()
+            .find_map(|episode| {
+                episode
+                    .show_id
+                    .map(|series_id| (episode.id, series_id))
+            })
     }
 
     /// The series' TMDB id, from whatever else it carries. Kitsu comes last:
@@ -1901,6 +1996,7 @@ mod tests {
         assert!(!find_matched_nothing(&sdks::tmdb::FindByIdResponse {
             movie_results: vec![sdks::tmdb::Movie::default()],
             tv_results: vec![],
+            ..Default::default()
         }));
     }
 
@@ -2487,7 +2583,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_missing_external_ids_fills_tmdb_and_tvdb_from_imdb_alone() {
+    async fn resolve_external_ids_fills_tmdb_and_tvdb_from_imdb_alone() {
         let tmdb = httpmock::MockServer::start();
         tmdb.mock(|when, then| {
             when.path("/find/tt0306414")
@@ -2518,7 +2614,7 @@ mod tests {
         )
         .await;
 
-        MediaResolveService::resolve_missing_external_ids(&mut media, ctx).await;
+        MediaResolveService::resolve_external_ids(&mut media, ctx, false).await;
 
         assert_eq!(
             media
@@ -2542,7 +2638,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_missing_external_ids_is_a_noop_when_nothing_is_missing() {
+    async fn resolve_external_ids_is_a_noop_when_nothing_is_missing() {
         // No mocks registered at all — any request would fail the test by
         // connection refused, proving no network call is made when every id
         // this kind cares about is already present.
@@ -2564,8 +2660,69 @@ mod tests {
             .external_ids
             .clone();
 
-        MediaResolveService::resolve_missing_external_ids(&mut media, ctx).await;
+        MediaResolveService::resolve_external_ids(&mut media, ctx, false).await;
 
         assert_eq!(media.external_ids, before);
+    }
+
+    #[tokio::test]
+    async fn resolve_external_ids_fills_missing_episode_ids() {
+        let tmdb = httpmock::MockServer::start();
+        let request = tmdb.mock(|when, then| {
+            when.path("/tv/1438/season/1/episode/1");
+            then.status(200)
+                .json_body(serde_json::json!({
+                    "id": 972467,
+                    "name": "The Target",
+                    "episode_number": 1,
+                    "season_number": 1,
+                    "external_ids": {
+                        "imdb_id": "tt0749419",
+                        "tvdb_id": 303821,
+                    },
+                }));
+        });
+        let guard = ctx_with_tmdb(&tmdb).await;
+        let ctx = &guard.0;
+        let mut episode = db::Media {
+            title: "The Target".into(),
+            kind: db::MediaKind::Episode,
+            parent_idx: Some(1),
+            idx: Some(1),
+            grandparent: Some(Box::new(db::Media {
+                title: "The Wire".into(),
+                kind: db::MediaKind::Series,
+                external_ids: db::ExternalIds {
+                    tmdb: Some(1438),
+                    ..Default::default()
+                },
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+
+        MediaResolveService::resolve_external_ids(&mut episode, ctx, false).await;
+
+        assert_eq!(request.hits(), 1);
+        assert_eq!(
+            episode
+                .external_ids
+                .tmdb,
+            Some(972467)
+        );
+        assert_eq!(
+            episode
+                .external_ids
+                .imdb
+                .as_deref()
+                .map(String::as_str),
+            Some("tt0749419")
+        );
+        assert_eq!(
+            episode
+                .external_ids
+                .tvdb,
+            Some(303821)
+        );
     }
 }

--- a/crates/remux-server/src/services/resolve.rs
+++ b/crates/remux-server/src/services/resolve.rs
@@ -358,6 +358,10 @@ impl MediaResolveService {
             let needs_ids = force_refresh
                 || media
                     .external_ids
+                    .tmdb
+                    .is_none()
+                || media
+                    .external_ids
                     .imdb
                     .is_none()
                 || media

--- a/crates/remux-server/src/tasks/refresh_all_meta.rs
+++ b/crates/remux-server/src/tasks/refresh_all_meta.rs
@@ -4,6 +4,7 @@ use std::sync::{
     Arc,
     atomic::{AtomicUsize, Ordering},
 };
+use tracing::trace;
 
 use super::{ProgressReporter, Task, TaskCategory, TaskService};
 use crate::{AppContext, db};
@@ -36,6 +37,8 @@ impl Task for RefreshAllMetaTask {
     ) -> Result<()> {
         const CHUNK_SIZE: u32 = 100;
 
+        let task_started = std::time::Instant::now();
+        let count_started = std::time::Instant::now();
         let total: i64 =
             sqlx::query_scalar("SELECT COUNT(*) FROM media WHERE kind IN (?, ?, ?, ?)")
                 .bind(db::MediaKind::Movie)
@@ -45,6 +48,13 @@ impl Task for RefreshAllMetaTask {
                 .fetch_one(&ctx.db)
                 .await?;
         let total = total as usize;
+        trace!(
+            target: "remux_server::metadata_refresh",
+            total,
+            elapsed = ?count_started.elapsed(),
+            chunk_size = CHUNK_SIZE,
+            "starting full metadata refresh"
+        );
 
         // Shared counter incremented per item inside process_meta_batch so progress
         // updates as each concurrent item finishes, not once per full 100-item batch.
@@ -62,7 +72,9 @@ impl Task for RefreshAllMetaTask {
         // Cursor-based pagination: WHERE id > last_id guarantees forward progress even
         // when refresh fails and refreshed_at is not updated for an item.
         let mut last_id: Option<uuid::Uuid> = None;
+        let mut batches = 0usize;
         loop {
+            let fetch_started = std::time::Instant::now();
             let batch = if let Some(cursor) = last_id {
                 sqlx::query_as::<_, db::Media>(
                     "SELECT * FROM media WHERE kind IN (?, ?, ?, ?) AND id > ? ORDER BY id LIMIT ?",
@@ -91,13 +103,42 @@ impl Task for RefreshAllMetaTask {
             if batch.is_empty() {
                 break;
             }
+            batches += 1;
+            let batch_len = batch.len();
+            let fetch_elapsed = fetch_started.elapsed();
+            trace!(
+                target: "remux_server::metadata_refresh",
+                batch = batches,
+                items = batch_len,
+                processed = processed.load(Ordering::Relaxed),
+                fetch_elapsed = ?fetch_elapsed,
+                "full metadata refresh batch starting"
+            );
             last_id = batch
                 .last()
                 .map(|m| m.id);
+            let process_started = std::time::Instant::now();
             ctx.addons
                 .process_meta_batch(batch, &ctx, true, Some(Arc::clone(&on_item_done)))
                 .await?;
+            trace!(
+                target: "remux_server::metadata_refresh",
+                batch = batches,
+                items = batch_len,
+                processed = processed.load(Ordering::Relaxed),
+                fetch_elapsed = ?fetch_elapsed,
+                process_elapsed = ?process_started.elapsed(),
+                "full metadata refresh batch complete"
+            );
         }
+        trace!(
+            target: "remux_server::metadata_refresh",
+            total,
+            processed = processed.load(Ordering::Relaxed),
+            batches,
+            elapsed = ?task_started.elapsed(),
+            "full metadata refresh complete"
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- cache deserialized SDK responses instead of JSON bodies
- reuse parsed TMDB season data across episode refreshes
- skip external-ID resolution for season and episode metadata refreshes

## Validation
- observed episode metadata fetches fall from ~22ms to ~0.3ms during a live library refresh