### PR TITLE
fix(torrent): release torrents after their last playback user

### DIFF
--- a/crates/remux-server/src/api/session.rs
+++ b/crates/remux-server/src/api/session.rs
@@ -92,7 +92,7 @@ pub async fn report_playback_start(
     session: auth::AuthSession,
     Json(data): Json<api::PlaybackInfo>,
 ) -> Result<impl IntoResponse> {
-    state
+    let evicted = state
         .ctx
         .sessions
         .start(
@@ -113,6 +113,24 @@ pub async fn report_playback_start(
                 e.context_internal("failed to start session")
             }
         })?;
+    // A stale session for this device just got silently replaced — its
+    // transcode is already dead, but whatever it was streaming from (e.g. a
+    // torrent) still needs releasing.
+    for stale in &evicted {
+        state
+            .ctx
+            .signals
+            .emit(Event::PlaybackSessionEnded {
+                item_id: stale.item_id,
+                media_source_id: stale
+                    .media_source_id
+                    .clone(),
+                device_id: stale
+                    .device_id
+                    .clone(),
+                user_id: stale.user_id,
+            });
+    }
     state
         .ctx
         .signals
@@ -286,6 +304,26 @@ pub async fn report_playback_stopped(
             .ctx
             .signals
             .emit(Event::SessionsChanged);
+        // `playback` was captured before `stopped` removed the session, so
+        // it still has the item/source info needed to release whatever this
+        // session was streaming from — fired for direct play too, not just
+        // transcode: neither has anything to do with the id used above,
+        // which a stop report may omit entirely.
+        if let Some(playback) = playback.as_ref() {
+            state
+                .ctx
+                .signals
+                .emit(Event::PlaybackSessionEnded {
+                    item_id: playback.item_id,
+                    media_source_id: playback
+                        .media_source_id
+                        .clone(),
+                    device_id: playback
+                        .device_id
+                        .clone(),
+                    user_id: playback.user_id,
+                });
+        }
         if let Some(item_id) = changed_item_id {
             state
                 .ctx

--- a/crates/remux-server/src/lib.rs
+++ b/crates/remux-server/src/lib.rs
@@ -359,6 +359,8 @@ pub async fn init_app(
         .register(services::media_tracker::MediaTrackerSubscriber { ctx: ctx.clone() });
     ctx.signals
         .register(api::webhooks::WebhookSubscriber { ctx: ctx.clone() });
+    ctx.signals
+        .register(torrent::TorrentCleanupSubscriber { ctx: ctx.clone() });
 
     // Sync intro items at startup (best-effort; errors are logged not fatal).
     if let Err(e) = intro::sync_intros(&ctx).await {

--- a/crates/remux-server/src/playback_session.rs
+++ b/crates/remux-server/src/playback_session.rs
@@ -59,12 +59,17 @@ impl PlaybackSessionManager {
     /// source, builds and inserts the `PlaybackSession`, and emits the playback-
     /// start log line (skipped for transcode — the HLS handler logs that after
     /// it has codec/bitrate/reason details).
+    /// Returns any sessions this start silently evicted (a stale session for
+    /// the same device) — their transcodes are already killed by the time
+    /// this returns, but the caller still needs them to release whatever
+    /// depended on that transcode's input (e.g. an owned torrent), which
+    /// this method has no visibility into.
     pub async fn start(
         &self,
         db: &sqlx::SqlitePool,
         auth_session: &auth::AuthSession,
         data: &PlaybackInfo,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<Vec<PlaybackSession>> {
         let play_session_id = data
             .play_session_id
             .clone()
@@ -106,7 +111,7 @@ impl PlaybackSessionManager {
                 client = %auth_session.device.app_name,
                 "PlaybackStart missing item_id, skipping session creation"
             );
-            return Ok(());
+            return Ok(Vec::new());
         }
 
         // If the client selected a StreamGroup source, record its group UUID.
@@ -179,7 +184,9 @@ impl PlaybackSessionManager {
             item_kind,
         };
 
-        self.insert(ps);
+        let evicted = self
+            .insert(ps)
+            .await;
 
         // For transcode sessions, master_hls_video fires the info log once it
         // has full codec/bitrate/reasons info. For direct play/stream, log here.
@@ -241,7 +248,7 @@ impl PlaybackSessionManager {
             );
         }
 
-        Ok(())
+        Ok(evicted)
     }
 
     /// Handle a `POST /sessions/playing/progress` report.
@@ -469,8 +476,11 @@ impl PlaybackSessionManager {
     /// Insert (or replace) a playback session, preserving any transcode that was
     /// pre-attached before `report_playback_start` fired.
     /// Removes stale sessions for the same device so `get_sessions` always
-    /// finds the most recent playback.
-    pub fn insert(&self, mut session: PlaybackSession) {
+    /// finds the most recent playback — killing their transcode (if any) and
+    /// returning them so the caller can release whatever the transcode's
+    /// input source was holding onto (e.g. a torrent), which this method has
+    /// no way to know about itself.
+    pub async fn insert(&self, mut session: PlaybackSession) -> Vec<PlaybackSession> {
         if session
             .transcode
             .is_none()
@@ -486,6 +496,7 @@ impl PlaybackSessionManager {
             }
         }
         // Remove any previous session for this device (different play_session_id).
+        let mut evicted = Vec::new();
         if !session
             .device_id
             .is_empty()
@@ -505,8 +516,12 @@ impl PlaybackSessionManager {
                 })
                 .collect();
             for id in stale {
-                self.sessions
-                    .remove(&id);
+                if let Some((_, stale_session)) = self
+                    .sessions
+                    .remove(&id)
+                {
+                    evicted.push(stale_session);
+                }
             }
         }
         self.sessions
@@ -516,6 +531,15 @@ impl PlaybackSessionManager {
                     .clone(),
                 session,
             );
+        for stale_session in &evicted {
+            if let Some(ts) = stale_session
+                .transcode
+                .clone()
+            {
+                kill_transcode(ts).await;
+            }
+        }
+        evicted
     }
 
     /// Return a clone of the session, if it exists.
@@ -814,4 +838,133 @@ async fn kill_transcode(ts: Arc<tokio::sync::RwLock<TranscodeSession>>) {
         notification.await;
     }
     let _ = std::fs::remove_dir_all(&output_dir);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::playback::session::TranscodeState;
+
+    fn minimal_transcode_session(input_url: &str) -> TranscodeSession {
+        let (state_tx, _) = tokio::sync::watch::channel(TranscodeState::Running);
+        TranscodeSession {
+            id: "ts".into(),
+            item_id: Uuid::nil(),
+            media_source_id: Uuid::nil(),
+            output_dir: std::env::temp_dir().join("remux-test-nonexistent"),
+            input_url: input_url.to_string(),
+            state: TranscodeState::Running,
+            state_tx: Arc::new(state_tx),
+            created_at: std::time::Instant::now(),
+            video_codec: String::new(),
+            audio_codec: String::new(),
+            audio_stream_index: None,
+            subtitle_stream_index: None,
+            burn_subtitle: false,
+            segment_length: 6,
+            transcode_reasons: Default::default(),
+            kill_tx: None,
+            wait_done: Arc::new(tokio::sync::Notify::new()),
+            last_segment_index: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            start_time_secs: 0,
+            playback_offset_secs: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            runtime_ticks: 0,
+            is_live: false,
+            source_video_codec: None,
+            source_audio_codec: None,
+            source_video_profile: None,
+            source_video_level: None,
+            source_video_range_type: None,
+            source_video_width: None,
+            source_video_height: None,
+            source_frame_rate: None,
+            video_bitrate: None,
+            hardware_acceleration_type: None,
+        }
+    }
+
+    fn minimal_session(
+        play_session_id: &str,
+        device_id: &str,
+        input_url: Option<&str>,
+    ) -> PlaybackSession {
+        PlaybackSession {
+            play_session_id: play_session_id.to_string(),
+            user_id: Uuid::nil(),
+            item_id: Uuid::nil(),
+            media_source_id: None,
+            device_id: device_id.to_string(),
+            client_name: String::new(),
+            position_ticks: 0,
+            can_seek: false,
+            is_paused: false,
+            last_paused_at: None,
+            is_muted: false,
+            volume_level: None,
+            audio_stream_index: None,
+            subtitle_stream_index: None,
+            play_method: None,
+            now_playing_queue: None,
+            playlist_item_id: None,
+            started_at: Utc::now(),
+            last_activity: Utc::now(),
+            transcode: input_url.map(|url| {
+                Arc::new(tokio::sync::RwLock::new(minimal_transcode_session(url)))
+            }),
+            group_id: None,
+            item_kind: None,
+        }
+    }
+
+    // Regression test: a new session on the same device used to silently
+    // drop the previous one via a raw DashMap remove, never killing its
+    // transcode or telling anyone what it was streaming from — the torrent
+    // (if any) backing it just kept running until the next daily sweep.
+    #[tokio::test]
+    async fn insert_returns_and_kills_evicted_same_device_session() {
+        let dir = std::env::temp_dir().join(format!("remux-test-{}", Uuid::new_v4()));
+        let mgr = PlaybackSessionManager::new(&dir);
+
+        let first = minimal_session(
+            "psid-1",
+            "device-1",
+            Some("http://127.0.0.1:3000/torrents/7/stream/0"),
+        );
+        let evicted = mgr
+            .insert(first)
+            .await;
+        assert!(
+            evicted.is_empty(),
+            "first insert for a device should never evict anything"
+        );
+
+        let second = minimal_session("psid-2", "device-1", None);
+        let evicted = mgr
+            .insert(second)
+            .await;
+
+        assert_eq!(evicted.len(), 1);
+        assert_eq!(evicted[0].play_session_id, "psid-1");
+        let ts = evicted[0]
+            .transcode
+            .as_ref()
+            .expect("evicted session should still carry its transcode");
+        assert_eq!(
+            ts.read()
+                .await
+                .input_url,
+            "http://127.0.0.1:3000/torrents/7/stream/0"
+        );
+        // The evicted session's slot is gone; only the new one remains.
+        assert!(
+            mgr.get("psid-1")
+                .is_none()
+        );
+        assert!(
+            mgr.get("psid-2")
+                .is_some()
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/crates/remux-server/src/signals.rs
+++ b/crates/remux-server/src/signals.rs
@@ -170,6 +170,19 @@ pub enum Event {
     RemotePlay(RemotePlayInfo),
     RemotePlaystate(RemotePlaystateInfo),
     RemoteCommand(RemoteCommandInfo),
+    /// A playback session ended — explicit stop, or silently evicted by a
+    /// new session on the same device — and whatever source it was using is
+    /// no longer needed. Fired for both transcode and direct-play sessions
+    /// alike (there's no `TranscodeSession` at all for direct play), so
+    /// subscribers re-derive the actual stream source the same way the
+    /// original request did rather than relying on it being captured
+    /// up front. Carries enough of the session to redo that lookup.
+    PlaybackSessionEnded {
+        item_id: Uuid,
+        media_source_id: Option<String>,
+        device_id: String,
+        user_id: Uuid,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -189,6 +202,7 @@ pub enum EventType {
     RemotePlay,
     RemotePlaystate,
     RemoteCommand,
+    PlaybackSessionEnded,
 }
 
 impl Event {
@@ -209,6 +223,7 @@ impl Event {
             Event::RemotePlay(_) => EventType::RemotePlay,
             Event::RemotePlaystate(_) => EventType::RemotePlaystate,
             Event::RemoteCommand(_) => EventType::RemoteCommand,
+            Event::PlaybackSessionEnded { .. } => EventType::PlaybackSessionEnded,
         }
     }
 }

--- a/crates/remux-server/src/torrent.rs
+++ b/crates/remux-server/src/torrent.rs
@@ -1,6 +1,7 @@
 use std::{path::PathBuf, sync::Arc, time::Duration};
 
 use anyhow::{Context, Result};
+use async_trait::async_trait;
 use librqbit::{
     AddTorrent, AddTorrentOptions, AddTorrentResponse, Session, SessionOptions,
     SessionPersistenceConfig, TorrentStatsState,
@@ -9,6 +10,8 @@ use librqbit::{
     http_api::HttpApi,
 };
 use tracing::{debug, warn};
+
+use crate::signals::{Event, EventType, Subscriber};
 
 #[derive(Clone, Debug)]
 struct TorrentFile {
@@ -232,6 +235,54 @@ impl TorrentManager {
             "http://127.0.0.1:{}/torrents/{}/stream/{}",
             self.http_port, torrent_id, file_idx
         ))
+    }
+
+    /// Delete a single managed torrent (and its downloaded data) by id. A
+    /// no-op if the torrent is already gone. Intended to be called as soon
+    /// as a playback session that was using it ends, rather than waiting
+    /// for the periodic sweep in `delete_unused_with_files` — a torrent left
+    /// running keeps announcing to DHT/trackers and holding peer
+    /// connections for content nobody is watching anymore.
+    pub async fn stop_torrent(&self, id: usize) -> Result<()> {
+        let api = Api::new(
+            self.session
+                .clone(),
+            None,
+            None,
+        );
+        api.api_torrent_action_delete(TorrentIdOrHash::Id(id))
+            .await
+            .context("failed to delete torrent")?;
+        Ok(())
+    }
+
+    /// Stop a managed torrent by info hash, if one is currently active for
+    /// it — a no-op both when it's already gone and when nothing ever
+    /// resolved it in the first place (e.g. a session that stopped before
+    /// its first byte request). Deliberately does not go through
+    /// `resolve_url`: that would *add* the torrent (starting a download)
+    /// just to immediately delete it.
+    pub async fn stop_torrent_by_hash(&self, info_hash: &str) -> Result<()> {
+        let api = Api::new(
+            self.session
+                .clone(),
+            None,
+            None,
+        );
+        let Some(id) = api
+            .api_torrent_list()
+            .torrents
+            .into_iter()
+            .find(|t| {
+                t.info_hash
+                    .eq_ignore_ascii_case(info_hash)
+            })
+            .and_then(|t| t.id)
+        else {
+            return Ok(());
+        };
+        self.stop_torrent(id)
+            .await
     }
 
     /// Delete managed torrents and their files, skipping any whose ID is in `active`.
@@ -631,9 +682,104 @@ fn parse_file_idx_param(magnet: &str) -> Option<usize> {
         })
 }
 
+/// Stops the torrent backing a playback session as soon as that session
+/// ends, instead of leaving it running until the next daily
+/// `CleanTranscodeFolderTask` sweep. A torrent nobody is watching anymore
+/// still announces to DHT/trackers and holds peer connections, which is pure
+/// overhead at best — and on Windows, `librqbit`'s DHT socket has been
+/// observed to die from a spurious WSAECONNRESET after enough of that
+/// background traffic accumulates, taking down every subsequent stream
+/// until the whole process restarts. Cutting torrents loose immediately
+/// doesn't fix that underlying socket issue, but it substantially reduces
+/// how much unnecessary DHT/peer traffic piles up between plays.
+///
+/// This fires on `PlaybackSessionEnded` — emitted regardless of play method
+/// — rather than anything transcode-specific: direct play resolves torrents
+/// through the exact same `TorrentManager` (see `TorrentSource::serve` in
+/// `stream.rs`) without ever going through a `TranscodeSession`, so a
+/// transcode-only trigger would miss it entirely. Re-derives the stream the
+/// session was actually using via the same lookup the original stream
+/// request used, rather than relying on it having been captured up front.
+pub struct TorrentCleanupSubscriber {
+    pub ctx: crate::AppContext,
+}
+
+#[async_trait]
+impl Subscriber for TorrentCleanupSubscriber {
+    fn key(&self) -> &'static str {
+        "torrent_cleanup"
+    }
+    fn events(&self) -> &[EventType] {
+        &[EventType::PlaybackSessionEnded]
+    }
+    async fn handle(&self, event: Event) -> anyhow::Result<()> {
+        let Event::PlaybackSessionEnded {
+            item_id,
+            media_source_id,
+            device_id,
+            user_id,
+        } = event
+        else {
+            return Ok(());
+        };
+        let Some(mgr) = self
+            .ctx
+            .torrent
+            .read()
+            .await
+            .clone()
+        else {
+            return Ok(());
+        };
+        let requested_id = media_source_id
+            .as_deref()
+            .and_then(|s| {
+                s.parse()
+                    .ok()
+            });
+        let media = crate::services::stream_service::StreamService::lookup(
+            &self.ctx,
+            item_id,
+            requested_id,
+            Some(&device_id),
+            Some(user_id),
+        )
+        .await?;
+        let Some(si) = media.stream_info else {
+            return Ok(());
+        };
+        let crate::stream::StreamDescriptor::Torrent { info_hash, .. } = si.descriptor
+        else {
+            return Ok(());
+        };
+        mgr.stop_torrent_by_hash(&info_hash)
+            .await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Regression guard for the `PlaybackSessionEnded` redesign: a session
+    // that stops before anything ever resolved a torrent for it (or one
+    // playing a non-torrent source) must not error or attempt to add one —
+    // `stop_torrent_by_hash` only ever looks at what's already managed.
+    #[tokio::test]
+    async fn stop_torrent_by_hash_is_a_noop_when_nothing_is_managed() {
+        let dir = std::env::temp_dir()
+            .join(format!("remux-torrent-test-{}", uuid::Uuid::new_v4()));
+        let mgr =
+            TorrentManager::new(dir.join("data"), dir.join("cache"), None, true, None)
+                .await
+                .expect("torrent manager should start with DHT disabled");
+
+        mgr.stop_torrent_by_hash("0000000000000000000000000000000000000000")
+            .await
+            .expect("stopping an unmanaged hash should be a no-op, not an error");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     fn file(name: &str, length: u64) -> TorrentFile {
         TorrentFile {


### PR DESCRIPTION
Torrents remained managed after playback ended. Track the actual torrent selected by each playback request and retain it while any playback session or HTTP response still uses it.

Stopping, replacing, or expiring a session releases its references through the session manager. After the last reference is released, cleanup waits 30 seconds for seeks, reconnects, or the next episode, then removes the unused torrent and its data. Active readers and other sessions prevent deletion; cleanup never resolves the source again. Requests without a matching playback session are protected for the lifetime of their response.

Validation: torrent regressions cover a real local torrent shared by two sessions and a reader, reacquisition, periodic cleanup protection, playback-start replacement, explicit stop, and expiry of unclaimed requests.
