### PR TITLE
fix(playback): honor the probe fallback on the stream request that follows

### DIFF
--- a/crates/remux-server/src/api/playback.rs
+++ b/crates/remux-server/src/api/playback.rs
@@ -846,20 +846,6 @@ fn ext_from_descriptor(descriptor: &crate::stream::StreamDescriptor) -> String {
     }
 }
 
-/// Which id the stream request resolves: a specific stream when the client
-/// named one, otherwise the probe fallback remembered for the play session
-/// (if any), otherwise whatever the client sent (item id or nothing).
-fn stream_lookup_id(
-    item_id: Uuid,
-    media_source_id: Option<Uuid>,
-    probe_fallback: Option<Uuid>,
-) -> Option<Uuid> {
-    match media_source_id {
-        Some(sid) if sid != item_id => Some(sid),
-        auto_play => probe_fallback.or(auto_play),
-    }
-}
-
 async fn videos_stream_inner(
     headers: headers::HeaderMap,
     state: AppState,
@@ -867,15 +853,24 @@ async fn videos_stream_inner(
     id: Uuid,
     q: api::VideoStreamQuery,
 ) -> Result<impl IntoResponse> {
-    // Auto-play names the item, not a stream (MediaSourceId absent or == id).
-    // If PlaybackInfo's probe fell over to another stream for this play
-    // session, follow it; the lookup below would otherwise land on the first
-    // source — the one that just failed to probe.
+    // Auto-play and stream-group requests name an id the client echoes back
+    // (the item id, or the group id), not a stream. If PlaybackInfo's probe
+    // fell over to another stream for that id in this play session, follow
+    // it; the lookup below would otherwise land on the first candidate — the
+    // one that just failed to probe. A specific stream named by the client
+    // has no such record and stands.
     let probe_fallback = q
         .play_session_id
         .as_deref()
-        .and_then(|psid| StreamService::probe_fallback_for(&state.ctx, psid));
-    let requested_id = stream_lookup_id(id, q.media_source_id, probe_fallback);
+        .and_then(|psid| {
+            StreamService::probe_fallback_for(
+                &state.ctx,
+                psid,
+                q.media_source_id
+                    .unwrap_or(id),
+            )
+        });
+    let requested_id = probe_fallback.or(q.media_source_id);
     let media = StreamService::lookup(
         &state.ctx,
         id,
@@ -1257,30 +1252,6 @@ mod tests {
         super::apply_item_runtime_fallback(&mut source, Some(142));
 
         assert_eq!(source.run_time_ticks, Some(1_420_000_000));
-    }
-
-    #[test]
-    fn stream_request_follows_probe_fallback_only_for_auto_play() {
-        let item = uuid::Uuid::new_v4();
-        let stream = uuid::Uuid::new_v4();
-        let fallback = uuid::Uuid::new_v4();
-        // Client named a stream: its choice stands.
-        assert_eq!(
-            super::stream_lookup_id(item, Some(stream), Some(fallback)),
-            Some(stream)
-        );
-        // Auto-play (MediaSourceId == item id, or absent) follows the fallback.
-        assert_eq!(
-            super::stream_lookup_id(item, Some(item), Some(fallback)),
-            Some(fallback)
-        );
-        assert_eq!(
-            super::stream_lookup_id(item, None, Some(fallback)),
-            Some(fallback)
-        );
-        // No fallback recorded: unchanged.
-        assert_eq!(super::stream_lookup_id(item, Some(item), None), Some(item));
-        assert_eq!(super::stream_lookup_id(item, None, None), None);
     }
 
     #[test]

--- a/crates/remux-server/src/api/playback.rs
+++ b/crates/remux-server/src/api/playback.rs
@@ -272,6 +272,7 @@ async fn items_playbackinfo_inner(
     let probed = service
         .probe_candidates()
         .await?;
+    service.save_probe_fallback(&play_session_id, &probed);
     let specific_stream_requested = probed.specific_requested;
     let mut media_sources = Vec::with_capacity(
         probed
@@ -845,6 +846,20 @@ fn ext_from_descriptor(descriptor: &crate::stream::StreamDescriptor) -> String {
     }
 }
 
+/// Which id the stream request resolves: a specific stream when the client
+/// named one, otherwise the probe fallback remembered for the play session
+/// (if any), otherwise whatever the client sent (item id or nothing).
+fn stream_lookup_id(
+    item_id: Uuid,
+    media_source_id: Option<Uuid>,
+    probe_fallback: Option<Uuid>,
+) -> Option<Uuid> {
+    match media_source_id {
+        Some(sid) if sid != item_id => Some(sid),
+        auto_play => probe_fallback.or(auto_play),
+    }
+}
+
 async fn videos_stream_inner(
     headers: headers::HeaderMap,
     state: AppState,
@@ -852,10 +867,19 @@ async fn videos_stream_inner(
     id: Uuid,
     q: api::VideoStreamQuery,
 ) -> Result<impl IntoResponse> {
+    // Auto-play names the item, not a stream (MediaSourceId absent or == id).
+    // If PlaybackInfo's probe fell over to another stream for this play
+    // session, follow it; the lookup below would otherwise land on the first
+    // source — the one that just failed to probe.
+    let probe_fallback = q
+        .play_session_id
+        .as_deref()
+        .and_then(|psid| StreamService::probe_fallback_for(&state.ctx, psid));
+    let requested_id = stream_lookup_id(id, q.media_source_id, probe_fallback);
     let media = StreamService::lookup(
         &state.ctx,
         id,
-        q.media_source_id,
+        requested_id,
         q.device_id
             .as_deref(),
         user_id,
@@ -1233,6 +1257,30 @@ mod tests {
         super::apply_item_runtime_fallback(&mut source, Some(142));
 
         assert_eq!(source.run_time_ticks, Some(1_420_000_000));
+    }
+
+    #[test]
+    fn stream_request_follows_probe_fallback_only_for_auto_play() {
+        let item = uuid::Uuid::new_v4();
+        let stream = uuid::Uuid::new_v4();
+        let fallback = uuid::Uuid::new_v4();
+        // Client named a stream: its choice stands.
+        assert_eq!(
+            super::stream_lookup_id(item, Some(stream), Some(fallback)),
+            Some(stream)
+        );
+        // Auto-play (MediaSourceId == item id, or absent) follows the fallback.
+        assert_eq!(
+            super::stream_lookup_id(item, Some(item), Some(fallback)),
+            Some(fallback)
+        );
+        assert_eq!(
+            super::stream_lookup_id(item, None, Some(fallback)),
+            Some(fallback)
+        );
+        // No fallback recorded: unchanged.
+        assert_eq!(super::stream_lookup_id(item, Some(item), None), Some(item));
+        assert_eq!(super::stream_lookup_id(item, None, None), None);
     }
 
     #[test]

--- a/crates/remux-server/src/services/stream_service.rs
+++ b/crates/remux-server/src/services/stream_service.rs
@@ -662,12 +662,16 @@ impl StreamService {
     /// plays at once. Keying on the play session id (minted by PlaybackInfo
     /// and echoed by every Jellyfin client on the stream URL) ties the two
     /// requests together without needing a device id, which not every client
-    /// sends on stream URLs. No-op when nothing fell over or the client named
-    /// a specific stream.
+    /// sends on stream URLs. A stream-group request answers with the group id
+    /// the same way, so the record is keyed by the id the client echoes back:
+    /// the item id, or the group id. No-op when nothing fell over or the
+    /// client named a specific stream.
     pub fn save_probe_fallback(&self, play_session_id: &str, probed: &ProbedStreams) {
-        if probed.specific_requested {
-            return;
-        }
+        let source_id = match &self.group {
+            Some((gid, _, _)) => *gid,
+            None if probed.specific_requested => return,
+            None => self.item_id,
+        };
         let Some(first) = probed
             .results
             .first()
@@ -686,7 +690,7 @@ impl StreamService {
         self.ctx
             .store
             .save(
-                Self::probe_fallback_key(play_session_id),
+                Self::probe_fallback_key(play_session_id, source_id),
                 first
                     .effective_stream
                     .id,
@@ -694,15 +698,20 @@ impl StreamService {
             );
     }
 
-    /// The stream PlaybackInfo's probe fell over to for `play_session_id`, if any.
-    pub fn probe_fallback_for(ctx: &AppContext, play_session_id: &str) -> Option<Uuid> {
+    /// The stream PlaybackInfo's probe fell over to when it answered
+    /// `play_session_id` with `source_id` (the item id or a group id), if any.
+    pub fn probe_fallback_for(
+        ctx: &AppContext,
+        play_session_id: &str,
+        source_id: Uuid,
+    ) -> Option<Uuid> {
         ctx.store
-            .get::<Uuid>(Self::probe_fallback_key(play_session_id))
+            .get::<Uuid>(Self::probe_fallback_key(play_session_id, source_id))
             .map(|id| *id)
     }
 
-    fn probe_fallback_key(play_session_id: &str) -> String {
-        format!("pstream:psid:{play_session_id}")
+    fn probe_fallback_key(play_session_id: &str, source_id: Uuid) -> String {
+        format!("pstream:psid:{play_session_id}:{source_id}")
     }
 
     /// Persist the resolved stream UUID in the device-preference store (24 h TTL).
@@ -1189,27 +1198,33 @@ mod tests {
         // Fell over to `alive`: remembered under the play session.
         service.save_probe_fallback("psid-fallback", &probed(&alive, false));
         assert_eq!(
-            StreamService::probe_fallback_for(ctx, "psid-fallback"),
+            StreamService::probe_fallback_for(ctx, "psid-fallback", owner.id),
             Some(alive.id)
         );
         // First source probed fine: nothing to remember.
         service.save_probe_fallback("psid-clean", &probed(&dead, false));
-        assert_eq!(StreamService::probe_fallback_for(ctx, "psid-clean"), None);
+        assert_eq!(
+            StreamService::probe_fallback_for(ctx, "psid-clean", owner.id),
+            None
+        );
         // Client named a specific stream: its choice stands, nothing remembered.
         service.save_probe_fallback("psid-specific", &probed(&alive, true));
         assert_eq!(
-            StreamService::probe_fallback_for(ctx, "psid-specific"),
+            StreamService::probe_fallback_for(ctx, "psid-specific", owner.id),
             None
         );
         // Unknown session: nothing.
-        assert_eq!(StreamService::probe_fallback_for(ctx, "psid-unknown"), None);
+        assert_eq!(
+            StreamService::probe_fallback_for(ctx, "psid-unknown", owner.id),
+            None
+        );
     }
 
     /// With stream groups on, the initial PlaybackInfo lists one representative
     /// stream per group and is not a specific request, so a fallback is
-    /// remembered exactly as without groups. A request for a group by its UUID
-    /// is specific: nothing is remembered and the stream request keeps
-    /// resolving the group itself.
+    /// remembered under the item id exactly as without groups. A request for a
+    /// group by its UUID answers with the group id, so its fallback is
+    /// remembered under the group id.
     #[tokio::test]
     async fn probe_fallback_with_stream_groups() {
         use crate::integration_test::{
@@ -1248,7 +1263,7 @@ mod tests {
         service
             .save_probe_fallback("psid-grouped", &probed(selection.specific_requested));
         assert_eq!(
-            StreamService::probe_fallback_for(ctx, "psid-grouped"),
+            StreamService::probe_fallback_for(ctx, "psid-grouped", owner.id),
             Some(alive.id)
         );
 
@@ -1275,8 +1290,8 @@ mod tests {
             &probed(selection.specific_requested),
         );
         assert_eq!(
-            StreamService::probe_fallback_for(ctx, "psid-group-request"),
-            None
+            StreamService::probe_fallback_for(ctx, "psid-group-request", group_a),
+            Some(alive.id)
         );
     }
 }

--- a/crates/remux-server/src/services/stream_service.rs
+++ b/crates/remux-server/src/services/stream_service.rs
@@ -650,6 +650,61 @@ impl StreamService {
         })
     }
 
+    /// Remember that the probe fell over from the client-facing first source
+    /// to `effective_stream` for this play session.
+    ///
+    /// PlaybackInfo stamps `MediaSources[0].Id` with the item id, so a client
+    /// that auto-plays comes back to `/videos/{id}/stream` naming the item,
+    /// not a stream. `dispatch_lookup` treats that as "first source" — the
+    /// very stream that just failed to probe — and the fallback PlaybackInfo
+    /// chose is lost: the stream request hangs on the dead source until the
+    /// upstream timeout and fails, while the second source, picked by hand,
+    /// plays at once. Keying on the play session id (minted by PlaybackInfo
+    /// and echoed by every Jellyfin client on the stream URL) ties the two
+    /// requests together without needing a device id, which not every client
+    /// sends on stream URLs. No-op when nothing fell over or the client named
+    /// a specific stream.
+    pub fn save_probe_fallback(&self, play_session_id: &str, probed: &ProbedStreams) {
+        if probed.specific_requested {
+            return;
+        }
+        let Some(first) = probed
+            .results
+            .first()
+        else {
+            return;
+        };
+        if first
+            .effective_stream
+            .id
+            == first
+                .stream
+                .id
+        {
+            return;
+        }
+        self.ctx
+            .store
+            .save(
+                Self::probe_fallback_key(play_session_id),
+                first
+                    .effective_stream
+                    .id,
+                std::time::Duration::from_secs(24 * 3600),
+            );
+    }
+
+    /// The stream PlaybackInfo's probe fell over to for `play_session_id`, if any.
+    pub fn probe_fallback_for(ctx: &AppContext, play_session_id: &str) -> Option<Uuid> {
+        ctx.store
+            .get::<Uuid>(Self::probe_fallback_key(play_session_id))
+            .map(|id| *id)
+    }
+
+    fn probe_fallback_key(play_session_id: &str) -> String {
+        format!("pstream:psid:{play_session_id}")
+    }
+
     /// Persist the resolved stream UUID in the device-preference store (24 h TTL).
     /// Also records the group→item association so /Items/{group_uuid} can redirect
     /// to the correct content item without a DB scan.
@@ -1097,5 +1152,56 @@ mod tests {
             ..Default::default()
         });
         assert!(media_info_from_probe(&probe_with_size(1), &stream, None).is_none());
+    }
+
+    /// A probe fallback must reach the stream request that follows PlaybackInfo.
+    /// That request names the item, not a stream, so without this the resolver
+    /// serves the first source — the one that just failed — and playback hangs
+    /// until the upstream timeout while the second source, picked by hand, plays.
+    #[tokio::test]
+    async fn probe_fallback_is_remembered_per_play_session() {
+        use crate::integration_test::{
+            authenticated_server, insert_test_source, seed_movie,
+        };
+        let (_server, guard, _token) = authenticated_server().await;
+        let ctx = &guard.0;
+        let owner = seed_movie(ctx).await;
+        let dead = insert_test_source(ctx).await;
+        let alive = insert_test_source(ctx).await;
+        assert_ne!(dead.id, alive.id);
+        let service = StreamService::new(StreamServiceConfig {
+            ctx: ctx.clone(),
+            item_id: owner.id,
+            requested_id: None,
+            show_ungrouped: true,
+            stream_filter: None,
+            user_id: None,
+        });
+        let probed = |effective: &db::Media, specific_requested: bool| ProbedStreams {
+            results: vec![ProbeResult {
+                source: api::MediaSourceInfo::from(dead.clone()),
+                stream: dead.clone(),
+                effective_stream: effective.clone(),
+            }],
+            specific_requested,
+        };
+
+        // Fell over to `alive`: remembered under the play session.
+        service.save_probe_fallback("psid-fallback", &probed(&alive, false));
+        assert_eq!(
+            StreamService::probe_fallback_for(ctx, "psid-fallback"),
+            Some(alive.id)
+        );
+        // First source probed fine: nothing to remember.
+        service.save_probe_fallback("psid-clean", &probed(&dead, false));
+        assert_eq!(StreamService::probe_fallback_for(ctx, "psid-clean"), None);
+        // Client named a specific stream: its choice stands, nothing remembered.
+        service.save_probe_fallback("psid-specific", &probed(&alive, true));
+        assert_eq!(
+            StreamService::probe_fallback_for(ctx, "psid-specific"),
+            None
+        );
+        // Unknown session: nothing.
+        assert_eq!(StreamService::probe_fallback_for(ctx, "psid-unknown"), None);
     }
 }

--- a/crates/remux-server/src/services/stream_service.rs
+++ b/crates/remux-server/src/services/stream_service.rs
@@ -1204,4 +1204,79 @@ mod tests {
         // Unknown session: nothing.
         assert_eq!(StreamService::probe_fallback_for(ctx, "psid-unknown"), None);
     }
+
+    /// With stream groups on, the initial PlaybackInfo lists one representative
+    /// stream per group and is not a specific request, so a fallback is
+    /// remembered exactly as without groups. A request for a group by its UUID
+    /// is specific: nothing is remembered and the stream request keeps
+    /// resolving the group itself.
+    #[tokio::test]
+    async fn probe_fallback_with_stream_groups() {
+        use crate::integration_test::{
+            authenticated_server, insert_test_source, seed_movie,
+        };
+        let (_server, guard, _token) = authenticated_server().await;
+        let ctx = &guard.0;
+        let owner = seed_movie(ctx).await;
+        let group_a = uuid::Uuid::new_v4();
+        let group_b = uuid::Uuid::new_v4();
+        let mut dead = insert_test_source(ctx).await;
+        let mut alive = insert_test_source(ctx).await;
+        dead.group_id = Some(group_a);
+        alive.group_id = Some(group_b);
+        let probed = |specific_requested: bool| ProbedStreams {
+            results: vec![ProbeResult {
+                source: api::MediaSourceInfo::from(dead.clone()),
+                stream: dead.clone(),
+                effective_stream: alive.clone(),
+            }],
+            specific_requested,
+        };
+
+        // Initial load: group representatives, no group context.
+        let mut service = StreamService::new(StreamServiceConfig {
+            ctx: ctx.clone(),
+            item_id: owner.id,
+            requested_id: None,
+            show_ungrouped: false,
+            stream_filter: None,
+            user_id: None,
+        });
+        service.streams = vec![dead.clone(), alive.clone()];
+        let selection = service.select_streams();
+        assert!(!selection.specific_requested);
+        service
+            .save_probe_fallback("psid-grouped", &probed(selection.specific_requested));
+        assert_eq!(
+            StreamService::probe_fallback_for(ctx, "psid-grouped"),
+            Some(alive.id)
+        );
+
+        // Group A requested by its UUID.
+        let mut service = StreamService::new(StreamServiceConfig {
+            ctx: ctx.clone(),
+            item_id: owner.id,
+            requested_id: Some(group_a),
+            show_ungrouped: false,
+            stream_filter: None,
+            user_id: None,
+        });
+        service.group = Some((
+            group_a,
+            "Group A".to_string(),
+            vec![dead.clone(), alive.clone()],
+        ));
+        service.stream = Some(dead.clone());
+        service.streams = vec![dead.clone(), alive.clone()];
+        let selection = service.select_streams();
+        assert!(selection.specific_requested);
+        service.save_probe_fallback(
+            "psid-group-request",
+            &probed(selection.specific_requested),
+        );
+        assert_eq!(
+            StreamService::probe_fallback_for(ctx, "psid-group-request"),
+            None
+        );
+    }
 }


### PR DESCRIPTION
PlaybackInfo probes the first source. If that times out it falls back to the next one and returns it, with `MediaSources[0].Id` set to the item id as usual. A client that auto-plays then requests `/videos/{id}/stream` with `MediaSourceId` equal to the item id. `dispatch_lookup` reads that as "first source" and serves the one that just failed. The request hangs until the upstream timeout and returns 500. Choosing the second source by hand works, because then the client names it directly.

Stream groups have the same problem: a group request answers with the group id, and the stream request resolves the group to its first candidate regardless of what the probe found.

Fix: after probing, `save_probe_fallback` records the stream that actually probed, keyed by the play session id and the id the client will echo back (the item id, or the group id). The stream handler looks that record up with the same key and uses it. A specific stream named by the client has no record and still wins. Keyed on the play session rather than the device because every client echoes it on the stream URL; not all send a device id there. Unit tests cover auto-play, group requests and specific streams. Full suite green.

`GET /videos/{id}/stream?MediaSourceId={id}` after PlaybackInfo had fallen back, first source unreachable:

```
before: 500 after 30 s   after: 206 in 0.4 s
```

Same check with a stream group defined and the group requested by its id, first candidate timing out: the stream request served the fallback stream (verified by file size), 206 in 0.3 s.

Written with Claude Code; I reviewed and tested it on my own instance.
