### PR TITLE
fix(search): return the stored row's id for remote results that exist locally

### DIFF
--- a/crates/remux-server/src/addons/mod.rs
+++ b/crates/remux-server/src/addons/mod.rs
@@ -2793,7 +2793,8 @@ impl AddonService {
                 .search(kind, query, limit, ctx)
                 .await
             {
-                Ok(Some(results)) => {
+                Ok(Some(mut results)) => {
+                    db::Media::adopt_existing_ids(&ctx.db, &mut results).await;
                     for m in &results {
                         ctx.store
                             .save(
@@ -4188,5 +4189,51 @@ mod tests {
             !called.load(std::sync::atomic::Ordering::SeqCst),
             "stream-only addon's get_children should never be called"
         );
+    }
+
+    /// Remote search mints a fresh id per request. A result that already
+    /// exists locally must carry the stored row's id, or a client that keeps
+    /// the id (next episode, continue watching) gets 404 on it once the
+    /// store entry is gone. Unknown items keep their own id.
+    #[tokio::test]
+    async fn search_results_adopt_existing_row_ids() {
+        use crate::integration_test::{authenticated_server, seed_movie};
+        let (_server, guard, _token) = authenticated_server().await;
+        let ctx = &guard.0;
+        let stored = seed_movie(ctx).await;
+        let mut results = vec![
+            db::Media {
+                id: Uuid::new_v4(),
+                title: stored
+                    .title
+                    .clone(),
+                kind: db::MediaKind::Movie,
+                external_ids: db::ExternalIds {
+                    imdb: stored
+                        .external_ids
+                        .imdb
+                        .clone(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            db::Media {
+                id: Uuid::new_v4(),
+                title: "Unknown".into(),
+                kind: db::MediaKind::Movie,
+                external_ids: db::ExternalIds {
+                    imdb: db::NonEmptyString::try_new("tt0000001".to_string()).ok(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ];
+        let unknown_id = results[1].id;
+        db::Media::adopt_existing_ids(&ctx.db, &mut results).await;
+        assert_eq!(
+            results[0].id, stored.id,
+            "known item takes the stored row's id"
+        );
+        assert_eq!(results[1].id, unknown_id, "unknown item keeps its own id");
     }
 }

--- a/crates/remux-server/src/addons/mod.rs
+++ b/crates/remux-server/src/addons/mod.rs
@@ -4229,11 +4229,29 @@ mod tests {
             },
         ];
         let unknown_id = results[1].id;
+        results.push(db::Media {
+            id: Uuid::new_v4(),
+            title: stored
+                .title
+                .clone(),
+            kind: db::MediaKind::Movie,
+            external_ids: db::ExternalIds {
+                tmdb: stored
+                    .external_ids
+                    .tmdb,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
         db::Media::adopt_existing_ids(&ctx.db, &mut results).await;
         assert_eq!(
             results[0].id, stored.id,
             "known item takes the stored row's id"
         );
         assert_eq!(results[1].id, unknown_id, "unknown item keeps its own id");
+        assert_eq!(
+            results[2].id, stored.id,
+            "a match on a lower-priority id adopts the stored row's id too"
+        );
     }
 }

--- a/crates/remux-server/src/addons/mod.rs
+++ b/crates/remux-server/src/addons/mod.rs
@@ -4195,6 +4195,29 @@ mod tests {
     /// exists locally must carry the stored row's id, or a client that keeps
     /// the id (next episode, continue watching) gets 404 on it once the
     /// store entry is gone. Unknown items keep their own id.
+    /// A remote result gets the id its stored row would have, so the first
+    /// search for a title and every search after it agree before anything
+    /// is stored.
+    #[test]
+    fn remote_results_get_the_stable_id() {
+        let meta = |id: &str| {
+            serde_json::from_value::<remux_sdks::stremio::Meta>(serde_json::json!({
+                "id": id, "type": "movie", "name": "Heat"
+            }))
+            .unwrap()
+        };
+        let a = db::Media::try_from(meta("tt0113277")).unwrap();
+        let b = db::Media::try_from(meta("tt0113277")).unwrap();
+        assert_eq!(a.id, b.id, "same identity, same id");
+        assert_eq!(
+            a.id,
+            Uuid::from(&a.media_id_raw()),
+            "the id a stored row gets"
+        );
+        let other = db::Media::try_from(meta("tt0000001")).unwrap();
+        assert_ne!(a.id, other.id);
+    }
+
     #[tokio::test]
     async fn search_results_adopt_existing_row_ids() {
         use crate::integration_test::{authenticated_server, seed_movie};

--- a/crates/remux-server/src/db/media.rs
+++ b/crates/remux-server/src/db/media.rs
@@ -1978,6 +1978,7 @@ pub enum MediaError {
 // doesn't coerce across storage classes in a bare `=`), so integer-valued
 // fields must bind as an integer, not a stringified one. Used by
 // `Media::find_by_external_ids` and `Media::resolve_ambiguous_external_id`.
+#[derive(Clone, PartialEq)]
 enum IdValue {
     Text(String),
     Int(i64),
@@ -2783,25 +2784,103 @@ impl Media {
     /// `/shows/{id}/seasons` while the stored series is fine. Only results
     /// with a matching row are rewritten; unknown items keep their id.
     pub async fn adopt_existing_ids(db: &SqlitePool, items: &mut [Media]) {
-        for m in items.iter_mut() {
-            if m.external_ids
+        let mut kinds: Vec<MediaKind> = Vec::new();
+        for m in items.iter() {
+            if !m
+                .external_ids
                 .is_empty()
+                && !kinds.contains(&m.kind)
             {
+                kinds.push(
+                    m.kind
+                        .clone(),
+                );
+            }
+        }
+        for kind in kinds {
+            let mut wanted: Vec<(&'static str, IdValue)> = Vec::new();
+            for m in items
+                .iter()
+                .filter(|m| m.kind == kind)
+            {
+                for field in Self::external_id_fields(&kind, &m.external_ids) {
+                    if !wanted.contains(&field) {
+                        wanted.push(field);
+                    }
+                }
+            }
+            let rows = Self::rows_with_external_ids(db, &kind, &wanted).await;
+            if rows.is_empty() {
                 continue;
             }
-            if let Some(id) =
-                Self::find_by_external_ids(db, &m.kind, &m.external_ids).await
+            for m in items
+                .iter_mut()
+                .filter(|m| m.kind == kind)
             {
-                m.id = id;
+                let fields = Self::external_id_fields(&kind, &m.external_ids);
+                let hit = fields
+                    .iter()
+                    .find_map(|field| {
+                        rows.iter()
+                            .find(|(_, row_fields)| row_fields.contains(field))
+                            .map(|(id, _)| *id)
+                    });
+                if let Some(id) = hit {
+                    m.id = id;
+                }
             }
         }
     }
 
-    pub async fn find_by_external_ids(
+    /// Rows of `kind` carrying any of `wanted`, each with its own id fields so
+    /// callers can apply the priority order in memory. One query per chunk.
+    async fn rows_with_external_ids(
         db: &SqlitePool,
         kind: &MediaKind,
+        wanted: &[(&'static str, IdValue)],
+    ) -> Vec<(Uuid, Vec<(&'static str, IdValue)>)> {
+        let mut out = Vec::new();
+        for chunk in wanted.chunks(SQLITE_VAR_LIMIT - 1) {
+            let mut qb = sqlx::QueryBuilder::new(
+                "SELECT id, external_ids FROM media WHERE kind = ",
+            );
+            qb.push_bind(kind.to_string());
+            qb.push(" AND (");
+            for (i, (path, value)) in chunk
+                .iter()
+                .enumerate()
+            {
+                if i > 0 {
+                    qb.push(" OR ");
+                }
+                qb.push("json_extract(external_ids, '")
+                    .push(path)
+                    .push("') = ");
+                match value {
+                    IdValue::Text(s) => qb.push_bind(s.clone()),
+                    IdValue::Int(n) => qb.push_bind(*n),
+                };
+            }
+            qb.push(")");
+            let rows: Vec<(Uuid, sqlx::types::Json<ExternalIds>)> = qb
+                .build_query_as()
+                .fetch_all(db)
+                .await
+                .unwrap_or_default();
+            out.extend(
+                rows.into_iter()
+                    .map(|(id, ext)| (id, Self::external_id_fields(kind, &ext.0))),
+            );
+        }
+        out
+    }
+
+    /// `(json path, bound value)` pairs identifying `ext` for `kind`, in
+    /// priority order.
+    fn external_id_fields(
+        kind: &MediaKind,
         ext: &ExternalIds,
-    ) -> Option<Uuid> {
+    ) -> Vec<(&'static str, IdValue)> {
         // (json path, bound value) in priority order — mirrors stable_media_uuid
         // for Movie/Series/TvProgram; Artist/Album/Track have no priority
         // conflict since each carries at most one provider's id in practice.
@@ -2848,8 +2927,17 @@ impl Media {
             // Season/Episode identity is positional (parent series + index),
             // not a single external id — never deduped this way, their ids
             // are minted deterministically via `season_id`/`episode_id`.
-            _ => return None,
+            _ => {}
         }
+        id_fields
+    }
+
+    pub async fn find_by_external_ids(
+        db: &SqlitePool,
+        kind: &MediaKind,
+        ext: &ExternalIds,
+    ) -> Option<Uuid> {
+        let id_fields = Self::external_id_fields(kind, ext);
         if id_fields.is_empty() {
             return None;
         }

--- a/crates/remux-server/src/db/media.rs
+++ b/crates/remux-server/src/db/media.rs
@@ -7165,6 +7165,18 @@ impl TryFrom<sdks::stremio::Meta> for Media {
         };
 
         let mut media = media;
+        // A remote result carries the same identity as the row it becomes, so
+        // give it that row's id up front: the first search for a title and
+        // every one after it agree, before anything is stored, and a client
+        // that keeps the id keeps a valid one. Random only when nothing
+        // identifies the item.
+        let raw = media.media_id_raw();
+        if raw
+            .canonical()
+            .is_some()
+        {
+            media.id = Uuid::from(&raw);
+        }
         if let Some(url) = meta
             .poster
             .or(meta.thumbnail)

--- a/crates/remux-server/src/db/media.rs
+++ b/crates/remux-server/src/db/media.rs
@@ -2773,6 +2773,30 @@ impl Media {
     /// imdb ▸ custom_stremio_id ▸ tmdb ▸ tvdb ▸ kitsu, or deezer ▸ youtube_id
     /// for music) and the conflict is logged — this is intentionally not
     /// resolved by merging the rows.
+    /// Point remote results (search, catalog) that already exist locally at
+    /// their stored row: same kind, matching external id.
+    ///
+    /// Remote results are minted with a fresh id per request and live in the
+    /// in-memory store for an hour. A client that keeps such an id, for
+    /// next-episode autoplay or a continue-watching entry, is left with a
+    /// dead one after that, or after a restart, and gets 404 on
+    /// `/shows/{id}/seasons` while the stored series is fine. Only results
+    /// with a matching row are rewritten; unknown items keep their id.
+    pub async fn adopt_existing_ids(db: &SqlitePool, items: &mut [Media]) {
+        for m in items.iter_mut() {
+            if m.external_ids
+                .is_empty()
+            {
+                continue;
+            }
+            if let Some(id) =
+                Self::find_by_external_ids(db, &m.kind, &m.external_ids).await
+            {
+                m.id = id;
+            }
+        }
+    }
+
     pub async fn find_by_external_ids(
         db: &SqlitePool,
         kind: &MediaKind,


### PR DESCRIPTION
Remote search results get a fresh id on every request, held in the in-memory store for an hour. Searching the same title repeatedly returns a different series id each time, none of them the stored series row, even though the episodes listed under each one name that row as their series. A client that keeps the id it was given, for next-episode autoplay, a continue-watching entry or the show page, comes back after the hour or after a restart and gets 404 on `/shows/{id}/seasons`: autoplay stops at the episode end, the entry opens blank, the show has no source until the client searches again.

Fix, two layers. `Media::try_from(Meta)` now derives the id from the result's external ids the way a stored row's id is derived, so the first search for a title and every search after it agree before anything is stored. For rows that ended up stored under a different id (matched through another provider's id), `Media::adopt_existing_ids` rewrites the result to the stored id, one query per kind with the usual id priority applied in memory. A result with no identity and no match keeps a random id. Two unit tests. Full suite green.

Series search for a title that already exists locally, four requests:

```
before: four different ids, none the stored row
after:  the stored row's id every time
```

Written with Claude Code; I reviewed and tested it on my own instance.
