### PR TITLE
fix(sessions): persist stop reports that arrive without a play session

### DIFF
--- a/crates/remux-server/src/api/session.rs
+++ b/crates/remux-server/src/api/session.rs
@@ -21,6 +21,7 @@ use crate::{
     db,
     db::auth,
     playback::session::TranscodeSession,
+    playback_session,
     services::{self, MediaResolveService},
     signals::{
         Event, PlaybackContext, RemoteCommandInfo, RemotePlayInfo, RemotePlaystateInfo,
@@ -300,6 +301,39 @@ pub async fn report_playback_stopped(
                     ..pctx
                 }));
         }
+    } else if !data
+        .item_id
+        .is_nil()
+    {
+        // No play session to attach this stop to: the client never reported a
+        // start and sent no `PlaySessionId`. The stop
+        // still names the item and the position, and Jellyfin persists it
+        // regardless of session state, so record it the same way.
+        let position_ticks = data
+            .position_ticks
+            .unwrap_or(0);
+        let played = playback_session::PlaybackSessionManager::persist_stop(
+            &state
+                .ctx
+                .db,
+            &session.user,
+            Some(data.item_id),
+            data.position_ticks,
+        )
+        .await
+        .context_internal("failed to record stop")?;
+        state
+            .ctx
+            .signals
+            .emit(Event::PlaybackStopped(PlaybackContext {
+                user_id: session
+                    .user
+                    .id,
+                media_id: data.item_id,
+                position_ticks,
+                played,
+                ..PlaybackContext::from_parts(&session, &data, None, None)
+            }));
     }
     Ok(StatusCode::NO_CONTENT.into_response())
 }
@@ -1355,6 +1389,126 @@ mod tests {
             "invalid"
                 .parse::<PlaystateCommand>()
                 .is_err()
+        );
+    }
+}
+
+#[cfg(test)]
+mod e2e_tests {
+    use crate::integration_test::{
+        auth_header_with_token, authenticated_server, seed_movie,
+    };
+    use http::{StatusCode, header::HeaderValue};
+    use serde_json::json;
+
+    /// Some clients never call `/sessions/playing` or
+    /// `/sessions/playing/progress`; their only report is the stop, carrying
+    /// the item id and position but no `PlaySessionId`. That report must still
+    /// create a resume point, as it does on Jellyfin.
+    #[tokio::test]
+    async fn stop_report_without_play_session_creates_resume_point() {
+        let (server, ctx, token) = authenticated_server().await;
+        let auth = auth_header_with_token(&token);
+        let media = seed_movie(&ctx.0).await;
+        let item_id = media
+            .id
+            .simple()
+            .to_string();
+        let position_ticks: i64 = 600 * 10_000_000;
+
+        let resp = server
+            .post("/sessions/playing/stopped")
+            .add_header(
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth).unwrap(),
+            )
+            .json(&json!({
+                "ItemId": item_id,
+                "PositionTicks": position_ticks,
+                "CanSeek": true,
+                "IsPaused": false,
+                "IsMuted": false,
+            }))
+            .await;
+        resp.assert_status(StatusCode::NO_CONTENT);
+
+        let resp = server
+            .get("/users/me/items/resume")
+            .add_header(
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth).unwrap(),
+            )
+            .await;
+        resp.assert_status_ok();
+        let body: serde_json::Value = resp.json();
+        let items = body["Items"]
+            .as_array()
+            .unwrap();
+        assert_eq!(
+            items.len(),
+            1,
+            "a session-less stop report must still land in Continue Watching"
+        );
+        assert_eq!(
+            items[0]["Id"]
+                .as_str()
+                .unwrap(),
+            item_id
+        );
+        assert_eq!(
+            items[0]["UserData"]["PlaybackPositionTicks"]
+                .as_i64()
+                .unwrap(),
+            position_ticks
+        );
+    }
+
+    /// A session-less stop under the resume threshold on an item with no prior
+    /// state must leave no trace: no resume point, and no `LastPlayedDate`
+    /// either — Jellyfin only writes that on playback start, which such a
+    /// client never sends, and some clients render "last played, position 0, not
+    /// played" as a fully watched episode.
+    #[tokio::test]
+    async fn abandoned_stop_report_without_play_session_leaves_no_state() {
+        let (server, ctx, token) = authenticated_server().await;
+        let auth = auth_header_with_token(&token);
+        let media = seed_movie(&ctx.0).await;
+        let item_id = media
+            .id
+            .simple()
+            .to_string();
+        // 60 s into a 6000 s movie: 1 %, under the 5 % default.
+        let resp = server
+            .post("/sessions/playing/stopped")
+            .add_header(
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth).unwrap(),
+            )
+            .json(&json!({
+                "ItemId": item_id,
+                "PositionTicks": 60 * 10_000_000i64,
+                "CanSeek": true,
+                "IsPaused": false,
+                "IsMuted": false,
+            }))
+            .await;
+        resp.assert_status(StatusCode::NO_CONTENT);
+
+        let resp = server
+            .get(&format!("/items/{item_id}"))
+            .add_header(
+                http::header::AUTHORIZATION,
+                HeaderValue::from_str(&auth).unwrap(),
+            )
+            .await;
+        resp.assert_status_ok();
+        let body: serde_json::Value = resp.json();
+        let user_data = &body["UserData"];
+        assert_eq!(user_data["PlaybackPositionTicks"].as_i64(), Some(0));
+        assert_eq!(user_data["Played"].as_bool(), Some(false));
+        assert!(
+            user_data["LastPlayedDate"].is_null(),
+            "no LastPlayedDate for an abandoned session-less play: {user_data}"
         );
     }
 }

--- a/crates/remux-server/src/db/user.rs
+++ b/crates/remux-server/src/db/user.rs
@@ -935,6 +935,33 @@ impl UserMediaState {
         Ok(ms)
     }
 
+    /// True when this state records nothing a client could act on: never
+    /// played, no resume point, no favourite, no rating, no remembered
+    /// stream/track selection. Such a row is not worth creating.
+    pub fn is_blank(&self) -> bool {
+        self.play_count == 0
+            && self
+                .played_at
+                .is_none()
+            && self.playback_position == 0
+            && !self.favorite
+            && self
+                .rating
+                .is_none()
+            && self
+                .stream_id
+                .is_none()
+            && self
+                .audio_idx
+                .is_none()
+            && self
+                .subtitle_idx
+                .is_none()
+            && self
+                .last_played_at
+                .is_none()
+    }
+
     /// Jellyfin does not persist `Likes`; it derives it from the rating.
     pub fn likes(&self) -> Option<bool> {
         self.rating
@@ -1009,6 +1036,14 @@ impl UserMediaState {
                 .await?;
             } else if no_resume {
                 ms.playback_position = 0;
+                // Nothing kept and nothing known before: don't create a row.
+                // A row would only carry a fresh `last_played_at`, which
+                // Jellyfin never writes on a stop (that comes from playback
+                // start), and some clients read "last played, position
+                // 0, not played" as a fully watched episode.
+                if ms.is_blank() {
+                    return Ok(false);
+                }
                 ms.save(db)
                     .await?;
             } else {

--- a/crates/remux-server/src/playback_session.rs
+++ b/crates/remux-server/src/playback_session.rs
@@ -446,24 +446,45 @@ impl PlaybackSessionManager {
                     .map(|s| s.position_ticks)
             });
 
-        let mut played = false;
-        if let Some(item_id) = item_id {
-            if let Ok(Some(media)) = db::Media::get_by_id(db, &item_id).await {
-                played = db::UserMediaState::update_playback(
-                    db,
-                    user,
-                    &media,
-                    final_ticks.unwrap_or(0),
-                    None, // don't overwrite stream selections on stop
-                    None,
-                    media.runtime, // Some(runtime) triggers watched-threshold check
-                )
-                .await?;
-            }
-        }
+        let played = Self::persist_stop(db, user, item_id, final_ticks).await?;
 
         debug!(play_session_id = psid, "Playback stopped");
         Ok(played)
+    }
+
+    /// Persist the final position of a stop report (with the 90 % watched-mark
+    /// check) for `item_id`, if it names a known media row.
+    ///
+    /// Shared by session-backed stops and stop reports that arrive without any
+    /// play session: some clients never call
+    /// `/sessions/playing` or `/sessions/playing/progress` and their only
+    /// report is the stop, carrying the item id and position but no
+    /// `PlaySessionId`. Jellyfin persists that report regardless of session
+    /// state, so dropping it would lose Continue Watching for those clients.
+    ///
+    /// Returns whether this stop crossed the watched threshold.
+    pub async fn persist_stop(
+        db: &sqlx::SqlitePool,
+        user: &db::User,
+        item_id: Option<uuid::Uuid>,
+        final_ticks: Option<i64>,
+    ) -> anyhow::Result<bool> {
+        let Some(item_id) = item_id else {
+            return Ok(false);
+        };
+        let Ok(Some(media)) = db::Media::get_by_id(db, &item_id).await else {
+            return Ok(false);
+        };
+        db::UserMediaState::update_playback(
+            db,
+            user,
+            &media,
+            final_ticks.unwrap_or(0),
+            None, // don't overwrite stream selections on stop
+            None,
+            media.runtime, // Some(runtime) triggers watched-threshold check
+        )
+        .await
     }
 
     /// Insert (or replace) a playback session, preserving any transcode that was


### PR DESCRIPTION
Some clients report playback with a single `/Sessions/Playing/Stopped` call: no `/Sessions/Playing` first, and no `PlaySessionId` on the stop. `report_playback_stopped` only persists when it can find a session for the report, so it returns 204 and discards it. Nothing is written for the play: no resume point, no watched mark. Jellyfin saves a stop report whether or not a session exists.

Fix: move the persist step out of `PlaybackSessionManager::stopped` into `persist_stop`, and call it from the handler when there is no session but the report names an item. If the stop is under the resume threshold and the item has no state yet, nothing is written (`UserMediaState::is_blank`); Jellyfin sets `LastPlayedDate` on playback start, not on stop, so a row here would carry a date it shouldn't. Two e2e tests, the first fails on `main`. Full suite green.

`POST /Sessions/Playing/Stopped` with `ItemId` and `PositionTicks`, no `PlaySessionId`:

```
/UserItems/Resume   before: 0 items   after: 1 item at the reported position
```

Written with Claude Code; I reviewed and tested it on my own instance.
