### PR TITLE
fix: index symlinked files in opendal-local scan (fixes #460)

### DIFF
--- a/crates/remux-server/src/addons/opendal.rs
+++ b/crates/remux-server/src/addons/opendal.rs
@@ -1122,11 +1122,21 @@ async fn scan_addon(
             .try_next()
             .await?
         {
-            if entry
+            // The lister classifies entries from a raw readdir() call, which does not
+            // follow symlinks and reports them as EntryMode::Unknown. Resolve those
+            // via stat() (which does follow symlinks) so symlinked media files staged
+            // by tools like Sonarr/Radarr + a debrid manager are indexed correctly.
+            let mode = entry
                 .metadata()
-                .mode()
-                != EntryMode::FILE
-            {
+                .mode();
+            let is_file = mode == EntryMode::FILE
+                || (mode == EntryMode::Unknown
+                    && operator
+                        .stat(entry.path())
+                        .await
+                        .map(|m| m.mode() == EntryMode::FILE)
+                        .unwrap_or(false));
+            if !is_file {
                 continue;
             }
 


### PR DESCRIPTION
## Summary

`scan_addon`'s opendal-local scanner filters directory entries for `EntryMode::FILE` and drops everything else. opendal's local Fs service classifies entries using `DirEntry::file_type()` from a raw `readdir()` call, which does not follow symlinks, so a symlink to a regular file comes back as `EntryMode::Unknown` instead of `FILE`. It gets skipped with no log output at any level.

This breaks any local library staged via symlinks, which is the standard pattern for Sonarr/Radarr plus a debrid manager (e.g. Decypharr's `default_download_action: symlink`).

## Fix

When an entry's mode is `Unknown`, resolve it with `operator.stat()` instead of assuming it should be skipped. Unlike the lister's cached `readdir()` classification, opendal's `Fs::stat()` is backed by `tokio::fs::metadata()`, which does follow symlinks. If the resolved metadata says `FILE`, the entry gets indexed like any other file.

The symlink's own path and name are what continue through identification (hunch parsing, `[imdbid-...]` extraction, etc). Only the mode gets re-resolved, so this doesn't change how files are named or matched, just whether symlinks are considered at all. Directories aren't affected here, since a symlink to a directory was already being handled correctly per the original report.

This only adds an extra `stat()` call for the Unknown case, i.e. only for symlinks and other special files, not for every entry, so there's no real overhead for ordinary regular-file libraries.

## Testing

Tested against a real opendal-local movie addon whose configured root (`/mnt/symlib/films/spanish`) currently contains a title that's purely a symlink (the folder has no regular file, just a `.mp4` symlink into an rclone-mounted debrid path, the same shape as the issue's repro). Built the release binary from this branch, rebuilt the Docker image, and ran it in place of the production container with the same volumes and env (`RUST_LOG=debug`):

- Before the fix: the addon's scan produced `upserted=0` for that symlink-only entry, no log line at any level, matching the report.
- After the fix: the scan logs show the entry going through hunch parsing (`release group - found ["tt0133093"]`, title `"The Matrix"`), it gets inserted into `opendal_files`, and the addon's scan reports `upserted=1`.

Fixes #460.